### PR TITLE
hisilicon: CV500 flash boot support (GZIP, CRG, secondary CPU halt)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -530,7 +530,7 @@ static const HisiSoCConfig hi3516cv500_soc = {
     .wdt_irq            = -1,
     .wdt_freq           = 3000000,
 
-    .num_crg_defaults   = 3,
+    .num_crg_defaults   = 4,
     .crg_defaults       = {
         { 0x1B8, (1 << 0) | (1 << 1) | (1 << 2) | (1 << 18)
                | (1 << 11) | (1 << 12) | (1 << 13)
@@ -540,9 +540,13 @@ static const HisiSoCConfig hi3516cv500_soc = {
                                          * + UART0 mux 24MHz */
         { 0x144, 0x02 },               /* FMC clock enable */
         { 0x16C, 0x02 },               /* ETH clock enable */
+        { 0x78,  (1 << 2) | (1 << 4) },
+                                        /* CPU1 + DBG1 in reset (kernel clears bit 2 for SMP) */
     },
 
     .gzip_base          = 0x11200000,
+
+    .cpu_srst_offset    = 0x78,         /* REG_CPU_SRST_CRG for SMP bringup */
 
     .num_regbanks       = 10,
     .regbanks           = {
@@ -1938,6 +1942,15 @@ static void hisilicon_common_init(MachineState *machine,
     /* CRG */
     {
         DeviceState *crg = qdev_new("hisi-crg");
+        if (c->cpu_srst_offset) {
+            qdev_prop_set_uint32(crg, "cpu-srst-offset", c->cpu_srst_offset);
+            if (c->max_cpus > 1) {
+                qdev_prop_set_uint32(crg, "smp-bootreg-addr",
+                                     c->sram_base + 0x100);
+                /* Address 0x4: where kernel writes secondary_startup addr */
+                qdev_prop_set_uint32(crg, "smp-entry-addr", 0x4);
+            }
+        }
         sysbus_realize_and_unref(SYS_BUS_DEVICE(crg), &error_fatal);
         sysbus_mmio_map(SYS_BUS_DEVICE(crg), 0, c->crg_base);
 

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -532,10 +532,17 @@ static const HisiSoCConfig hi3516cv500_soc = {
 
     .num_crg_defaults   = 3,
     .crg_defaults       = {
-        { 0x1B8, (1 << 18) },          /* UART clock: 24 MHz select */
+        { 0x1B8, (1 << 0) | (1 << 1) | (1 << 2) | (1 << 18)
+               | (1 << 11) | (1 << 12) | (1 << 13)
+               | (1 << 14) | (1 << 15) | (1 << 16)
+               | (1 << 17) | (1 << 18) },
+                                        /* UART0/1/2 clk enable + I2C0-7 clk enable
+                                         * + UART0 mux 24MHz */
         { 0x144, 0x02 },               /* FMC clock enable */
         { 0x16C, 0x02 },               /* ETH clock enable */
     },
+
+    .gzip_base          = 0x11200000,
 
     .num_regbanks       = 10,
     .regbanks           = {
@@ -1847,9 +1854,13 @@ static void hisilicon_common_init(MachineState *machine,
     /* RAM */
     memory_region_add_subregion(sysmem, c->ram_base, machine->ram);
 
-    /* CPUs */
+    /* CPUs — secondary CPUs start halted (held in reset until kernel brings them up) */
     for (n = 0; n < smp_cpus; n++) {
         cpuobj[n] = object_new(machine->cpu_type);
+        if (n > 0) {
+            object_property_set_bool(cpuobj[n], "start-powered-off", true,
+                                     &error_fatal);
+        }
         qdev_realize(DEVICE(cpuobj[n]), NULL, &error_fatal);
         cpu[n] = ARM_CPU(cpuobj[n]);
     }

--- a/qemu/hw/misc/hisi-crg.c
+++ b/qemu/hw/misc/hisi-crg.c
@@ -1,9 +1,14 @@
 /*
- * HiSilicon Clock/Reset Generator (CRG) stub.
+ * HiSilicon Clock/Reset Generator (CRG).
  *
  * Provides a simple read/write register bank so the kernel's clock
  * driver can probe without hanging. PLL status registers always
  * report "locked" (bit 28 set).
+ *
+ * When cpu_srst_offset is set (e.g. 0x78 for CV500/DV300), monitors
+ * writes to the CPU soft-reset register.  On CPU1 reset deassert,
+ * writes the kernel's secondary_startup address to smp_bootreg_addr,
+ * waking CPU1 from QEMU's WFI-poll loop.
  *
  * Copyright (c) 2026 OpenIPC.
  * Written by Dmitry Ilyin
@@ -15,12 +20,21 @@
 #include "hw/sysbus.h"
 #include "hw/qdev-properties.h"
 #include "qemu/log.h"
+#include "system/address-spaces.h"
 
 #define TYPE_HISI_CRG "hisi-crg"
 OBJECT_DECLARE_SIMPLE_TYPE(HisiCrgState, HISI_CRG)
 
 #define HISI_CRG_REG_SIZE  0x10000
 #define HISI_CRG_REG_COUNT (HISI_CRG_REG_SIZE / 4)
+
+/*
+ * CPU soft-reset register bits (from SDK: arch/arm/mach-hibvt/).
+ * Bit 2 = CPU1 reset request, bit 4 = CPU1 debug reset request.
+ * Clearing CPU1_SRST_REQ releases CPU1 from reset.
+ */
+#define CPU1_SRST_REQ  (1 << 2)
+#define DBG1_SRST_REQ  (1 << 4)
 
 /*
  * PLL lock bit — HiSilicon CRG drivers check bit 28 of PLL status
@@ -38,6 +52,9 @@ struct HisiCrgState {
     SysBusDevice parent_obj;
     MemoryRegion iomem;
     uint32_t regs[HISI_CRG_REG_COUNT];
+    uint32_t cpu_srst_offset;   /* 0 = disabled, e.g. 0x78 for CV500 */
+    uint32_t smp_bootreg_addr;  /* QEMU WFI-poll loop's boot register */
+    uint32_t smp_entry_addr;    /* phys addr where kernel puts entry (0x4) */
 };
 
 static bool is_pll_status_reg(hwaddr offset)
@@ -86,7 +103,36 @@ static void hisi_crg_write(void *opaque, hwaddr offset,
         return;
     }
 
-    s->regs[offset / 4] = val;
+    uint32_t old = s->regs[offset / 4];
+    s->regs[offset / 4] = (uint32_t)val;
+
+    /*
+     * CPU soft-reset register: the vendor kernel's SMP bringup
+     * (platsmp.c → hi35xx_set_cpu) clears CPU1_SRST_REQ (bit 2)
+     * to release CPU1 from reset.  Before doing so, it writes a
+     * trampoline at physical address 0x0 with secondary_startup
+     * address at offset 0x4.
+     *
+     * We read the entry point from smp_entry_addr (captured by the
+     * rom_device trap page at 0x0) and write it to smp_bootreg_addr.
+     * CPU1 is running QEMU's WFI-poll loop and wakes up to jump there.
+     */
+    if (s->cpu_srst_offset && offset == s->cpu_srst_offset) {
+        /* CPU1 reset deasserted (bit 2: 1→0) */
+        if ((old & CPU1_SRST_REQ) && !(val & CPU1_SRST_REQ)) {
+            if (s->smp_bootreg_addr && s->smp_entry_addr) {
+                uint32_t entry = address_space_ldl(&address_space_memory,
+                                    s->smp_entry_addr,
+                                    MEMTXATTRS_UNSPECIFIED, NULL);
+                qemu_log_mask(LOG_UNIMP,
+                              "hisi_crg: CPU1 reset released, entry=0x%x\n",
+                              entry);
+                address_space_stl(&address_space_memory,
+                                  s->smp_bootreg_addr, entry,
+                                  MEMTXATTRS_UNSPECIFIED, NULL);
+            }
+        }
+    }
 }
 
 static const MemoryRegionOps hisi_crg_ops = {
@@ -106,9 +152,31 @@ static void hisi_crg_init(Object *obj)
     sysbus_init_mmio(SYS_BUS_DEVICE(obj), &s->iomem);
 }
 
+static void hisi_crg_reset(DeviceState *dev)
+{
+    HisiCrgState *s = HISI_CRG(dev);
+
+    /*
+     * Don't zero regs — CRG defaults (clock enables for UART, FMC, ETH)
+     * are written during machine init and must survive machine reset.
+     * Only reinitialize the CPU reset register for SMP bringup detection.
+     */
+    if (s->cpu_srst_offset) {
+        s->regs[s->cpu_srst_offset / 4] = CPU1_SRST_REQ | DBG1_SRST_REQ;
+    }
+}
+
+static const Property hisi_crg_properties[] = {
+    DEFINE_PROP_UINT32("cpu-srst-offset", HisiCrgState, cpu_srst_offset, 0),
+    DEFINE_PROP_UINT32("smp-bootreg-addr", HisiCrgState, smp_bootreg_addr, 0),
+    DEFINE_PROP_UINT32("smp-entry-addr", HisiCrgState, smp_entry_addr, 0),
+};
+
 static void hisi_crg_class_init(ObjectClass *klass, const void *data)
 {
-    (void)klass;
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    device_class_set_props(dc, hisi_crg_properties);
+    device_class_set_legacy_reset(dc, hisi_crg_reset);
 }
 
 static const TypeInfo hisi_crg_info = {

--- a/qemu/hw/misc/hisi-sysctl.c
+++ b/qemu/hw/misc/hisi-sysctl.c
@@ -72,6 +72,9 @@ static void hisi_sysctl_write(void *opaque, hwaddr offset,
 
     switch (offset) {
     case 0x04: /* SC_SYSRES — system reset */
+        qemu_log_mask(LOG_UNIMP,
+                      "hisi-sysctl: SC_SYSRES reset triggered (val=0x%08x)\n",
+                      (uint32_t)val);
         qemu_system_reset_request(SHUTDOWN_CAUSE_GUEST_RESET);
         break;
     default:

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -133,6 +133,9 @@ typedef struct HisiSoCConfig {
     /* Hardware GZIP decompressor */
     hwaddr          gzip_base;      /* 0 = no GZIP engine */
 
+    /* CPU soft-reset register offset in CRG (for SMP bringup) */
+    uint32_t        cpu_srst_offset; /* 0 = disabled, e.g. 0x78 for CV500 */
+
     /* CRG register defaults (mimics U-Boot clock init before kernel boot) */
     int             num_crg_defaults;
     struct { uint32_t offset; uint32_t value; } crg_defaults[HISI_MAX_CRG_DEFAULTS];


### PR DESCRIPTION
## Summary

Enable full SPI NOR flash boot for hi3516cv500 (builds on #32):

- **GZIP decompressor** at `0x11200000` — U-Boot's compressed first stage needs this to decompress itself from flash
- **CRG clock defaults** — enable UART0/1/2 + I2C0-7 clocks so U-Boot's post-relocation init succeeds
- **Secondary CPUs halted** — `start-powered-off=true` prevents CPU1 from running U-Boot simultaneously; kernel brings it up via `enable-method`
- **Sysctl reset trace** — `qemu_log_mask(LOG_UNIMP)` on SC_SYSRES writes for debugging boot loops

## Test plan

- [x] Full flash boot: `qemu-system-arm -M hi3516cv500 -smp 2 -m 1024M -global hisi-fmc.flash-file=<16MB.bin>` → login prompt
- [ ] Existing `-kernel` boot mode still works
- [ ] Other machines unaffected (gzip_base/CRG changes are CV500-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)