### PR TITLE
hisi-sfc350: add flash-file support for V1/V2 SoC flash boot

### DIFF
--- a/qemu-boot/run-cv100-flash.sh
+++ b/qemu-boot/run-cv100-flash.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Boot Hi3516CV100 from a SPI NOR flash dump.
+#
+# Usage:
+#   bash qemu-boot/run-cv100-flash.sh /tmp/flash_dump_cv100.bin
+#
+# The flash dump is loaded into the emulated SFC350 flash controller.
+# A built-in boot ROM at address 0 copies U-Boot from the flash
+# memory window to DDR and jumps to it — just like real hardware.
+#
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+QEMU="$REPO_ROOT/qemu-src/build/qemu-system-arm"
+
+FLASH_FILE="${1:-/tmp/openipc-hi3516cv100-nor-8m.bin}"
+
+if [ ! -f "$FLASH_FILE" ]; then
+    echo "Error: flash dump not found: $FLASH_FILE" >&2
+    echo "Usage: $0 <flash_dump.bin>" >&2
+    exit 1
+fi
+
+shift 2>/dev/null  # consume $1 so "$@" passes only extra args
+
+NIC_ARGS="-nic user"
+
+exec "$QEMU" -M hi3516cv100 -m 64M \
+    -global hisi-sfc350.flash-file="$FLASH_FILE" \
+    -nographic -serial mon:stdio \
+    $NIC_ARGS \
+    -d unimp,guest_errors \
+    -D "$SCRIPT_DIR/qemu-cv100-flash.log" \
+    "$@"

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -1692,64 +1692,90 @@ static void hisilicon_write_bootrom(MemoryRegion *sysmem,
         rom[n++] = cpu_to_le32(0xe12fff11);     /* bx r1                  */
     } else {
         /*
-         * ARMv5 (ARM926): no movw/movt.  Use PC-relative loads from a
-         * literal pool placed after the branch instruction.
+         * ARMv5 (ARM926): no movw/movt, no VBAR.  Exception vectors are
+         * always at address 0, so the boot ROM must provide a proper
+         * vector table.  QEMU's ARM926 model raises undefined-instruction
+         * exceptions for some cp15 registers that real silicon silently
+         * ignores (e.g. L2 cache aux control), so the undefined handler
+         * must skip the faulting instruction instead of looping.
          *
-         * Layout (n starts at 1 after msr):
-         *   [1] ldr r0, [pc, #20]   -> pool[0] = flash_src
-         *   [2] ldr r1, [pc, #20]   -> pool[1] = ram_dst
-         *   [3] ldr r2, [pc, #20]   -> pool[2] = copy_sz
-         *   [4] add r3, r1, r2
-         *   [5] ldr r4, [r0], #4    (copy_loop)
-         *   [6] str r4, [r1], #4
-         *   [7] cmp r1, r3
-         *   [8] bne copy_loop
-         *   [9] ldr r1, [pc, #4]    -> pool[1] = ram_dst
-         *  [10] bx r1
-         *  [11] pool[0] = flash_src
-         *  [12] pool[1] = ram_dst
-         *  [13] pool[2] = copy_sz
-         *
-         * PC-relative offset = target_addr - (insn_addr + 8)
-         * For insn at index i: addr = i*4, pc_val = i*4 + 8
-         * pool[j] at index (11+j): addr = (11+j)*4
-         * offset for insn[i] -> pool[j] = (11+j)*4 - (i*4+8)
+         * Layout:
+         *   [0]  b reset_handler      ; reset vector  -> word 8
+         *   [1]  movs pc, lr          ; undefined insn -> skip & continue
+         *   [2]  b .                  ; SWI            -> hang
+         *   [3]  b .                  ; prefetch abort -> hang
+         *   [4]  subs pc, lr, #4      ; data abort     -> retry
+         *   [5]  b .                  ; reserved
+         *   [6]  b .                  ; IRQ            -> hang
+         *   [7]  b .                  ; FIQ            -> hang
+         *   [8]  msr cpsr_c, #0xD3   ; reset_handler
+         *   [9]  ldr r0, [pc, #32]   -> pool[0] = flash_src
+         *  [10]  ldr r1, [pc, #32]   -> pool[1] = ram_dst
+         *  [11]  ldr r2, [pc, #32]   -> pool[2] = copy_sz
+         *  [12]  add r3, r1, r2
+         *  [13]  ldr r4, [r0], #4    (copy_loop)
+         *  [14]  str r4, [r1], #4
+         *  [15]  cmp r1, r3
+         *  [16]  bne copy_loop
+         *  [17]  ldr r1, [pc, #4]    -> pool[1] = ram_dst
+         *  [18]  bx r1
+         *  [19]  pool[0] = flash_src
+         *  [20]  pool[1] = ram_dst
+         *  [21]  pool[2] = copy_sz
          */
-        /* insn[1]: ldr r0, [pc, #offset_to_pool0]
-         * pool[0] at word 11, insn at word 1: offset = (11-1-2)*4 = 32 */
-        rom[n++] = cpu_to_le32(0xe59f0000 | 32);  /* ldr r0, [pc, #32] */
-        /* insn[2]: pool[1] at word 12: offset = (12-2-2)*4 = 32 */
-        rom[n++] = cpu_to_le32(0xe59f1000 | 32);  /* ldr r1, [pc, #32] */
-        /* insn[3]: pool[2] at word 13: offset = (13-3-2)*4 = 32 */
-        rom[n++] = cpu_to_le32(0xe59f2000 | 32);  /* ldr r2, [pc, #32] */
+        n = 0;
+        rom[n++] = cpu_to_le32(0xea000006);     /* b reset_handler (word 8) */
+        rom[n++] = cpu_to_le32(0xe1b0f00e);     /* movs pc, lr              */
+        rom[n++] = cpu_to_le32(0xeafffffe);     /* b .  (SWI)               */
+        rom[n++] = cpu_to_le32(0xeafffffe);     /* b .  (prefetch abort)    */
+        rom[n++] = cpu_to_le32(0xe25ef004);     /* subs pc, lr, #4 (dabort) */
+        rom[n++] = cpu_to_le32(0xeafffffe);     /* b .  (reserved)          */
+        rom[n++] = cpu_to_le32(0xeafffffe);     /* b .  (IRQ)               */
+        rom[n++] = cpu_to_le32(0xeafffffe);     /* b .  (FIQ)               */
 
-        rom[n++] = cpu_to_le32(0xe0813002);     /* add r3, r1, r2         */
-        rom[n++] = cpu_to_le32(0xe4904004);     /* ldr r4, [r0], #4       */
-        rom[n++] = cpu_to_le32(0xe4814004);     /* str r4, [r1], #4       */
-        rom[n++] = cpu_to_le32(0xe1510003);     /* cmp r1, r3             */
-        rom[n++] = cpu_to_le32(0x1afffffb);     /* bne copy_loop          */
+        /* reset_handler at word 8 */
+        assert(n == 8);
+        rom[n++] = cpu_to_le32(0xe321f0d3);     /* msr cpsr_c, #0xD3       */
 
-        /* insn[9]: ldr r1, [pc, #offset_to_pool1]
-         * pool[1] at word 12: offset = (12-9-2)*4 = 4 */
-        rom[n++] = cpu_to_le32(0xe59f1000 | 4); /* ldr r1, [pc, #4]  */
-        rom[n++] = cpu_to_le32(0xe12fff11);     /* bx r1                  */
+        /* PC-relative offset = pool_addr - (insn_addr + 8)
+         * For insn[i] -> pool at word p: offset = (p - i - 2) * 4 */
+        rom[n++] = cpu_to_le32(0xe59f0000 | 32); /* ldr r0, [pc, #32]      */
+        rom[n++] = cpu_to_le32(0xe59f1000 | 32); /* ldr r1, [pc, #32]      */
+        rom[n++] = cpu_to_le32(0xe59f2000 | 32); /* ldr r2, [pc, #32]      */
 
-        /* Literal pool at word 11 */
-        assert(n == 11);
+        rom[n++] = cpu_to_le32(0xe0813002);     /* add r3, r1, r2           */
+        rom[n++] = cpu_to_le32(0xe4904004);     /* ldr r4, [r0], #4         */
+        rom[n++] = cpu_to_le32(0xe4814004);     /* str r4, [r1], #4         */
+        rom[n++] = cpu_to_le32(0xe1510003);     /* cmp r1, r3               */
+        rom[n++] = cpu_to_le32(0x1afffffb);     /* bne copy_loop            */
+
+        rom[n++] = cpu_to_le32(0xe59f1000 | 4); /* ldr r1, [pc, #4]        */
+        rom[n++] = cpu_to_le32(0xe12fff11);     /* bx r1                    */
+
+        /* Literal pool at word 19 */
+        assert(n == 19);
         rom[n++] = cpu_to_le32(flash_src);
         rom[n++] = cpu_to_le32(ram_dst);
         rom[n++] = cpu_to_le32(copy_sz);
     }
 
     MemoryRegion *bootrom = g_new(MemoryRegion, 1);
-    memory_region_init_rom(bootrom, NULL, "hisilicon.bootrom",
-                           0x1000, &error_fatal);
+    if (armv7) {
+        /* Cortex-A7+ uses VBAR for exception vectors, so address 0 can be
+         * ROM.  Firmware with NULL pointer bugs that write to address 0
+         * will have writes silently dropped — same as real silicon. */
+        memory_region_init_rom(bootrom, NULL, "hisilicon.bootrom",
+                               0x1000, &error_fatal);
+    } else {
+        /* ARM926 has no VBAR — exception vectors are always at address 0.
+         * U-Boot must overwrite the boot ROM vectors with its own handlers
+         * (e.g. for undefined instruction).  Use RAM so the vectors are
+         * writable, matching real hardware where address 0 is internal
+         * SRAM that becomes writable after boot ROM handoff. */
+        memory_region_init_ram(bootrom, NULL, "hisilicon.bootrom",
+                               0x1000, &error_fatal);
+    }
     memory_region_add_subregion(sysmem, 0, bootrom);
-    /* ROM is read-only after initial write, matching real hardware where
-     * address 0 is internal boot ROM.  U-Boot on Cortex-A7 uses VBAR for
-     * exception vectors (not address 0).  Firmware with NULL pointer bugs
-     * that write to address 0 will have writes silently dropped — same as
-     * real silicon where the boot ROM is not writable. */
     address_space_write_rom(&address_space_memory, 0,
                             MEMTXATTRS_UNSPECIFIED, rom, sizeof(rom));
 }

--- a/qemu/hw/misc/hisi-sfc350.c
+++ b/qemu/hw/misc/hisi-sfc350.c
@@ -18,6 +18,7 @@
 #include "hw/qdev-properties.h"
 #include "qemu/log.h"
 #include "system/dma.h"
+#include <sys/stat.h>
 
 /* ── Register offsets ────────────────────────────────────────────────── */
 
@@ -77,6 +78,8 @@
 #define SPI_CMD_SE_32K          0x52
 #define SPI_CMD_SE_64K          0xD8
 #define SPI_CMD_CE              0xC7
+#define SPI_CMD_FAST_READ_DUAL  0x3B
+#define SPI_CMD_FAST_READ_QUAD  0x6B
 #define SPI_CMD_EN4B            0xB7
 #define SPI_CMD_EX4B            0xE9
 
@@ -129,6 +132,9 @@ struct HisiSfc350State {
     uint32_t cmd_addr;
     uint32_t cmd_databuf[DATABUF_REGS];
 
+    /* Configuration properties */
+    char    *flash_file;
+
     /* SPI flash state */
     uint8_t  sr;
     uint8_t *flash;
@@ -151,11 +157,18 @@ static void hisi_sfc350_exec_cmd(HisiSfc350State *s)
     }
 
     switch (opcode) {
-    case SPI_CMD_RDID:
-        s->cmd_databuf[0] = NOR_JEDEC_MFR | (NOR_JEDEC_TYPE << 8) |
-                            (NOR_JEDEC_CAP << 16);
+    case SPI_CMD_RDID: {
+        /* Only CS0 has a flash chip; CS1 returns 0 (no chip) */
+        uint32_t cs = (s->cmd_config >> CMD_CONFIG_SEL_CS_SHIFT) & 1;
+        if (cs == 0) {
+            s->cmd_databuf[0] = NOR_JEDEC_MFR | (NOR_JEDEC_TYPE << 8) |
+                                (NOR_JEDEC_CAP << 16);
+        } else {
+            s->cmd_databuf[0] = 0;
+        }
         s->cmd_databuf[1] = 0;
         break;
+    }
 
     case SPI_CMD_RDSR:
         s->cmd_databuf[0] = s->sr;
@@ -180,6 +193,8 @@ static void hisi_sfc350_exec_cmd(HisiSfc350State *s)
 
     case SPI_CMD_READ:
     case SPI_CMD_FAST_READ:
+    case SPI_CMD_FAST_READ_DUAL:
+    case SPI_CMD_FAST_READ_QUAD:
         if (data_en && rw_read && addr < s->flash_size) {
             uint32_t len = data_cnt;
             if (addr + len > s->flash_size) {
@@ -396,7 +411,7 @@ static uint64_t hisi_sfc350_mem_read(void *opaque, hwaddr offset,
                                       unsigned size)
 {
     HisiSfc350State *s = HISI_SFC350(opaque);
-    uint32_t val = 0xFF;
+    uint32_t val = 0xFFFFFFFF;
 
     if (offset < s->flash_size) {
         memcpy(&val, &s->flash[offset], size > 4 ? 4 : size);
@@ -441,20 +456,70 @@ static void hisi_sfc350_realize(DeviceState *dev, Error **errp)
     s->flash_size = NOR_FLASH_SIZE;
     s->flash = g_malloc(s->flash_size);
     memset(s->flash, 0xFF, s->flash_size);
+
+    /* SFC_BUS_FLASH_SIZE: bits [1:0] = CS0 flash size
+     * 0=16MiB, 1=8MiB, 2=4MiB, 3=2MiB.
+     * Default to 8 MiB (W25Q64) so the kernel detects the correct size. */
+    s->bus_flash_size = 0x01;
+
+    /* Load flash contents from file if specified */
+    if (s->flash_file && s->flash_file[0]) {
+        struct stat st;
+        if (stat(s->flash_file, &st) != 0) {
+            error_setg(errp, "hisi-sfc350: cannot stat flash file '%s'",
+                       s->flash_file);
+            return;
+        }
+        uint32_t file_size = (uint32_t)st.st_size;
+        if (file_size > s->flash_size) {
+            g_free(s->flash);
+            s->flash_size = file_size;
+            s->flash = g_malloc(file_size);
+            memset(s->flash, 0xFF, file_size);
+        }
+        FILE *f = fopen(s->flash_file, "rb");
+        if (!f) {
+            error_setg(errp, "hisi-sfc350: cannot open flash file '%s'",
+                       s->flash_file);
+            return;
+        }
+        size_t nread = fread(s->flash, 1, file_size, f);
+        fclose(f);
+        if (nread != file_size) {
+            error_setg(errp, "hisi-sfc350: short read from '%s' "
+                       "(got %zu, expected %u)", s->flash_file,
+                       nread, file_size);
+            return;
+        }
+        qemu_log("hisi-sfc350: loaded %u bytes from '%s'\n",
+                 file_size, s->flash_file);
+    }
 }
+
+static void hisi_sfc350_finalize(Object *obj)
+{
+    HisiSfc350State *s = HISI_SFC350(obj);
+    g_free(s->flash);
+}
+
+static const Property hisi_sfc350_properties[] = {
+    DEFINE_PROP_STRING("flash-file", HisiSfc350State, flash_file),
+};
 
 static void hisi_sfc350_class_init(ObjectClass *klass, const void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
     dc->realize = hisi_sfc350_realize;
+    device_class_set_props(dc, hisi_sfc350_properties);
 }
 
 static const TypeInfo hisi_sfc350_info = {
-    .name          = TYPE_HISI_SFC350,
-    .parent        = TYPE_SYS_BUS_DEVICE,
-    .instance_size = sizeof(HisiSfc350State),
-    .instance_init = hisi_sfc350_init,
-    .class_init    = hisi_sfc350_class_init,
+    .name              = TYPE_HISI_SFC350,
+    .parent            = TYPE_SYS_BUS_DEVICE,
+    .instance_size     = sizeof(HisiSfc350State),
+    .instance_init     = hisi_sfc350_init,
+    .instance_finalize = hisi_sfc350_finalize,
+    .class_init        = hisi_sfc350_class_init,
 };
 
 static void hisi_sfc350_register_types(void)


### PR DESCRIPTION
## Summary

- Add `flash-file` property to `hisi-sfc350` so V1/V2 SoCs (hi3516cv100, hi3516av100) can boot from SPI NOR flash dumps via `-global hisi-sfc350.flash-file=<path>`
- Fix 4 bugs discovered while testing with OpenIPC full flash firmware that prevented flash boot from working end-to-end
- Add `run-cv100-flash.sh` boot script

## Bugs fixed

| Bug | Root cause | Fix |
|-----|-----------|-----|
| U-Boot infinite reboot loop | Boot ROM code occupied ARM exception vector slots; undefined cp15 access caused infinite exception loop | Restructured ARMv5 boot ROM with proper vector table + `movs pc, lr` undefined handler |
| U-Boot `sf read` returned all zeros | SFC350 lacked Quad Output Read (0x6B) command support | Added 0x6B and 0x3B (Dual Read) to SPI command handler |
| SquashFS rootfs corruption | Both CS0 and CS1 returned same JEDEC ID → kernel detected 16 MiB (2×8M) → JFFS2 format wrapped around and overwrote rootfs | CS1 now returns 0 (no chip); kernel correctly detects 8 MiB |
| Boot ROM not writable on ARM926 | Address 0 mapped as ROM; ARM926 (no VBAR) needs writable vectors | Use RAM for address 0 on ARM926 SoCs |

## Test plan

- [x] Flash boot: `bash qemu-boot/run-cv100-flash.sh <flash.bin>` → U-Boot → Linux → OpenIPC login prompt
- [x] Kernel boot regression: `bash qemu-boot/run-cv100.sh` → Linux → OpenIPC login prompt
- [ ] CI passes

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)