### PR TITLE
hisi-sysctl: return full 32-bit chip ID at SCSYSID0

### DIFF
--- a/qemu/hw/misc/hisi-sysctl.c
+++ b/qemu/hw/misc/hisi-sysctl.c
@@ -49,14 +49,19 @@ static uint64_t hisi_sysctl_read(void *opaque, hwaddr offset, unsigned size)
         return 0;
     case 0x8C: /* REG_SYSSTAT — boot mode (0 = SPI NOR boot) */
         return s->regs[0x8C / 4];
-    case 0xEE0: /* SCSYSID0 */
-        return s->soc_id & 0xFF;
-    case 0xEE4: /* SCSYSID1 */
-        return (s->soc_id >> 8) & 0xFF;
+    case 0xEE0: /* SCSYSID0 — full 32-bit chip ID */
+        /*
+         * Vendor SDK (e.g. EV200 sys.o SYS_HAL_GetChipID) reads this as
+         * a single u32 and expects the packed chip ID (e.g. 0x3516E200).
+         * On real silicon SCSYSID0..3 are four contiguous bytes; reading
+         * 0xEE0 as a word naturally yields the full ID. We return the
+         * whole 32-bit value here for the same reason.
+         */
+        return s->soc_id;
+    case 0xEE4: /* SCSYSID1 — second word of the SCSYSID block, unused */
     case 0xEE8: /* SCSYSID2 */
-        return (s->soc_id >> 16) & 0xFF;
     case 0xEEC: /* SCSYSID3 */
-        return (s->soc_id >> 24) & 0xFF;
+        return 0;
     default:
         if (offset < HISI_SYSCTL_MMIO_SIZE) {
             return s->regs[offset / 4];


### PR DESCRIPTION
## Summary
- Vendor SDK (`SYS_HAL_GetChipID`) reads `0xEE0` as a single `u32` and expects the packed chip ID (e.g. `0x3516E200`). The previous byte-split decode returned only the low byte on a word-sized read, so vendor userspace saw `0x00` and failed chip detection.
- On real silicon `SCSYSID0..3` are four contiguous bytes, so a word read at `0xEE0` naturally yields the full ID. This change matches that behaviour.
- `0xEE4/0xEE8/0xEEC` now return `0` — the SDK does not consult the upper words.

## Test plan
- [ ] Boot an emulated Hi3516EV200 guest and confirm vendor `sys.ko` / `SYS_HAL_GetChipID` reports the expected chip ID
- [ ] Verify existing V2/V3/V4 machines still boot (no regressions from collapsing the byte-split reads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)