### PR TITLE
hisi-i2c-v1: implement V1 I2C controller + verify CV100 sensor detection

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -160,8 +160,10 @@ static const HisiSoCConfig hi3516cv100_soc = {
     .himci_bases        = { 0x10020000 },
     .himci_irqs         = { 18 },
 
-    /* No I2C buses in V1 platform headers */
-    .num_i2c            = 0,
+    /* V1 register-poll I2C controller (vendor hi_i2c.ko target). */
+    .num_i2c            = 1,
+    .i2c_bases          = { 0x200D0000 },
+    .i2c_type           = "hisi-i2c-v1",
 
     .wdt_base           = 0x20040000,
     .wdt_irq            = -1,
@@ -190,13 +192,12 @@ static const HisiSoCConfig hi3516cv100_soc = {
      * hardware during init.  Without mapped regions, reads return 0
      * from QEMU's "unimplemented" handler, causing poll loops to hang.
      */
-    .num_regbanks       = 9,
+    .num_regbanks       = 8,
     .regbanks           = {
         { "hisi-misc",   0x20120000, 0x10000 },
         { "hisi-ddr",    0x20110000, 0x10000 },
         { "hisi-pwm",    0x20130000, 0x10000 },
         { "hisi-nandc",  0x10000000, 0x10000 },
-        { "hisi-i2c-v1", 0x200D0000, 0x1000 },
         { "hisi-viu",    0x20580000, 0x40000 },
         { "hisi-vpss",   0x20600000, 0x10000 },
         { "hisi-vedu",   0x20620000, 0x10000 },
@@ -2093,10 +2094,11 @@ static void hisilicon_common_init(MachineState *machine,
         }
     }
 
-    /* I2C (HiBVT) */
+    /* I2C — HiBVT for V2+, register-poll "hisi-i2c-v1" for CV100 family. */
+    const char *i2c_type = c->i2c_type ? c->i2c_type : "hisi-i2c";
     DeviceState *i2c_devs[HISI_MAX_I2C] = { NULL };
     for (n = 0; n < c->num_i2c; n++) {
-        i2c_devs[n] = qdev_new("hisi-i2c");
+        i2c_devs[n] = qdev_new(i2c_type);
         sysbus_realize_and_unref(SYS_BUS_DEVICE(i2c_devs[n]), &error_fatal);
         sysbus_mmio_map(SYS_BUS_DEVICE(i2c_devs[n]), 0, c->i2c_bases[n]);
     }
@@ -2175,17 +2177,6 @@ static void hisilicon_common_init(MachineState *machine,
             if (!strcmp(c->regbanks[n].name, "hisi-nandc")) {
                 address_space_stl(&address_space_memory,
                                   c->regbanks[n].base + 0x20, 0x01,
-                                  MEMTXATTRS_UNSPECIFIED, NULL);
-            }
-            /*
-             * V1 I2C controller: pre-set I2C_OVER_INTR (bit 0) in the
-             * status register (offset 0x0C) so poll loops in the vendor
-             * hi_i2c.ko module exit immediately instead of spinning
-             * through 4096-iteration timeouts per I2C probe address.
-             */
-            if (!strcmp(c->regbanks[n].name, "hisi-i2c-v1")) {
-                address_space_stl(&address_space_memory,
-                                  c->regbanks[n].base + 0x0C, 0x01,
                                   MEMTXATTRS_UNSPECIFIED, NULL);
             }
             /*

--- a/qemu/hw/i2c/hisi-i2c-v1.c
+++ b/qemu/hw/i2c/hisi-i2c-v1.c
@@ -1,0 +1,260 @@
+/*
+ * HiSilicon V1 I2C controller (vendor "hi_i2c" driver target).
+ *
+ * Used on CV100 family SoCs (Hi3516CV100, Hi3518CV100, Hi3518EV100).
+ * Mapped at 0x200D0000.  The vendor `hi_i2c.ko` kernel module exposes
+ * /dev/hi_i2c on top of this controller; OpenIPC's ipctool issues
+ * CMD_I2C_READ / CMD_I2C_WRITE ioctls that translate into the register
+ * sequence below.  No interrupt is wired — the vendor driver polls
+ * SR.OVER (and SR.RECEIVE on reads) every iteration.
+ *
+ * Reference: hisilicon_mpp/hi3518v100_mpp_1.0.A.0/extdrv/hi_i2c/hii2c.c
+ *
+ * Register layout:
+ *   0x000 CTRL     b8 ENABLE, b7 UNMASK_TOTAL, b6..b0 per-source unmask
+ *   0x004 COM      b3 START, b2 READ, b1 WRITE, b0 STOP, b4 SEND_ACK (active-low)
+ *   0x008 ICR      write-1-to-clear of SR bits
+ *   0x00C SR       b7 BUSY, b6 START, b5 END, b4 SEND, b3 RECEIVE,
+ *                  b2 ACK (=NACK seen), b1 ARB, b0 OVER
+ *   0x010 SCL_H    high-period prescaler (timing — ignored)
+ *   0x014 SCL_L    low-period prescaler  (timing — ignored)
+ *   0x018 TXR      byte to transmit (incl. address byte with R/W LSB)
+ *   0x01C RXR      last received byte
+ *
+ * The TXR byte already carries the standard I2C address-with-R/W
+ * encoding (bit 0 = read), so a START with WRITE flag translates into
+ * either i2c_start_send() or i2c_start_recv() depending on TXR's LSB.
+ *
+ * Copyright (c) 2026 OpenIPC.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/sysbus.h"
+#include "hw/irq.h"
+#include "hw/i2c/i2c.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+#include "qom/object.h"
+
+#define TYPE_HISI_I2C_V1 "hisi-i2c-v1"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiI2cV1State, HISI_I2C_V1)
+
+#define HISI_I2C_V1_REG_SIZE 0x1000
+
+/* Register offsets */
+#define R_CTRL   0x000
+#define R_COM    0x004
+#define R_ICR    0x008
+#define R_SR     0x00C
+#define R_SCL_H  0x010
+#define R_SCL_L  0x014
+#define R_TXR    0x018
+#define R_RXR    0x01C
+
+/* COM register bits */
+#define COM_SEND_ACK (1 << 4)
+#define COM_START    (1 << 3)
+#define COM_READ     (1 << 2)
+#define COM_WRITE    (1 << 1)
+#define COM_STOP     (1 << 0)
+
+/* SR / ICR bits (same layout) */
+#define SR_BUSY      (1 << 7)
+#define SR_START     (1 << 6)
+#define SR_END       (1 << 5)
+#define SR_SEND      (1 << 4)
+#define SR_RECEIVE   (1 << 3)
+#define SR_ACK       (1 << 2)   /* NACK observed on the bus */
+#define SR_ARB       (1 << 1)
+#define SR_OVER      (1 << 0)
+#define SR_ALL       0x7F
+
+struct HisiI2cV1State {
+    SysBusDevice parent_obj;
+    MemoryRegion iomem;
+    I2CBus      *bus;
+    qemu_irq     irq;
+
+    uint32_t     ctrl;
+    uint32_t     sr;
+    uint32_t     scl_h;
+    uint32_t     scl_l;
+    uint32_t     txr;
+    uint32_t     rxr;
+
+    bool         active;   /* an i2c transfer is currently open */
+    bool         is_read;  /* the open transfer is read-direction */
+};
+
+static uint64_t hisi_i2c_v1_read(void *opaque, hwaddr offset, unsigned size)
+{
+    HisiI2cV1State *s = opaque;
+
+    switch (offset) {
+    case R_CTRL:  return s->ctrl;
+    case R_SR:    return s->sr;
+    case R_SCL_H: return s->scl_h;
+    case R_SCL_L: return s->scl_l;
+    case R_TXR:   return s->txr;
+    case R_RXR:   return s->rxr;
+    case R_COM:
+    case R_ICR:
+        return 0;
+    default:
+        qemu_log_mask(LOG_GUEST_ERROR,
+                      "hisi-i2c-v1: bad read offset 0x%x\n", (int)offset);
+        return 0;
+    }
+}
+
+static void hisi_i2c_v1_do_com(HisiI2cV1State *s, uint8_t com)
+{
+    /* START condition: open a new transfer using the byte in TXR. */
+    if (com & COM_START) {
+        uint8_t addr = (s->txr >> 1) & 0x7F;
+        bool    want_read = (s->txr & 1) != 0;
+        int     ret;
+
+        if (s->active) {
+            /* Repeated start — close the prior transfer first.  QEMU's
+             * i2c_start_*() will issue STOP+START internally, but
+             * end_transfer here makes our state machine match. */
+            i2c_end_transfer(s->bus);
+            s->active = false;
+        }
+
+        ret = want_read ? i2c_start_recv(s->bus, addr)
+                        : i2c_start_send(s->bus, addr);
+        if (ret == 0) {
+            s->active  = true;
+            s->is_read = want_read;
+            s->sr |= SR_START;
+        } else {
+            /* No slave at this address — flag NACK to userspace. */
+            s->sr |= SR_ACK;
+        }
+    }
+
+    /* Plain WRITE (no START) — push one byte to the open send transfer. */
+    if ((com & COM_WRITE) && !(com & COM_START) && s->active && !s->is_read) {
+        i2c_send(s->bus, s->txr & 0xFF);
+        s->sr |= SR_SEND;
+    }
+
+    /* READ — clock one byte in from the open recv transfer. */
+    if ((com & COM_READ) && s->active && s->is_read) {
+        s->rxr = i2c_recv(s->bus);
+        s->sr |= SR_RECEIVE;
+    }
+
+    /* STOP — close the open transfer (if any). */
+    if (com & COM_STOP) {
+        if (s->active) {
+            i2c_end_transfer(s->bus);
+            s->active = false;
+        }
+        s->sr |= SR_END;
+    }
+
+    /* Every COM trigger completes "immediately" from the kernel's
+     * viewpoint — set OVER so I2C_DRV_WaitWriteEnd's polling loop
+     * exits on its first iteration. */
+    s->sr |= SR_OVER;
+}
+
+static void hisi_i2c_v1_write(void *opaque, hwaddr offset,
+                              uint64_t value, unsigned size)
+{
+    HisiI2cV1State *s = opaque;
+
+    switch (offset) {
+    case R_CTRL:
+        s->ctrl = value & 0x1FF;
+        break;
+    case R_COM:
+        hisi_i2c_v1_do_com(s, value & 0x1F);
+        break;
+    case R_ICR:
+        s->sr &= ~(value & SR_ALL);
+        break;
+    case R_SCL_H:
+        s->scl_h = value;
+        break;
+    case R_SCL_L:
+        s->scl_l = value;
+        break;
+    case R_TXR:
+        s->txr = value & 0xFF;
+        break;
+    case R_SR:
+    case R_RXR:
+        /* Read-only on real hardware — ignore. */
+        break;
+    default:
+        qemu_log_mask(LOG_GUEST_ERROR,
+                      "hisi-i2c-v1: bad write offset 0x%x val=0x%x\n",
+                      (int)offset, (unsigned)value);
+        break;
+    }
+}
+
+static const MemoryRegionOps hisi_i2c_v1_ops = {
+    .read  = hisi_i2c_v1_read,
+    .write = hisi_i2c_v1_write,
+    .endianness = DEVICE_LITTLE_ENDIAN,
+    .valid.min_access_size = 4,
+    .valid.max_access_size = 4,
+};
+
+static void hisi_i2c_v1_reset(DeviceState *dev)
+{
+    HisiI2cV1State *s = HISI_I2C_V1(dev);
+
+    if (s->active) {
+        i2c_end_transfer(s->bus);
+    }
+    s->ctrl = 0;
+    s->sr = 0;
+    s->scl_h = 0;
+    s->scl_l = 0;
+    s->txr = 0;
+    s->rxr = 0;
+    s->active = false;
+    s->is_read = false;
+}
+
+static void hisi_i2c_v1_init(Object *obj)
+{
+    HisiI2cV1State *s = HISI_I2C_V1(obj);
+    SysBusDevice *sbd = SYS_BUS_DEVICE(obj);
+
+    memory_region_init_io(&s->iomem, obj, &hisi_i2c_v1_ops, s,
+                          TYPE_HISI_I2C_V1, HISI_I2C_V1_REG_SIZE);
+    sysbus_init_mmio(sbd, &s->iomem);
+    sysbus_init_irq(sbd, &s->irq);
+    s->bus = i2c_init_bus(DEVICE(obj), "i2c");
+}
+
+static void hisi_i2c_v1_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+
+    device_class_set_legacy_reset(dc, hisi_i2c_v1_reset);
+}
+
+static const TypeInfo hisi_i2c_v1_info = {
+    .name          = TYPE_HISI_I2C_V1,
+    .parent        = TYPE_SYS_BUS_DEVICE,
+    .instance_size = sizeof(HisiI2cV1State),
+    .instance_init = hisi_i2c_v1_init,
+    .class_init    = hisi_i2c_v1_class_init,
+};
+
+static void hisi_i2c_v1_register_types(void)
+{
+    type_register_static(&hisi_i2c_v1_info);
+}
+
+type_init(hisi_i2c_v1_register_types)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -107,9 +107,10 @@ typedef struct HisiSoCConfig {
     hwaddr          sdhci_bases[HISI_MAX_SDHCI];
     int             sdhci_irqs[HISI_MAX_SDHCI];
 
-    /* I2C (HiBVT) */
+    /* I2C (HiBVT for V2+, register-poll "hisi-i2c-v1" for CV100 family) */
     int             num_i2c;
     hwaddr          i2c_bases[HISI_MAX_I2C];
+    const char     *i2c_type;       /* NULL = "hisi-i2c", or "hisi-i2c-v1" */
 
     /* MIPI RX (CSI-2 / LVDS receiver) */
     hwaddr          mipi_rx_base;   /* 0 = no MIPI RX */

--- a/qemu/setup.sh
+++ b/qemu/setup.sh
@@ -57,6 +57,7 @@ cp qemu/hw/i2c/hisi-gc2053.c       "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-sp2305.c       "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-mis2006.c      "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-smartsens.c    "$QEMU_DIR/hw/i2c/"
+cp qemu/hw/i2c/hisi-i2c-v1.c       "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/ssi/hisi-spi.c          "$QEMU_DIR/hw/ssi/"
 cp qemu/hw/ssi/hisi-imx122.c       "$QEMU_DIR/hw/ssi/"
 
@@ -181,9 +182,14 @@ fi
 
 # hw/i2c/meson.build
 if ! grep -q hisi-i2c "$QEMU_DIR/hw/i2c/meson.build"; then
-    echo "system_ss.add(when: 'CONFIG_HISI_I2C', if_true: files('hisi-i2c.c', 'hisi-imx335.c', 'hisi-imx307.c', 'hisi-f37.c', 'hisi-gc2053.c', 'hisi-sp2305.c', 'hisi-mis2006.c', 'hisi-smartsens.c'))" \
+    echo "system_ss.add(when: 'CONFIG_HISI_I2C', if_true: files('hisi-i2c.c', 'hisi-i2c-v1.c', 'hisi-imx335.c', 'hisi-imx307.c', 'hisi-f37.c', 'hisi-gc2053.c', 'hisi-sp2305.c', 'hisi-mis2006.c', 'hisi-smartsens.c'))" \
         >> "$QEMU_DIR/hw/i2c/meson.build"
     echo "  patched hw/i2c/meson.build"
+elif ! grep -q hisi-i2c-v1 "$QEMU_DIR/hw/i2c/meson.build"; then
+    # Existing tree from an older setup.sh — splice in the new file.
+    sed -i "s/'hisi-i2c.c', 'hisi-imx335.c'/'hisi-i2c.c', 'hisi-i2c-v1.c', 'hisi-imx335.c'/" \
+        "$QEMU_DIR/hw/i2c/meson.build"
+    echo "  hw/i2c/meson.build: added hisi-i2c-v1.c"
 else
     echo "  hw/i2c/meson.build already patched"
 fi


### PR DESCRIPTION
## Summary

Closes #7. Builds on PR #37.

- New SysBusDevice **`hisi-i2c-v1`** at `qemu/hw/i2c/hisi-i2c-v1.c` implements the vendor `hi_i2c.ko` register interface (CTRL/COM/ICR/SR/SCL_H/SCL_L/TXR/RXR at offsets `0x000`-`0x01C`). Each `COM` write translates the START/READ/WRITE/STOP/~SEND_ACK bits into `i2c_start_send` / `i2c_start_recv` / `i2c_send` / `i2c_recv` / `i2c_end_transfer` calls on a child `I2CBus`, then sets `SR.OVER` (and the appropriate per-source status bits) so the vendor's polling loops complete on the first iteration.
- Adds `i2c_type` to `HisiSoCConfig` (parallel to `fmc_type`); `NULL` means the existing HiBVT `hisi-i2c` device, `"hisi-i2c-v1"` selects the new one. CV100 SoC is wired to `hisi-i2c-v1` at `0x200D0000`.
- Removes the regbank stub at `0x200D0000` and the regbank-special-case in `hisilicon_common_init` that pre-set `I2C_OVER_INTR` to satisfy the polling loop — no longer needed.
- Existing I2C sensor stubs (`hisi-imx307`, `hisi-imx335`, `hisi-f37`, `hisi-gc2053`, `hisi-sp2305`, `hisi-mis2006`, `hisi-smartsens`) attach to the new V1 controller without modification because the child bus is named `"i2c"` on both V1 and V2+ controllers.
- `setup.sh` adds `hisi-i2c-v1.c` to the `hw/i2c` copy block and meson.build (with an idempotent fallback for existing trees).

## Test plan

- [x] `bash qemu-boot/run-cv100.sh -M hi3516cv100,sensor=imx307` — boot log shows `hisilicon: Get data from ipcinfo and set SENSOR as imx307`; after login `ipcinfo -s` returns `imx307`, `ipcinfo -l` returns `imx307_i2c`
- [x] `... sensor=f37` — `ipcinfo -s` returns `jxf37`, `ipcinfo -l` returns `jxf37_i2c`
- [x] Default `bash qemu-boot/run-cv100.sh` (`sensor=imx222`, SPI path from PR #37) — still detects `imx122`; no regression
- [x] `... -M hi3516cv100` (no sensor attached) — `ipcinfo -s` exits 1 with no false positives
- [x] `bash qemu-boot/run-ev300.sh` — V2+ HiBVT path unchanged, boots to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)