### PR TITLE
hisi: add I2C sensor models for all 13 EV200 sensors

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2197,20 +2197,86 @@ static void hisilicon_common_init(MachineState *machine,
         }
     }
 
-    /* Sensor auto-attach via -machine sensor=imx335 */
+    /* Sensor auto-attach via -machine sensor=<name>
+     *
+     * I2C addresses below are 7-bit slave addresses (vendor docs use 8-bit
+     * which is shifted left by one).  All SmartSens sensors share addr 0x30
+     * so only one can be attached at a time — the user picks which one
+     * via the machine arg.
+     */
     {
         HisiMachineState *hms = (HisiMachineState *)machine;
         if (hms->sensor && c->num_i2c > 0 && i2c_devs[0]) {
+            BusState *i2c_bus = qdev_get_child_bus(i2c_devs[0], "i2c");
+            DeviceState *sensor = NULL;
+            uint8_t i2c_addr = 0;
+
             if (!strcmp(hms->sensor, "imx335")) {
-                BusState *i2c_bus = qdev_get_child_bus(i2c_devs[0], "i2c");
-                DeviceState *sensor = qdev_new("hisi-imx335");
-                qdev_prop_set_uint8(sensor, "address", 0x1A);
-                qdev_realize_and_unref(sensor, i2c_bus, &error_fatal);
+                sensor = qdev_new("hisi-imx335");
+                i2c_addr = 0x1A;
+            } else if (!strcmp(hms->sensor, "imx307")) {
+                sensor = qdev_new("hisi-imx307");
+                i2c_addr = 0x1A;
+            } else if (!strcmp(hms->sensor, "f37")) {
+                sensor = qdev_new("hisi-f37");
+                i2c_addr = 0x40;
+            } else if (!strcmp(hms->sensor, "gc2053")) {
+                sensor = qdev_new("hisi-gc2053");
+                i2c_addr = 0x37;
+            } else if (!strcmp(hms->sensor, "sp2305")) {
+                sensor = qdev_new("hisi-sp2305");
+                i2c_addr = 0x3C;
+            } else if (!strcmp(hms->sensor, "mis2006")) {
+                sensor = qdev_new("hisi-mis2006");
+                i2c_addr = 0x30;
+            } else if (!strcmp(hms->sensor, "sc2315e")) {
+                sensor = qdev_new("hisi-smartsens");
+                qdev_prop_set_uint8(sensor, "id_high", 0x22);
+                qdev_prop_set_uint8(sensor, "id_low",  0x38);
+                i2c_addr = 0x30;
+            } else if (!strcmp(hms->sensor, "sc2315")) {
+                sensor = qdev_new("hisi-smartsens");
+                qdev_prop_set_uint8(sensor, "id_high", 0x23);
+                qdev_prop_set_uint8(sensor, "id_low",  0x11);
+                i2c_addr = 0x30;
+            } else if (!strcmp(hms->sensor, "sc2235p")) {
+                sensor = qdev_new("hisi-smartsens");
+                qdev_prop_set_uint8(sensor, "id_high", 0x22);
+                qdev_prop_set_uint8(sensor, "id_low",  0x32);
+                qdev_prop_set_uint8(sensor, "disc",    0x01);
+                i2c_addr = 0x30;
+            } else if (!strcmp(hms->sensor, "sc2235e")) {
+                sensor = qdev_new("hisi-smartsens");
+                qdev_prop_set_uint8(sensor, "id_high", 0x22);
+                qdev_prop_set_uint8(sensor, "id_low",  0x32);
+                qdev_prop_set_uint8(sensor, "disc",    0x20);
+                i2c_addr = 0x30;
+            } else if (!strcmp(hms->sensor, "sc2335")) {
+                sensor = qdev_new("hisi-smartsens");
+                qdev_prop_set_uint8(sensor, "id_high", 0xCB);
+                qdev_prop_set_uint8(sensor, "id_low",  0x14);
+                i2c_addr = 0x30;
+            } else if (!strcmp(hms->sensor, "sc2239")) {
+                sensor = qdev_new("hisi-smartsens");
+                qdev_prop_set_uint8(sensor, "id_high", 0xCB);
+                qdev_prop_set_uint8(sensor, "id_low",  0x10);
+                i2c_addr = 0x30;
+            } else if (!strcmp(hms->sensor, "sc307h")) {
+                sensor = qdev_new("hisi-smartsens");
+                qdev_prop_set_uint8(sensor, "id_high", 0xCB);
+                qdev_prop_set_uint8(sensor, "id_low",  0x1C);
+                i2c_addr = 0x30;
             } else {
-                error_report("Unknown sensor '%s' (supported: imx335)",
+                error_report("Unknown sensor '%s' (supported: imx335, "
+                             "imx307, f37, gc2053, sp2305, mis2006, "
+                             "sc2235p, sc2235e, sc2315, sc2315e, "
+                             "sc2335, sc2239, sc307h)",
                              hms->sensor);
                 exit(1);
             }
+
+            qdev_prop_set_uint8(sensor, "address", i2c_addr);
+            qdev_realize_and_unref(sensor, i2c_bus, &error_fatal);
         }
     }
 

--- a/qemu/hw/i2c/hisi-f37.c
+++ b/qemu/hw/i2c/hisi-f37.c
@@ -1,0 +1,106 @@
+/*
+ * SOI F37 image sensor I2C stub.
+ *
+ * Sofia (XiongMai) detects F37 by:
+ *   1. Setting I2C addr 0x80 (8-bit) = 0x40 (7-bit slave addr)
+ *   2. Reading reg 0x0A (high byte) and 0x0B (low byte) — 8-bit reg, 8-bit data
+ *   3. Checking (high << 8) | low == 0x0F37
+ *
+ * Returning 0x0F at 0x0A and 0x37 at 0x0B satisfies the probe.
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * Written by Dmitry Ilyin
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/i2c/i2c.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_F37 "hisi-f37"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiF37State, HISI_F37)
+
+#define F37_REG_COUNT 0x100
+
+struct HisiF37State {
+    I2CSlave parent_obj;
+    uint8_t  cur_reg;
+    bool     have_reg;
+    uint8_t  regs[F37_REG_COUNT];
+};
+
+static void hisi_f37_reset_regs(HisiF37State *s)
+{
+    memset(s->regs, 0, sizeof(s->regs));
+    /* Sofia checks regs 0x0A:0x0B → expects 0x0F37 */
+    s->regs[0x0A] = 0x0F;
+    s->regs[0x0B] = 0x37;
+}
+
+static int hisi_f37_event(I2CSlave *i2c, enum i2c_event event)
+{
+    HisiF37State *s = HISI_F37(i2c);
+
+    if (event == I2C_START_SEND) {
+        s->have_reg = false;
+    }
+    return 0;
+}
+
+static int hisi_f37_send(I2CSlave *i2c, uint8_t data)
+{
+    HisiF37State *s = HISI_F37(i2c);
+
+    if (!s->have_reg) {
+        s->cur_reg = data;
+        s->have_reg = true;
+    } else {
+        s->regs[s->cur_reg] = data;
+        s->cur_reg++;
+    }
+    return 0;
+}
+
+static uint8_t hisi_f37_recv(I2CSlave *i2c)
+{
+    HisiF37State *s = HISI_F37(i2c);
+    uint8_t val = s->regs[s->cur_reg];
+    s->cur_reg++;
+    return val;
+}
+
+static void hisi_f37_reset(DeviceState *dev)
+{
+    HisiF37State *s = HISI_F37(dev);
+
+    s->cur_reg = 0;
+    s->have_reg = false;
+    hisi_f37_reset_regs(s);
+}
+
+static void hisi_f37_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    I2CSlaveClass *k = I2C_SLAVE_CLASS(klass);
+
+    device_class_set_legacy_reset(dc, hisi_f37_reset);
+    k->event = hisi_f37_event;
+    k->recv  = hisi_f37_recv;
+    k->send  = hisi_f37_send;
+}
+
+static const TypeInfo hisi_f37_info = {
+    .name          = TYPE_HISI_F37,
+    .parent        = TYPE_I2C_SLAVE,
+    .instance_size = sizeof(HisiF37State),
+    .class_init    = hisi_f37_class_init,
+};
+
+static void hisi_f37_register_types(void)
+{
+    type_register_static(&hisi_f37_info);
+}
+
+type_init(hisi_f37_register_types)

--- a/qemu/hw/i2c/hisi-gc2053.c
+++ b/qemu/hw/i2c/hisi-gc2053.c
@@ -1,0 +1,106 @@
+/*
+ * GalaxyCore GC2053 image sensor I2C stub.
+ *
+ * Sofia (XiongMai) detects GC2053 by:
+ *   1. Setting I2C addr 0x6E (8-bit) = 0x37 (7-bit slave addr)
+ *   2. Reading reg 0xF0 (high byte) and 0xF1 (low byte) — 8-bit reg, 8-bit data
+ *   3. Checking (high << 8) | low == 0x2053
+ *
+ * Returning 0x20 at 0xF0 and 0x53 at 0xF1 satisfies the probe.
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * Written by Dmitry Ilyin
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/i2c/i2c.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_GC2053 "hisi-gc2053"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiGC2053State, HISI_GC2053)
+
+#define GC2053_REG_COUNT 0x100
+
+struct HisiGC2053State {
+    I2CSlave parent_obj;
+    uint8_t  cur_reg;
+    bool     have_reg;
+    uint8_t  regs[GC2053_REG_COUNT];
+};
+
+static void hisi_gc2053_reset_regs(HisiGC2053State *s)
+{
+    memset(s->regs, 0, sizeof(s->regs));
+    /* Sofia checks regs 0xF0:0xF1 → expects 0x2053 */
+    s->regs[0xF0] = 0x20;
+    s->regs[0xF1] = 0x53;
+}
+
+static int hisi_gc2053_event(I2CSlave *i2c, enum i2c_event event)
+{
+    HisiGC2053State *s = HISI_GC2053(i2c);
+
+    if (event == I2C_START_SEND) {
+        s->have_reg = false;
+    }
+    return 0;
+}
+
+static int hisi_gc2053_send(I2CSlave *i2c, uint8_t data)
+{
+    HisiGC2053State *s = HISI_GC2053(i2c);
+
+    if (!s->have_reg) {
+        s->cur_reg = data;
+        s->have_reg = true;
+    } else {
+        s->regs[s->cur_reg] = data;
+        s->cur_reg++;
+    }
+    return 0;
+}
+
+static uint8_t hisi_gc2053_recv(I2CSlave *i2c)
+{
+    HisiGC2053State *s = HISI_GC2053(i2c);
+    uint8_t val = s->regs[s->cur_reg];
+    s->cur_reg++;
+    return val;
+}
+
+static void hisi_gc2053_reset(DeviceState *dev)
+{
+    HisiGC2053State *s = HISI_GC2053(dev);
+
+    s->cur_reg = 0;
+    s->have_reg = false;
+    hisi_gc2053_reset_regs(s);
+}
+
+static void hisi_gc2053_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    I2CSlaveClass *k = I2C_SLAVE_CLASS(klass);
+
+    device_class_set_legacy_reset(dc, hisi_gc2053_reset);
+    k->event = hisi_gc2053_event;
+    k->recv  = hisi_gc2053_recv;
+    k->send  = hisi_gc2053_send;
+}
+
+static const TypeInfo hisi_gc2053_info = {
+    .name          = TYPE_HISI_GC2053,
+    .parent        = TYPE_I2C_SLAVE,
+    .instance_size = sizeof(HisiGC2053State),
+    .class_init    = hisi_gc2053_class_init,
+};
+
+static void hisi_gc2053_register_types(void)
+{
+    type_register_static(&hisi_gc2053_info);
+}
+
+type_init(hisi_gc2053_register_types)

--- a/qemu/hw/i2c/hisi-imx307.c
+++ b/qemu/hw/i2c/hisi-imx307.c
@@ -1,0 +1,127 @@
+/*
+ * Sony IMX307 image sensor I2C stub.
+ *
+ * Sofia (XiongMai) detects IMX307 by:
+ *   1. Setting I2C addr 0x34 (8-bit) = 0x1A (7-bit slave addr)
+ *   2. Reading reg 0x31DC (16-bit reg, 8-bit data)
+ *   3. Checking (val & 6) == 4   (bit 2 set, bit 1 clear)
+ *
+ * Returning 0x04 at 0x31DC satisfies the probe.  All other registers
+ * read back as 0xFF (uninitialized).
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * Written by Dmitry Ilyin
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/i2c/i2c.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_IMX307 "hisi-imx307"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiIMX307State, HISI_IMX307)
+
+#define IMX307_REG_BASE  0x3000
+#define IMX307_REG_COUNT 0x1000
+
+struct HisiIMX307State {
+    I2CSlave parent_obj;
+    uint8_t  reg_buf[2];
+    uint8_t  reg_ptr;
+    uint16_t cur_reg;
+    uint8_t  regs[IMX307_REG_COUNT];
+};
+
+static void hisi_imx307_reset_regs(HisiIMX307State *s)
+{
+    memset(s->regs, 0, sizeof(s->regs));
+    /* Sofia checks reg 0x31DC: (val & 6) == 4 → bit 2 set, bit 1 clear */
+    s->regs[0x31DC - IMX307_REG_BASE] = 0x04;
+}
+
+static int hisi_imx307_event(I2CSlave *i2c, enum i2c_event event)
+{
+    HisiIMX307State *s = HISI_IMX307(i2c);
+
+    switch (event) {
+    case I2C_START_SEND:
+        s->reg_ptr = 0;
+        break;
+    case I2C_START_RECV:
+        s->cur_reg = ((uint16_t)s->reg_buf[0] << 8) | s->reg_buf[1];
+        break;
+    default:
+        break;
+    }
+    return 0;
+}
+
+static int hisi_imx307_send(I2CSlave *i2c, uint8_t data)
+{
+    HisiIMX307State *s = HISI_IMX307(i2c);
+
+    if (s->reg_ptr < 2) {
+        s->reg_buf[s->reg_ptr++] = data;
+    } else {
+        uint16_t addr = ((uint16_t)s->reg_buf[0] << 8) | s->reg_buf[1];
+        if (addr >= IMX307_REG_BASE &&
+            addr < IMX307_REG_BASE + IMX307_REG_COUNT) {
+            s->regs[addr - IMX307_REG_BASE] = data;
+        }
+        s->reg_buf[1]++;
+        if (s->reg_buf[1] == 0) {
+            s->reg_buf[0]++;
+        }
+    }
+    return 0;
+}
+
+static uint8_t hisi_imx307_recv(I2CSlave *i2c)
+{
+    HisiIMX307State *s = HISI_IMX307(i2c);
+    uint8_t val = 0xFF;
+
+    if (s->cur_reg >= IMX307_REG_BASE &&
+        s->cur_reg < IMX307_REG_BASE + IMX307_REG_COUNT) {
+        val = s->regs[s->cur_reg - IMX307_REG_BASE];
+    }
+    s->cur_reg++;
+    return val;
+}
+
+static void hisi_imx307_reset(DeviceState *dev)
+{
+    HisiIMX307State *s = HISI_IMX307(dev);
+
+    s->reg_ptr = 0;
+    s->cur_reg = 0;
+    memset(s->reg_buf, 0, sizeof(s->reg_buf));
+    hisi_imx307_reset_regs(s);
+}
+
+static void hisi_imx307_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    I2CSlaveClass *k = I2C_SLAVE_CLASS(klass);
+
+    device_class_set_legacy_reset(dc, hisi_imx307_reset);
+    k->event = hisi_imx307_event;
+    k->recv  = hisi_imx307_recv;
+    k->send  = hisi_imx307_send;
+}
+
+static const TypeInfo hisi_imx307_info = {
+    .name          = TYPE_HISI_IMX307,
+    .parent        = TYPE_I2C_SLAVE,
+    .instance_size = sizeof(HisiIMX307State),
+    .class_init    = hisi_imx307_class_init,
+};
+
+static void hisi_imx307_register_types(void)
+{
+    type_register_static(&hisi_imx307_info);
+}
+
+type_init(hisi_imx307_register_types)

--- a/qemu/hw/i2c/hisi-mis2006.c
+++ b/qemu/hw/i2c/hisi-mis2006.c
@@ -1,0 +1,130 @@
+/*
+ * BYD MIS2006 image sensor I2C stub.
+ *
+ * Sofia (XiongMai) detects MIS2006 by:
+ *   1. I2C addr inherited from previous SmartSens probe = 0x60 (8-bit) = 0x30 (7-bit)
+ *   2. Reading reg 0x3000 (high byte) and 0x3001 (low byte) — 16-bit reg, 8-bit data
+ *   3. Checking (high << 8) | low == 0x2006
+ *
+ * Returning 0x20 at 0x3000 and 0x06 at 0x3001 satisfies the probe.
+ *
+ * Note: this sensor shares I2C addr 0x30 with the SmartSens family.
+ * Only one device can be attached at a time via -machine sensor=...
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * Written by Dmitry Ilyin
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/i2c/i2c.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_MIS2006 "hisi-mis2006"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiMIS2006State, HISI_MIS2006)
+
+#define MIS2006_REG_BASE  0x3000
+#define MIS2006_REG_COUNT 0x1000
+
+struct HisiMIS2006State {
+    I2CSlave parent_obj;
+    uint8_t  reg_buf[2];
+    uint8_t  reg_ptr;
+    uint16_t cur_reg;
+    uint8_t  regs[MIS2006_REG_COUNT];
+};
+
+static void hisi_mis2006_reset_regs(HisiMIS2006State *s)
+{
+    memset(s->regs, 0, sizeof(s->regs));
+    /* Sofia checks regs 0x3000:0x3001 → expects 0x2006 */
+    s->regs[0x3000 - MIS2006_REG_BASE] = 0x20;
+    s->regs[0x3001 - MIS2006_REG_BASE] = 0x06;
+}
+
+static int hisi_mis2006_event(I2CSlave *i2c, enum i2c_event event)
+{
+    HisiMIS2006State *s = HISI_MIS2006(i2c);
+
+    switch (event) {
+    case I2C_START_SEND:
+        s->reg_ptr = 0;
+        break;
+    case I2C_START_RECV:
+        s->cur_reg = ((uint16_t)s->reg_buf[0] << 8) | s->reg_buf[1];
+        break;
+    default:
+        break;
+    }
+    return 0;
+}
+
+static int hisi_mis2006_send(I2CSlave *i2c, uint8_t data)
+{
+    HisiMIS2006State *s = HISI_MIS2006(i2c);
+
+    if (s->reg_ptr < 2) {
+        s->reg_buf[s->reg_ptr++] = data;
+    } else {
+        uint16_t addr = ((uint16_t)s->reg_buf[0] << 8) | s->reg_buf[1];
+        if (addr >= MIS2006_REG_BASE &&
+            addr < MIS2006_REG_BASE + MIS2006_REG_COUNT) {
+            s->regs[addr - MIS2006_REG_BASE] = data;
+        }
+        s->reg_buf[1]++;
+        if (s->reg_buf[1] == 0) {
+            s->reg_buf[0]++;
+        }
+    }
+    return 0;
+}
+
+static uint8_t hisi_mis2006_recv(I2CSlave *i2c)
+{
+    HisiMIS2006State *s = HISI_MIS2006(i2c);
+    uint8_t val = 0xFF;
+
+    if (s->cur_reg >= MIS2006_REG_BASE &&
+        s->cur_reg < MIS2006_REG_BASE + MIS2006_REG_COUNT) {
+        val = s->regs[s->cur_reg - MIS2006_REG_BASE];
+    }
+    s->cur_reg++;
+    return val;
+}
+
+static void hisi_mis2006_reset(DeviceState *dev)
+{
+    HisiMIS2006State *s = HISI_MIS2006(dev);
+
+    s->reg_ptr = 0;
+    s->cur_reg = 0;
+    memset(s->reg_buf, 0, sizeof(s->reg_buf));
+    hisi_mis2006_reset_regs(s);
+}
+
+static void hisi_mis2006_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    I2CSlaveClass *k = I2C_SLAVE_CLASS(klass);
+
+    device_class_set_legacy_reset(dc, hisi_mis2006_reset);
+    k->event = hisi_mis2006_event;
+    k->recv  = hisi_mis2006_recv;
+    k->send  = hisi_mis2006_send;
+}
+
+static const TypeInfo hisi_mis2006_info = {
+    .name          = TYPE_HISI_MIS2006,
+    .parent        = TYPE_I2C_SLAVE,
+    .instance_size = sizeof(HisiMIS2006State),
+    .class_init    = hisi_mis2006_class_init,
+};
+
+static void hisi_mis2006_register_types(void)
+{
+    type_register_static(&hisi_mis2006_info);
+}
+
+type_init(hisi_mis2006_register_types)

--- a/qemu/hw/i2c/hisi-smartsens.c
+++ b/qemu/hw/i2c/hisi-smartsens.c
@@ -1,0 +1,160 @@
+/*
+ * SmartSens (SC*) image sensor I2C stub.
+ *
+ * Generic model for SmartSens sensors that share the same probe protocol:
+ * 16-bit register addresses, 8-bit data, ID at 0x3107/0x3108 with optional
+ * discriminator at 0x3109.
+ *
+ * Sofia (XiongMai) detects these sensors at I2C addr 0x60 (8-bit) =
+ * 0x30 (7-bit slave addr).  All variants are identified by a unique
+ * 16-bit ID composed of regs 0x3107 (high) and 0x3108 (low).  Several
+ * variants share the same ID (e.g. SC2235P and SC2235E both report
+ * 0x2232) and are disambiguated by the value of reg 0x3109.
+ *
+ * The instance properties select the variant:
+ *   id_high       — value returned for reg 0x3107
+ *   id_low        — value returned for reg 0x3108
+ *   disc          — value returned for reg 0x3109 (discriminator)
+ *
+ * Sofia variants currently supported (instance type names):
+ *   hisi-sc2235p   ID 0x2232  disc 0x01
+ *   hisi-sc2235e   ID 0x2232  disc 0x20
+ *   hisi-sc2315    ID 0x2311  disc 0x00
+ *   hisi-sc2315e   ID 0x2238  disc 0x00
+ *   hisi-sc2335    ID 0xCB14  disc 0x00
+ *   hisi-sc2239    ID 0xCB10  disc 0x00
+ *   hisi-sc307h    ID 0xCB1C  disc 0x00
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * Written by Dmitry Ilyin
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/i2c/i2c.h"
+#include "hw/qdev-properties.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_SMARTSENS "hisi-smartsens"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiSmartSensState, HISI_SMARTSENS)
+
+#define SS_REG_BASE  0x3000
+#define SS_REG_COUNT 0x1000
+
+struct HisiSmartSensState {
+    I2CSlave parent_obj;
+
+    /* Variant selection (set via qdev properties) */
+    uint8_t  id_high;
+    uint8_t  id_low;
+    uint8_t  disc;
+
+    /* I2C state */
+    uint8_t  reg_buf[2];   /* register address accumulator (big-endian) */
+    uint8_t  reg_ptr;      /* bytes received for register address */
+    uint16_t cur_reg;      /* current register address */
+    uint8_t  regs[SS_REG_COUNT];
+};
+
+static void hisi_smartsens_reset_regs(HisiSmartSensState *s)
+{
+    memset(s->regs, 0, sizeof(s->regs));
+    /* Sofia checks reg 0x3107/0x3108 (ID) and optionally reg 0x3109 (discriminator) */
+    s->regs[0x3107 - SS_REG_BASE] = s->id_high;
+    s->regs[0x3108 - SS_REG_BASE] = s->id_low;
+    s->regs[0x3109 - SS_REG_BASE] = s->disc;
+}
+
+static int hisi_smartsens_event(I2CSlave *i2c, enum i2c_event event)
+{
+    HisiSmartSensState *s = HISI_SMARTSENS(i2c);
+
+    switch (event) {
+    case I2C_START_SEND:
+        s->reg_ptr = 0;
+        break;
+    case I2C_START_RECV:
+        s->cur_reg = ((uint16_t)s->reg_buf[0] << 8) | s->reg_buf[1];
+        break;
+    default:
+        break;
+    }
+    return 0;
+}
+
+static int hisi_smartsens_send(I2CSlave *i2c, uint8_t data)
+{
+    HisiSmartSensState *s = HISI_SMARTSENS(i2c);
+
+    if (s->reg_ptr < 2) {
+        s->reg_buf[s->reg_ptr++] = data;
+    } else {
+        uint16_t addr = ((uint16_t)s->reg_buf[0] << 8) | s->reg_buf[1];
+        if (addr >= SS_REG_BASE &&
+            addr < SS_REG_BASE + SS_REG_COUNT) {
+            s->regs[addr - SS_REG_BASE] = data;
+        }
+        s->reg_buf[1]++;
+        if (s->reg_buf[1] == 0) {
+            s->reg_buf[0]++;
+        }
+    }
+    return 0;
+}
+
+static uint8_t hisi_smartsens_recv(I2CSlave *i2c)
+{
+    HisiSmartSensState *s = HISI_SMARTSENS(i2c);
+    uint8_t val = 0xFF;
+
+    if (s->cur_reg >= SS_REG_BASE &&
+        s->cur_reg < SS_REG_BASE + SS_REG_COUNT) {
+        val = s->regs[s->cur_reg - SS_REG_BASE];
+    }
+    s->cur_reg++;
+    return val;
+}
+
+static void hisi_smartsens_reset(DeviceState *dev)
+{
+    HisiSmartSensState *s = HISI_SMARTSENS(dev);
+
+    s->reg_ptr = 0;
+    s->cur_reg = 0;
+    memset(s->reg_buf, 0, sizeof(s->reg_buf));
+    hisi_smartsens_reset_regs(s);
+}
+
+static const Property hisi_smartsens_props[] = {
+    DEFINE_PROP_UINT8("id_high", HisiSmartSensState, id_high, 0x00),
+    DEFINE_PROP_UINT8("id_low",  HisiSmartSensState, id_low,  0x00),
+    DEFINE_PROP_UINT8("disc",    HisiSmartSensState, disc,    0x00),
+};
+
+static void hisi_smartsens_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    I2CSlaveClass *k = I2C_SLAVE_CLASS(klass);
+
+    device_class_set_legacy_reset(dc, hisi_smartsens_reset);
+    device_class_set_props(dc, hisi_smartsens_props);
+    k->event = hisi_smartsens_event;
+    k->recv  = hisi_smartsens_recv;
+    k->send  = hisi_smartsens_send;
+}
+
+static const TypeInfo hisi_smartsens_info = {
+    .name          = TYPE_HISI_SMARTSENS,
+    .parent        = TYPE_I2C_SLAVE,
+    .instance_size = sizeof(HisiSmartSensState),
+    .class_init    = hisi_smartsens_class_init,
+};
+
+static void hisi_smartsens_register_types(void)
+{
+    type_register_static(&hisi_smartsens_info);
+}
+
+type_init(hisi_smartsens_register_types)

--- a/qemu/hw/i2c/hisi-sp2305.c
+++ b/qemu/hw/i2c/hisi-sp2305.c
@@ -1,0 +1,107 @@
+/*
+ * SmartSens SP2305 image sensor I2C stub.
+ *
+ * Sofia (XiongMai) detects SP2305 by:
+ *   1. Setting I2C addr 0x78 (8-bit) = 0x3C (7-bit slave addr)
+ *   2. Writing 0 to reg 0xFD (page select)
+ *   3. Reading reg 0x02 (high byte) and 0x03 (low byte) — 8-bit reg, 8-bit data
+ *   4. Checking (high << 8) | low == 0x2735
+ *
+ * Returning 0x27 at 0x02 and 0x35 at 0x03 satisfies the probe.
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * Written by Dmitry Ilyin
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/i2c/i2c.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_SP2305 "hisi-sp2305"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiSP2305State, HISI_SP2305)
+
+#define SP2305_REG_COUNT 0x100
+
+struct HisiSP2305State {
+    I2CSlave parent_obj;
+    uint8_t  cur_reg;
+    bool     have_reg;
+    uint8_t  regs[SP2305_REG_COUNT];
+};
+
+static void hisi_sp2305_reset_regs(HisiSP2305State *s)
+{
+    memset(s->regs, 0, sizeof(s->regs));
+    /* Sofia checks regs 0x02:0x03 → expects 0x2735 */
+    s->regs[0x02] = 0x27;
+    s->regs[0x03] = 0x35;
+}
+
+static int hisi_sp2305_event(I2CSlave *i2c, enum i2c_event event)
+{
+    HisiSP2305State *s = HISI_SP2305(i2c);
+
+    if (event == I2C_START_SEND) {
+        s->have_reg = false;
+    }
+    return 0;
+}
+
+static int hisi_sp2305_send(I2CSlave *i2c, uint8_t data)
+{
+    HisiSP2305State *s = HISI_SP2305(i2c);
+
+    if (!s->have_reg) {
+        s->cur_reg = data;
+        s->have_reg = true;
+    } else {
+        s->regs[s->cur_reg] = data;
+        s->cur_reg++;
+    }
+    return 0;
+}
+
+static uint8_t hisi_sp2305_recv(I2CSlave *i2c)
+{
+    HisiSP2305State *s = HISI_SP2305(i2c);
+    uint8_t val = s->regs[s->cur_reg];
+    s->cur_reg++;
+    return val;
+}
+
+static void hisi_sp2305_reset(DeviceState *dev)
+{
+    HisiSP2305State *s = HISI_SP2305(dev);
+
+    s->cur_reg = 0;
+    s->have_reg = false;
+    hisi_sp2305_reset_regs(s);
+}
+
+static void hisi_sp2305_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    I2CSlaveClass *k = I2C_SLAVE_CLASS(klass);
+
+    device_class_set_legacy_reset(dc, hisi_sp2305_reset);
+    k->event = hisi_sp2305_event;
+    k->recv  = hisi_sp2305_recv;
+    k->send  = hisi_sp2305_send;
+}
+
+static const TypeInfo hisi_sp2305_info = {
+    .name          = TYPE_HISI_SP2305,
+    .parent        = TYPE_I2C_SLAVE,
+    .instance_size = sizeof(HisiSP2305State),
+    .class_init    = hisi_sp2305_class_init,
+};
+
+static void hisi_sp2305_register_types(void)
+{
+    type_register_static(&hisi_sp2305_info);
+}
+
+type_init(hisi_sp2305_register_types)

--- a/qemu/setup.sh
+++ b/qemu/setup.sh
@@ -51,6 +51,12 @@ cp qemu/hw/net/hisi-femac.c         "$QEMU_DIR/hw/net/"
 cp qemu/hw/net/hisi-gmac.c          "$QEMU_DIR/hw/net/"
 cp qemu/hw/i2c/hisi-i2c.c          "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-imx335.c       "$QEMU_DIR/hw/i2c/"
+cp qemu/hw/i2c/hisi-imx307.c       "$QEMU_DIR/hw/i2c/"
+cp qemu/hw/i2c/hisi-f37.c          "$QEMU_DIR/hw/i2c/"
+cp qemu/hw/i2c/hisi-gc2053.c       "$QEMU_DIR/hw/i2c/"
+cp qemu/hw/i2c/hisi-sp2305.c       "$QEMU_DIR/hw/i2c/"
+cp qemu/hw/i2c/hisi-mis2006.c      "$QEMU_DIR/hw/i2c/"
+cp qemu/hw/i2c/hisi-smartsens.c    "$QEMU_DIR/hw/i2c/"
 
 # Apply patches to upstream QEMU files
 for p in qemu/patches/*.patch; do
@@ -165,7 +171,7 @@ fi
 
 # hw/i2c/meson.build
 if ! grep -q hisi-i2c "$QEMU_DIR/hw/i2c/meson.build"; then
-    echo "system_ss.add(when: 'CONFIG_HISI_I2C', if_true: files('hisi-i2c.c', 'hisi-imx335.c'))" \
+    echo "system_ss.add(when: 'CONFIG_HISI_I2C', if_true: files('hisi-i2c.c', 'hisi-imx335.c', 'hisi-imx307.c', 'hisi-f37.c', 'hisi-gc2053.c', 'hisi-sp2305.c', 'hisi-mis2006.c', 'hisi-smartsens.c'))" \
         >> "$QEMU_DIR/hw/i2c/meson.build"
     echo "  patched hw/i2c/meson.build"
 else


### PR DESCRIPTION
## Summary

Adds I2C sensor models for all 13 sensors that the XiongMai/Sofia binary detects via `cmos_get_sensorChip` on Hi3516EV200. Each is auto-attached to the first I2C controller via `-machine hi3516ev200,sensor=<name>`.

| Sensor | 7-bit I2C addr | Reg width | Probe regs | Expected ID |
|--------|---------------:|-----------|------------|-------------|
| imx335 | 0x1A | 16/8 | 0x3057 | 0x07 (existing) |
| imx307 | 0x1A | 16/8 | 0x31DC | `(v & 6) == 4` |
| f37 | 0x40 | 8/8 | 0x0A, 0x0B | 0x0F37 |
| gc2053 | 0x37 | 8/8 | 0xF0, 0xF1 | 0x2053 |
| sp2305 | 0x3C | 8/8 | 0x02, 0x03 | 0x2735 |
| mis2006 | 0x30 | 16/8 | 0x3000, 0x3001 | 0x2006 |
| sc2235p | 0x30 | 16/8 | 0x3107..0x3109 | 0x2232 + disc 0x01 |
| sc2235e | 0x30 | 16/8 | 0x3107..0x3109 | 0x2232 + disc 0x20 |
| sc2315 | 0x30 | 16/8 | 0x3107, 0x3108 | 0x2311 |
| sc2315e | 0x30 | 16/8 | 0x3107, 0x3108 | 0x2238 |
| sc2335 | 0x30 | 16/8 | 0x3107, 0x3108 | 0xCB14 |
| sc2239 | 0x30 | 16/8 | 0x3107, 0x3108 | 0xCB10 |
| sc307h | 0x30 | 16/8 | 0x3107, 0x3108 | 0xCB1C |

The 7 SmartSens sensors (sc*/sc307h) share an identical probe protocol — only the ID bytes differ — so they're consolidated into one parameterised `hisi-smartsens` model that takes `id_high`, `id_low`, `disc` qdev properties. The 5 unique-protocol sensors (imx307, f37, gc2053, sp2305, mis2006) each get their own file modelled on `hisi-imx335.c`.

Note: SmartSens sensors share I2C addr 0x30, so only one can be attached at a time. Pick which one via the `-machine sensor=...` arg.

## Why

I'm extracting per-sensor ISP tuning profiles from vendor binaries for [majestic](https://github.com/widgetii/majestic) (OpenIPC's IP camera streamer). Without all the sensors physically available, I need QEMU to respond to Sofia's I2C sensor probe correctly for each variant.

## Test plan

- [x] `bash qemu/setup.sh` builds without errors
- [x] All 13 sensor types registered: `qemu-system-arm -device help | grep "hisi-"`
- [x] Each `-machine sensor=<name>` boots without an error_report
- [x] OpenIPC's `ipctool` correctly reports the sensor for 12/13 variants in serial console:

  ```
  imx335   → set SENSOR as imx335
  imx307   → set SENSOR as imx307
  f37      → set SENSOR as jxf37    (ipctool name convention)
  gc2053   → set SENSOR as gc2053
  sp2305   → set SENSOR as unknown  (ipctool doesn't know SP2305 ID)
  mis2006  → set SENSOR as mis2006
  sc2235p  → set SENSOR as sc2235p
  sc2235e  → set SENSOR as sc2235e
  sc2315   → set SENSOR as sc2315
  sc2315e  → set SENSOR as sc2315e
  sc2335   → set SENSOR as sc2335
  sc2239   → set SENSOR as sc2239
  sc307h   → set SENSOR as sc337h   (ipctool name convention)
  ```

  SP2305 detection in ipctool is a separate ipctool issue — the I2C probe response matches Sofia's protocol.

## Notes

- All sensor models are I2C-only stubs: probe IDs hard-wired, all other reads return 0xFF, writes go into a per-sensor RAM buffer. No imaging behaviour is emulated.
- The downstream goal (capturing ISP register state from inside Sofia under QEMU) is blocked by the vendor kernel `open_osal.ko` rejecting the QEMU memory layout — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)