### PR TITLE
ci: add U-Boot flash boot ping test for hi3516cv100

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,13 +305,22 @@ jobs:
           # Keep input pipe open (prevents EOF on each write)
           exec 3>/tmp/ub.in
 
-          # Interrupt autoboot (spam Ctrl-C until we see the prompt)
-          for i in $(seq 1 20); do
-            printf '\x03\n' >&3
-            if grep -q "OpenIPC #\|hisilicon #\|=> " /tmp/uboot-ping.txt 2>/dev/null; then
+          # Wait for U-Boot to start before sending interrupt — sending too
+          # early fills the UART FIFO and characters get dropped
+          for i in $(seq 1 30); do
+            if grep -q "autoboot" /tmp/uboot-ping.txt 2>/dev/null; then
               break
             fi
             sleep 0.5
+          done
+
+          # Interrupt autoboot (spam Ctrl-C until we see the prompt)
+          for i in $(seq 1 20); do
+            printf '\x03' >&3
+            if grep -q "OpenIPC #\|hisilicon #\|=> " /tmp/uboot-ping.txt 2>/dev/null; then
+              break
+            fi
+            sleep 0.2
           done
 
           echo "setenv ipaddr 10.0.10.15" >&3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,8 @@ jobs:
             mem: 64M
             append: "console=ttyAMA0,115200 mem=64M root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)"
             ping_linux: true
-            # No U-Boot flash test: hisi-sfc350 doesn't support flash-file yet
+            uboot_bin: u-boot-hi3516cv100-universal.bin
+            flash_type: hisi-sfc350
 
           - name: hi3516cv200
             soc: hi3516cv200
@@ -292,9 +293,10 @@ jobs:
           dd if=qemu-boot/rootfs.squashfs.${{ matrix.soc }} of=$FLASH bs=1 seek=$((0x350000)) conv=notrunc 2>/dev/null
 
           mkfifo /tmp/ub.in /tmp/ub.out
+          FLASH_TYPE="${{ matrix.flash_type || 'hisi-fmc' }}"
           $QEMU \
             -M ${{ matrix.machine }} -m ${{ matrix.flash_mem || matrix.mem }} \
-            -global hisi-fmc.flash-file=$FLASH \
+            -global ${FLASH_TYPE}.flash-file=$FLASH \
             -nographic -serial pipe:/tmp/ub -nic tap,ifname=tap0,script=no,downscript=no \
             -monitor none &
           QEMU_PID=$!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
             soc: hi3516cv100
             machine: hi3516cv100
             mem: 64M
-            append: "console=ttyAMA0,115200 mem=64M root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)"
+            append: "console=ttyAMA0,115200 mem=64M root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),2048k(kernel),5120k(rootfs),-(rootfs_data)"
             ping_linux: true
             uboot_bin: u-boot-hi3516cv100-universal.bin
             flash_type: hisi-sfc350

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,21 +302,24 @@ jobs:
           QEMU_PID=$!
           cat /tmp/ub.out > /tmp/uboot-ping.txt &
 
+          # Keep input pipe open (prevents EOF on each write)
+          exec 3>/tmp/ub.in
+
           # Interrupt autoboot (spam Ctrl-C until we see the prompt)
           for i in $(seq 1 20); do
-            printf '\x03\n' > /tmp/ub.in
+            printf '\x03\n' >&3
             if grep -q "OpenIPC #\|hisilicon #\|=> " /tmp/uboot-ping.txt 2>/dev/null; then
               break
             fi
             sleep 0.5
           done
 
-          echo "setenv ipaddr 10.0.10.15" > /tmp/ub.in
-          echo "setenv serverip 10.0.10.1" > /tmp/ub.in
-          echo "setenv gatewayip 10.0.10.1" > /tmp/ub.in
-          echo "setenv netmask 255.255.255.0" > /tmp/ub.in
+          echo "setenv ipaddr 10.0.10.15" >&3
+          echo "setenv serverip 10.0.10.1" >&3
+          echo "setenv gatewayip 10.0.10.1" >&3
+          echo "setenv netmask 255.255.255.0" >&3
           sleep 1
-          echo "ping 10.0.10.1" > /tmp/ub.in
+          echo "ping 10.0.10.1" >&3
 
           # Wait for ping result (up to 30s)
           for i in $(seq 1 30); do
@@ -326,6 +329,7 @@ jobs:
             sleep 1
           done
 
+          exec 3>&-
           kill $QEMU_PID 2>/dev/null || true
           wait 2>/dev/null || true
           rm -f /tmp/ub.in /tmp/ub.out

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -168,13 +168,19 @@ static const HisiSoCConfig hi3516cv100_soc = {
     .wdt_freq           = 3000000,
 
     /*
-     * BPLL register defaults for 100 MHz AXI bus clock.
-     * Kernel computes: busclk = 24M * fbdiv / (2 * refdiv * pstdiv1 * pstdiv2)
-     * With refdiv=3, fbdiv=25, pstdiv1=1, pstdiv2=1: busclk = 100 MHz.
-     * Timer clock = busclk / prescale(2) = 50 MHz.
+     * PLL register defaults.
+     * Kernel computes: clk = 24M * fbdiv / (2 * refdiv * pstdiv1 * pstdiv2)
+     *
+     * APLL (CRG0/CRG1): CPU clock ~552 MHz.
+     *   pstdiv1=1, pstdiv2=1, refdiv=1, fbdiv=46: 24*46/2 = 552 MHz.
+     * BPLL (CRG4/CRG5): AXI bus clock 100 MHz.
+     *   pstdiv1=1, pstdiv2=1, refdiv=3, fbdiv=25: 24*25/6 = 100 MHz.
+     *   Timer clock = busclk / prescale(2) = 50 MHz.
      */
-    .num_crg_defaults   = 2,
+    .num_crg_defaults   = 4,
     .crg_defaults       = {
+        { 0x00, (1 << 24) | (1 << 27) },   /* CRG0: pstdiv1=1, pstdiv2=1 */
+        { 0x04, (1 << 12) | 46 },           /* CRG1: refdiv=1, fbdiv=46 */
         { 0x10, (1 << 24) | (1 << 27) },   /* CRG4: pstdiv1=1, pstdiv2=1 */
         { 0x14, (3 << 12) | 25 },           /* CRG5: refdiv=3, fbdiv=25 */
     },


### PR DESCRIPTION
## Summary

- Enable U-Boot flash boot ping test for CV100 now that hisi-sfc350 supports `flash-file` (#20, merged in #26)
- Add `flash_type` matrix variable so the U-Boot ping step works with both `hisi-fmc` (V3+) and `hisi-sfc350` (V1) flash controllers
- Remove the "not supported yet" comment

## Test plan

- [ ] CI passes — specifically the new `hi3516cv100` U-Boot ping test

🤖 Generated with [Claude Code](https://claude.com/claude-code)