### PR TITLE
XNN reverse engineering: kprobe_ive tracer, vendor Conv layout in oms_builder, test binaries

### DIFF
--- a/qemu-boot/kprobe_ive.c
+++ b/qemu-boot/kprobe_ive.c
@@ -1,101 +1,82 @@
 /*
- * kprobe_ive — Dump model_ctx from ive_start_task
+ * kprobe_ive — Capture tile data table from ive_start_task
  *
- * Places kprobe at ive_start_task+0x68 (after r6 = model_ctx is computed)
- * to capture the per-model context fields that control Conv tiling.
- *
- * At offset 0x68: r6 = model_ctx_base + model_idx * 1080
- * We read r7 = task node virt pointer, and dump model_ctx at 0x400-0x440.
+ * Probes at ive_start_task+0x68 (bcc) where r4=global, r7=task_node.
+ * Reads model_ctx and tile table to understand Conv HW configuration.
  */
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/kprobes.h>
+#include <linux/kallsyms.h>
 #include <asm/io.h>
-
-/* Probe on drv_ive_write_regs — simple, reliable.
- * Manually walk globals to find model_ctx. */
 
 static int call_count;
 
-/* Use hardcoded address from kallsyms for the global */
-static unsigned long g_xnn_ctx_addr;
-module_param(g_xnn_ctx_addr, ulong, S_IRUGO);
-
-static int write_pre(struct kprobe *p, struct pt_regs *regs)
+static int start_handler(struct kprobe *p, struct pt_regs *regs)
 {
-	u32 phys = regs->ARM_r0;
-	u8 *virt;
-	u8 *base;
-	u32 ctx_arr_ptr;
-	u16 model_idx;
+	u32 r4 = regs->ARM_r4;  /* global base (g_ive_md_ctx) */
+	u32 r7 = regs->ARM_r7;  /* task node virtual addr */
+	u8 *node = (u8 *)(unsigned long)r7;
+	u32 ctx_arr, node12;
 	u8 *mctx;
-	int i;
 
-	if (phys < 0x40000000 || phys > 0x50000000) return 0;
+	if (!node || node[10] != 0x36) return 0;
 
-	virt = phys_to_virt(phys);
-	if (!virt) return 0;
+	node12 = *(u32 *)(node + 12);
+	pr_info("kp_ive: node type=%d node[12]=0x%x\n", node[11], node12);
 
-	/* node[6..7] = model context index */
-	model_idx = *(u16 *)(virt + 6);
+	ctx_arr = *(u32 *)((u8 *)r4 + 0x1c0);
+	if (ctx_arr) {
+		u16 model_idx = *(u16 *)(node + 6);
+		u32 field420, base18;
+		u8 *table;
 
-	pr_info("kp_ive: SUBMIT phys=0x%x type=%d model_idx=%d\n",
-		phys, virt[11], model_idx);
+		mctx = (u8 *)(unsigned long)ctx_arr + model_idx * 1080;
 
-	if (g_xnn_ctx_addr) {
-		base = (u8 *)g_xnn_ctx_addr;
+		field420 = *(u32 *)(mctx + 0x420);
+		base18 = *(u32 *)(mctx + 0x18);
 
-		/* Dump relevant offsets from g_xnn_ctx to find model_ctx_arr */
-		pr_info("kp_ive: g_xnn[0x064]=%08x\n", *(u32*)(base+0x64));
-		pr_info("kp_ive: g_xnn[0x1c0]=%08x\n", *(u32*)(base+0x1c0));
-		pr_info("kp_ive: g_xnn[0x1cc]=%08x\n", *(u32*)(base+0x1cc));
+		pr_info("kp_ive: mctx=%p field420=%d base18=0x%x\n",
+			mctx, field420, base18);
+		pr_info("kp_ive: mctx+420: %*ph\n", 16, mctx + 0x420);
 
-		ctx_arr_ptr = *(u32*)(base + 0x1c0);
-		if (ctx_arr_ptr) {
-			mctx = (u8*)(unsigned long)ctx_arr_ptr +
-				(u32)model_idx * 1080;
-			pr_info("kp_ive: model_ctx at %p (arr=0x%x + %d*1080)\n",
-				mctx, ctx_arr_ptr, model_idx);
+		/* Tile table = node[12] * field420 + base18 */
+		table = (u8 *)(unsigned long)(base18 + node12 * field420);
+		pr_info("kp_ive: tile_table = 0x%x * %d + 0x%x = %p\n",
+			node12, field420, base18, table);
 
-			/* Dump 0x400-0x440 */
-			for (i = 0x400; i < 0x440; i += 16)
-				pr_info("kp_ive: mctx+%03x: %*ph\n",
-					i, 16, mctx + i);
-		} else {
-			pr_info("kp_ive: model_ctx_arr is NULL\n");
-		}
+		/* Dump first 3 table entries (20 bytes each) */
+		pr_info("kp_ive: entry[0]: %*ph\n", 20, table);
+		pr_info("kp_ive: entry[1]: %*ph\n", 20, table + 20);
+		pr_info("kp_ive: entry[2]: %*ph\n", 20, table + 40);
 	}
-
-	/* Also dump first node */
-	pr_info("kp_ive: node +00: %*ph\n", 16, virt);
-	pr_info("kp_ive: node +10: %*ph\n", 16, virt+16);
 
 	call_count++;
 	return 0;
 }
 
-static struct kprobe kp = { .symbol_name = "drv_ive_write_regs" };
+static struct kprobe kp_start;
 
 static int __init kprobe_ive_init(void)
 {
 	int ret;
+	unsigned long addr = kallsyms_lookup_name("ive_start_task");
+	if (!addr) return -ENOENT;
 
-	if (!g_xnn_ctx_addr) {
-		/* Try to find from kallsyms */
-		g_xnn_ctx_addr = kallsyms_lookup_name("g_ive_xnn_ctx");
-		if (!g_xnn_ctx_addr)
-			g_xnn_ctx_addr = kallsyms_lookup_name("g_svp_alg_xnn_ctx");
-	}
-
-	kp.pre_handler = write_pre;
-	ret = register_kprobe(&kp);
+	kp_start.addr = (void *)(addr + 0x68);
+	kp_start.pre_handler = start_handler;
+	ret = register_kprobe(&kp_start);
 	if (ret < 0) return ret;
 
-	pr_info("kp_ive: ready, g_xnn_ctx=0x%lx\n", g_xnn_ctx_addr);
+	pr_info("kp_ive: probing at %pS\n", kp_start.addr);
 	return 0;
 }
 
-static void __exit kprobe_ive_exit(void) { unregister_kprobe(&kp); }
+static void __exit kprobe_ive_exit(void)
+{
+	unregister_kprobe(&kp_start);
+}
+
 module_init(kprobe_ive_init);
 module_exit(kprobe_ive_exit);
 MODULE_LICENSE("GPL");

--- a/qemu-boot/kprobe_ive.c
+++ b/qemu-boot/kprobe_ive.c
@@ -1,82 +1,92 @@
 /*
- * kprobe_ive — Capture tile data table from ive_start_task
+ * kprobe_ive — Check if loadmodel writes transformed weights to s[8] area
  *
- * Probes at ive_start_task+0x68 (bcc) where r4=global, r7=task_node.
- * Reads model_ctx and tile table to understand Conv HW configuration.
+ * At drv_ive_write_regs time, read from model memory at arg_off and s[8]
+ * to see if the loadmodel wrote transformed weights.
  */
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/kprobes.h>
-#include <linux/kallsyms.h>
 #include <asm/io.h>
 
-static int call_count;
-
-static int start_handler(struct kprobe *p, struct pt_regs *regs)
+static int write_pre(struct kprobe *p, struct pt_regs *regs)
 {
-	u32 r4 = regs->ARM_r4;  /* global base (g_ive_md_ctx) */
-	u32 r7 = regs->ARM_r7;  /* task node virtual addr */
-	u8 *node = (u8 *)(unsigned long)r7;
-	u32 ctx_arr, node12;
-	u8 *mctx;
+	u32 phys = regs->ARM_r0;
+	u8 *virt;
+	u32 node24, node28, node12;
 
-	if (!node || node[10] != 0x36) return 0;
+	if (phys < 0x40000000 || phys > 0x50000000) return 0;
 
-	node12 = *(u32 *)(node + 12);
-	pr_info("kp_ive: node type=%d node[12]=0x%x\n", node[11], node12);
+	virt = phys_to_virt(phys);
+	if (!virt || virt[10] != 0x36) return 0;
 
-	ctx_arr = *(u32 *)((u8 *)r4 + 0x1c0);
-	if (ctx_arr) {
-		u16 model_idx = *(u16 *)(node + 6);
-		u32 field420, base18;
-		u8 *table;
+	/* Only process Conv nodes (type=0) */
+	if (virt[11] != 0) return 0;
 
-		mctx = (u8 *)(unsigned long)ctx_arr + model_idx * 1080;
+	node24 = *(u32 *)(virt + 24);  /* weight/arg phys addr */
+	node28 = *(u32 *)(virt + 28);  /* arg_len */
+	node12 = *(u32 *)(virt + 12);  /* s[8] runtime value */
 
-		field420 = *(u32 *)(mctx + 0x420);
-		base18 = *(u32 *)(mctx + 0x18);
+	pr_info("kp_ive: Conv node24(wt)=0x%x node28(len)=%d node12(s8)=0x%x\n",
+		node24, node28, node12);
 
-		pr_info("kp_ive: mctx=%p field420=%d base18=0x%x\n",
-			mctx, field420, base18);
-		pr_info("kp_ive: mctx+420: %*ph\n", 16, mctx + 0x420);
-
-		/* Tile table = node[12] * field420 + base18 */
-		table = (u8 *)(unsigned long)(base18 + node12 * field420);
-		pr_info("kp_ive: tile_table = 0x%x * %d + 0x%x = %p\n",
-			node12, field420, base18, table);
-
-		/* Dump first 3 table entries (20 bytes each) */
-		pr_info("kp_ive: entry[0]: %*ph\n", 20, table);
-		pr_info("kp_ive: entry[1]: %*ph\n", 20, table + 20);
-		pr_info("kp_ive: entry[2]: %*ph\n", 20, table + 40);
+	/* Dump arg data at node24 (biases+pad+weights) */
+	if (node24 >= 0x42000000) {
+		u8 *arg = phys_to_virt(node24);
+		if (arg) {
+			pr_info("kp_ive: arg[0..15] (biases): %*ph\n", 16, arg);
+			pr_info("kp_ive: arg[32..47] (pad):    %*ph\n", 16, arg+32);
+			pr_info("kp_ive: arg[64..79] (weights): %*ph\n", 16, arg+64);
+		}
 	}
 
-	call_count++;
+	/* Now check what's at model_phys + s[8] from DESCRIPTOR (not node[12] which is 0)
+	 * The descriptor s[8] was patched to hw_weight_off.
+	 * model_phys = node24 - arg_off. We need to compute this.
+	 * But we don't know arg_off at this point. Instead, scan backwards
+	 * from node24 to find the segment start (CRC + size pattern). */
+
+	/* Try: the model segment data starts at a page boundary before node24.
+	 * Or: dump memory at several offsets from node24 to find s[8] data. */
+	{
+		u8 *model_base;
+		u32 seg_size;
+		int off;
+
+		/* Model data typically starts at a page-aligned address.
+		 * node24 = model_phys + arg_off. arg_off is small (< 0x1000).
+		 * So model_phys ≈ node24 & ~0xFFF. */
+		model_base = phys_to_virt(node24 & ~0xFFF);
+		if (!model_base) return 0;
+
+		/* Read segment size to find actual base */
+		seg_size = *(u32 *)(model_base + 4);
+		pr_info("kp_ive: model_base guess=%p seg_size=%d\n",
+			model_base, seg_size);
+
+		/* Dump at offsets 0x3C0 (our hw_weight_off for small models) */
+		for (off = 0x160; off <= 0x400; off += 0x40) {
+			u8 *p = model_base + off;
+			int nz = 0, j;
+			for (j = 0; j < 16; j++) if (p[j]) nz++;
+			if (nz)
+				pr_info("kp_ive: model+%03x: %*ph\n", off, 16, p);
+		}
+	}
+
 	return 0;
 }
 
-static struct kprobe kp_start;
+static struct kprobe kp = { .symbol_name = "drv_ive_write_regs" };
 
 static int __init kprobe_ive_init(void)
 {
-	int ret;
-	unsigned long addr = kallsyms_lookup_name("ive_start_task");
-	if (!addr) return -ENOENT;
-
-	kp_start.addr = (void *)(addr + 0x68);
-	kp_start.pre_handler = start_handler;
-	ret = register_kprobe(&kp_start);
-	if (ret < 0) return ret;
-
-	pr_info("kp_ive: probing at %pS\n", kp_start.addr);
-	return 0;
+	kp.pre_handler = write_pre;
+	return register_kprobe(&kp) < 0 ? -1 :
+		(pr_info("kp_ive: ready\n"), 0);
 }
 
-static void __exit kprobe_ive_exit(void)
-{
-	unregister_kprobe(&kp_start);
-}
-
+static void __exit kprobe_ive_exit(void) { unregister_kprobe(&kp); }
 module_init(kprobe_ive_init);
 module_exit(kprobe_ive_exit);
 MODULE_LICENSE("GPL");

--- a/qemu-boot/kprobe_ive.c
+++ b/qemu-boot/kprobe_ive.c
@@ -1,39 +1,100 @@
 /*
- * kprobe_ive — Dump full task chain for comparison
+ * kprobe_ive — Dump model_ctx from ive_start_task
+ *
+ * Places kprobe at ive_start_task+0x68 (after r6 = model_ctx is computed)
+ * to capture the per-model context fields that control Conv tiling.
+ *
+ * At offset 0x68: r6 = model_ctx_base + model_idx * 1080
+ * We read r7 = task node virt pointer, and dump model_ctx at 0x400-0x440.
  */
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/kprobes.h>
 #include <asm/io.h>
 
+/* Probe on drv_ive_write_regs — simple, reliable.
+ * Manually walk globals to find model_ctx. */
+
+static int call_count;
+
+/* Use hardcoded address from kallsyms for the global */
+static unsigned long g_xnn_ctx_addr;
+module_param(g_xnn_ctx_addr, ulong, S_IRUGO);
+
 static int write_pre(struct kprobe *p, struct pt_regs *regs)
 {
 	u32 phys = regs->ARM_r0;
 	u8 *virt;
-	int n, i;
+	u8 *base;
+	u32 ctx_arr_ptr;
+	u16 model_idx;
+	u8 *mctx;
+	int i;
 
 	if (phys < 0x40000000 || phys > 0x50000000) return 0;
 
 	virt = phys_to_virt(phys);
 	if (!virt) return 0;
 
-	for (n = 0; n < 8; n++) {
-		pr_info("kp_ive: NODE[%d] type=%d phys=0x%08x\n", n, virt[11], phys);
-		for (i = 0; i < 128; i += 16)
-			pr_info("kp_ive:  +%02x: %*ph\n", i, 16, virt + i);
-		phys = *(u32 *)virt;
-		if (!phys || phys < 0x42000000) break;
-		virt = phys_to_virt(phys);
-		if (!virt) break;
+	/* node[6..7] = model context index */
+	model_idx = *(u16 *)(virt + 6);
+
+	pr_info("kp_ive: SUBMIT phys=0x%x type=%d model_idx=%d\n",
+		phys, virt[11], model_idx);
+
+	if (g_xnn_ctx_addr) {
+		base = (u8 *)g_xnn_ctx_addr;
+
+		/* Dump relevant offsets from g_xnn_ctx to find model_ctx_arr */
+		pr_info("kp_ive: g_xnn[0x064]=%08x\n", *(u32*)(base+0x64));
+		pr_info("kp_ive: g_xnn[0x1c0]=%08x\n", *(u32*)(base+0x1c0));
+		pr_info("kp_ive: g_xnn[0x1cc]=%08x\n", *(u32*)(base+0x1cc));
+
+		ctx_arr_ptr = *(u32*)(base + 0x1c0);
+		if (ctx_arr_ptr) {
+			mctx = (u8*)(unsigned long)ctx_arr_ptr +
+				(u32)model_idx * 1080;
+			pr_info("kp_ive: model_ctx at %p (arr=0x%x + %d*1080)\n",
+				mctx, ctx_arr_ptr, model_idx);
+
+			/* Dump 0x400-0x440 */
+			for (i = 0x400; i < 0x440; i += 16)
+				pr_info("kp_ive: mctx+%03x: %*ph\n",
+					i, 16, mctx + i);
+		} else {
+			pr_info("kp_ive: model_ctx_arr is NULL\n");
+		}
 	}
+
+	/* Also dump first node */
+	pr_info("kp_ive: node +00: %*ph\n", 16, virt);
+	pr_info("kp_ive: node +10: %*ph\n", 16, virt+16);
+
+	call_count++;
 	return 0;
 }
 
 static struct kprobe kp = { .symbol_name = "drv_ive_write_regs" };
-static int __init kprobe_ive_init(void) {
+
+static int __init kprobe_ive_init(void)
+{
+	int ret;
+
+	if (!g_xnn_ctx_addr) {
+		/* Try to find from kallsyms */
+		g_xnn_ctx_addr = kallsyms_lookup_name("g_ive_xnn_ctx");
+		if (!g_xnn_ctx_addr)
+			g_xnn_ctx_addr = kallsyms_lookup_name("g_svp_alg_xnn_ctx");
+	}
+
 	kp.pre_handler = write_pre;
-	return register_kprobe(&kp) ?: (pr_info("kp_ive: ready\n"), 0);
+	ret = register_kprobe(&kp);
+	if (ret < 0) return ret;
+
+	pr_info("kp_ive: ready, g_xnn_ctx=0x%lx\n", g_xnn_ctx_addr);
+	return 0;
 }
+
 static void __exit kprobe_ive_exit(void) { unregister_kprobe(&kp); }
 module_init(kprobe_ive_init);
 module_exit(kprobe_ive_exit);

--- a/qemu-boot/kprobe_ive.c
+++ b/qemu-boot/kprobe_ive.c
@@ -1,0 +1,84 @@
+/*
+ * kprobe_ive — Capture vendor's HW register writes + task nodes
+ *
+ * Probes drv_ive_write_regs (task submit) AND drv_ive_read_regs (status read).
+ * Also probes writel to capture ALL register writes to IVE space (0x11320000).
+ */
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/kprobes.h>
+#include <asm/io.h>
+
+static int call_count;
+static void __iomem *ive_base;
+
+/* Capture task node submission */
+static int write_pre(struct kprobe *p, struct pt_regs *regs)
+{
+	u32 phys = regs->ARM_r0;
+	u8 *virt;
+	int n, i;
+
+	if (phys < 0x40000000 || phys > 0x50000000)
+		return 0;
+
+	pr_info("kp_ive: SUBMIT phys=0x%08x\n", phys);
+
+	for (n = 0; n < 16; n++) {
+		virt = phys_to_virt(phys);
+		if (!virt) break;
+		pr_info("kp_ive: chain[%d] phys=0x%08x type=%d\n",
+			n, phys, virt[11]);
+		for (i = 0; i < 128; i += 16)
+			pr_info("kp_ive:   +%02x: %*ph\n", i, 16, virt + i);
+		phys = *(u32 *)virt;
+		if (!phys || phys < 0x40000000) break;
+	}
+
+	/* Dump IVE regs snapshot before submit */
+	if (ive_base) {
+		pr_info("kp_ive: REGS before submit:\n");
+		for (i = 0; i < 0x90; i += 4)
+			pr_info("kp_ive:   reg[0x%02x]=0x%08x\n",
+				i, readl(ive_base + i));
+	}
+
+	call_count++;
+	return 0;
+}
+
+static struct kprobe kp_write = {
+	.symbol_name = "drv_ive_write_regs",
+};
+
+static int __init kprobe_ive_init(void)
+{
+	int ret;
+
+	ive_base = ioremap(0x11320000, 0x100);
+
+	kp_write.pre_handler = write_pre;
+	ret = register_kprobe(&kp_write);
+	if (ret < 0) {
+		pr_err("kp_ive: register_kprobe failed: %d\n", ret);
+		if (ive_base) iounmap(ive_base);
+		return ret;
+	}
+
+	call_count = 0;
+	pr_info("kp_ive: probing at %pS, ive_base=%p\n",
+		kp_write.addr, ive_base);
+	return 0;
+}
+
+static void __exit kprobe_ive_exit(void)
+{
+	unregister_kprobe(&kp_write);
+	if (ive_base) iounmap(ive_base);
+	pr_info("kp_ive: removed, %d calls\n", call_count);
+}
+
+module_init(kprobe_ive_init);
+module_exit(kprobe_ive_exit);
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("kprobe to capture IVE register state during Conv dispatch");

--- a/qemu-boot/kprobe_ive.c
+++ b/qemu-boot/kprobe_ive.c
@@ -1,84 +1,70 @@
 /*
- * kprobe_ive — Capture vendor's HW register writes + task nodes
+ * kprobe_ive — Hijack vendor's task chain to test Conv parameters
  *
- * Probes drv_ive_write_regs (task submit) AND drv_ive_read_regs (status read).
- * Also probes writel to capture ALL register writes to IVE space (0x11320000).
+ * Hooks drv_ive_write_regs to modify the Conv task node before HW submit.
+ * Keeps the vendor module loaded (no rmmod), so all HW state is intact.
+ *
+ * Module param "test_weight_addr" — if set, overrides Conv node[24] (weight address).
+ * This lets us test different weight data while using the vendor's infrastructure.
  */
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/kprobes.h>
 #include <asm/io.h>
 
-static int call_count;
-static void __iomem *ive_base;
+static unsigned int test_weight_addr;
+module_param(test_weight_addr, uint, S_IRUGO | S_IWUSR);
 
-/* Capture task node submission */
+static int submit_count;
+
 static int write_pre(struct kprobe *p, struct pt_regs *regs)
 {
 	u32 phys = regs->ARM_r0;
 	u8 *virt;
-	int n, i;
 
-	if (phys < 0x40000000 || phys > 0x50000000)
-		return 0;
+	if (phys < 0x40000000 || phys > 0x50000000) return 0;
 
-	pr_info("kp_ive: SUBMIT phys=0x%08x\n", phys);
+	virt = phys_to_virt(phys);
+	if (!virt) return 0;
 
-	for (n = 0; n < 16; n++) {
-		virt = phys_to_virt(phys);
-		if (!virt) break;
-		pr_info("kp_ive: chain[%d] phys=0x%08x type=%d\n",
-			n, phys, virt[11]);
-		for (i = 0; i < 128; i += 16)
-			pr_info("kp_ive:   +%02x: %*ph\n", i, 16, virt + i);
-		phys = *(u32 *)virt;
-		if (!phys || phys < 0x40000000) break;
+	/* Check if this is a Conv node (marker=0x36, type=0) */
+	if (virt[10] == 0x36 && virt[11] == 0) {
+		pr_info("kp_ive: Conv node submit #%d, weight=0x%08x\n",
+			submit_count, *(u32 *)(virt + 24));
+
+		if (test_weight_addr) {
+			pr_info("kp_ive: OVERRIDE weight 0x%08x -> 0x%08x\n",
+				*(u32 *)(virt + 24), test_weight_addr);
+			*(u32 *)(virt + 24) = test_weight_addr;
+		}
 	}
 
-	/* Dump IVE regs snapshot before submit */
-	if (ive_base) {
-		pr_info("kp_ive: REGS before submit:\n");
-		for (i = 0; i < 0x90; i += 4)
-			pr_info("kp_ive:   reg[0x%02x]=0x%08x\n",
-				i, readl(ive_base + i));
-	}
-
-	call_count++;
+	submit_count++;
 	return 0;
 }
 
-static struct kprobe kp_write = {
-	.symbol_name = "drv_ive_write_regs",
-};
+static struct kprobe kp = { .symbol_name = "drv_ive_write_regs" };
 
 static int __init kprobe_ive_init(void)
 {
 	int ret;
-
-	ive_base = ioremap(0x11320000, 0x100);
-
-	kp_write.pre_handler = write_pre;
-	ret = register_kprobe(&kp_write);
+	kp.pre_handler = write_pre;
+	ret = register_kprobe(&kp);
 	if (ret < 0) {
-		pr_err("kp_ive: register_kprobe failed: %d\n", ret);
-		if (ive_base) iounmap(ive_base);
+		pr_err("kp_ive: failed: %d\n", ret);
 		return ret;
 	}
-
-	call_count = 0;
-	pr_info("kp_ive: probing at %pS, ive_base=%p\n",
-		kp_write.addr, ive_base);
+	submit_count = 0;
+	pr_info("kp_ive: hijack mode, test_weight_addr=0x%x\n", test_weight_addr);
 	return 0;
 }
 
 static void __exit kprobe_ive_exit(void)
 {
-	unregister_kprobe(&kp_write);
-	if (ive_base) iounmap(ive_base);
-	pr_info("kp_ive: removed, %d calls\n", call_count);
+	unregister_kprobe(&kp);
+	pr_info("kp_ive: removed after %d submits\n", submit_count);
 }
 
 module_init(kprobe_ive_init);
 module_exit(kprobe_ive_exit);
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("kprobe to capture IVE register state during Conv dispatch");

--- a/qemu-boot/kprobe_ive.c
+++ b/qemu-boot/kprobe_ive.c
@@ -1,70 +1,40 @@
 /*
- * kprobe_ive — Hijack vendor's task chain to test Conv parameters
- *
- * Hooks drv_ive_write_regs to modify the Conv task node before HW submit.
- * Keeps the vendor module loaded (no rmmod), so all HW state is intact.
- *
- * Module param "test_weight_addr" — if set, overrides Conv node[24] (weight address).
- * This lets us test different weight data while using the vendor's infrastructure.
+ * kprobe_ive — Dump full task chain for comparison
  */
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/kprobes.h>
 #include <asm/io.h>
 
-static unsigned int test_weight_addr;
-module_param(test_weight_addr, uint, S_IRUGO | S_IWUSR);
-
-static int submit_count;
-
 static int write_pre(struct kprobe *p, struct pt_regs *regs)
 {
 	u32 phys = regs->ARM_r0;
 	u8 *virt;
+	int n, i;
 
 	if (phys < 0x40000000 || phys > 0x50000000) return 0;
 
 	virt = phys_to_virt(phys);
 	if (!virt) return 0;
 
-	/* Check if this is a Conv node (marker=0x36, type=0) */
-	if (virt[10] == 0x36 && virt[11] == 0) {
-		pr_info("kp_ive: Conv node submit #%d, weight=0x%08x\n",
-			submit_count, *(u32 *)(virt + 24));
-
-		if (test_weight_addr) {
-			pr_info("kp_ive: OVERRIDE weight 0x%08x -> 0x%08x\n",
-				*(u32 *)(virt + 24), test_weight_addr);
-			*(u32 *)(virt + 24) = test_weight_addr;
-		}
+	for (n = 0; n < 8; n++) {
+		pr_info("kp_ive: NODE[%d] type=%d phys=0x%08x\n", n, virt[11], phys);
+		for (i = 0; i < 128; i += 16)
+			pr_info("kp_ive:  +%02x: %*ph\n", i, 16, virt + i);
+		phys = *(u32 *)virt;
+		if (!phys || phys < 0x42000000) break;
+		virt = phys_to_virt(phys);
+		if (!virt) break;
 	}
-
-	submit_count++;
 	return 0;
 }
 
 static struct kprobe kp = { .symbol_name = "drv_ive_write_regs" };
-
-static int __init kprobe_ive_init(void)
-{
-	int ret;
+static int __init kprobe_ive_init(void) {
 	kp.pre_handler = write_pre;
-	ret = register_kprobe(&kp);
-	if (ret < 0) {
-		pr_err("kp_ive: failed: %d\n", ret);
-		return ret;
-	}
-	submit_count = 0;
-	pr_info("kp_ive: hijack mode, test_weight_addr=0x%x\n", test_weight_addr);
-	return 0;
+	return register_kprobe(&kp) ?: (pr_info("kp_ive: ready\n"), 0);
 }
-
-static void __exit kprobe_ive_exit(void)
-{
-	unregister_kprobe(&kp);
-	pr_info("kp_ive: removed after %d submits\n", submit_count);
-}
-
+static void __exit kprobe_ive_exit(void) { unregister_kprobe(&kp); }
 module_init(kprobe_ive_init);
 module_exit(kprobe_ive_exit);
 MODULE_LICENSE("GPL");

--- a/qemu-boot/test-cnn-model.c
+++ b/qemu-boot/test-cnn-model.c
@@ -1,0 +1,228 @@
+/*
+ * Test IVE CNN API with vendor's .bin model files
+ *
+ * Uses HI_MPI_IVE_CNN_LoadModel / CNN_Predict / CNN_GetResult
+ * instead of the XNN API. The CNN API handles weight transformation
+ * internally, bypassing the OMS format issues.
+ *
+ * Build:
+ *   CC=arm-openipc-linux-musleabi-gcc
+ *   SDK=Hi3516EV200_SDK_V1.0.1.2/mpp
+ *   LIBS=output/target/usr/lib
+ *   $CC -O2 -o test-cnn-model test-cnn-model.c \
+ *       -I$SDK/include -L$LIBS -lmpi -live \
+ *       -lVoiceEngine -lupvqe -ldnvqe -lsecurec \
+ *       -Wl,-rpath,/usr/lib -Wl,--allow-shlib-undefined -lm
+ *
+ * Run: killall majestic; ./test-cnn-model model.bin [image.yuv]
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+
+/* mmap shim */
+#define PROT_READ 0x1
+#define PROT_WRITE 0x2
+#define MAP_SHARED 0x01
+#define MAP_FAILED ((void *)-1)
+int munmap(void *addr, size_t len);
+void *mmap(void *start, size_t len, int prot, int flags, int fd, uint32_t off) {
+    return (void *)syscall(SYS_mmap2, start, len, prot, flags, fd, off >> 12);
+}
+
+/* uclibc shims */
+int memcpy_s(void *d, size_t dn, const void *s, size_t n) { memcpy(d, s, n < dn ? n : dn); return 0; }
+int memset_s(void *d, size_t dn, int c, size_t n) { memset(d, c, n < dn ? n : dn); return 0; }
+int memmove_s(void *d, size_t dn, const void *s, size_t n) { memmove(d, s, n < dn ? n : dn); return 0; }
+int strncpy_s(char *d, size_t dn, const char *s, size_t n) { strncpy(d, s, n < dn ? n : dn); return 0; }
+int snprintf_s(char *d, size_t dn, size_t n, const char *f, ...) {
+    va_list a; va_start(a, f); int r = vsnprintf(d, dn, f, a); va_end(a); return r;
+}
+const unsigned short int *__ctype_b;
+size_t _stdlib_mb_cur_max(void) { return 0; }
+int __fputc_unlocked(int c, FILE *stream) { return fputc(c, stream); }
+int __fgetc_unlocked(FILE *stream) { return fgetc(stream); }
+
+#include "hi_type.h"
+#include "hi_common.h"
+#include "mpi_sys.h"
+#include "mpi_ive.h"
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <model.bin> [image.yuv]\n", argv[0]);
+        return 1;
+    }
+
+    /* Init */
+    HI_MPI_SYS_Exit();
+    HI_S32 ret = HI_MPI_SYS_Init();
+    if (ret) { fprintf(stderr, "SYS_Init: 0x%x\n", ret); return 1; }
+
+    /* Skip IVE subsystem init — CNN API may not need it */
+
+    /* Load CNN model */
+    IVE_CNN_MODEL_S model;
+    memset(&model, 0, sizeof(model));
+    ret = HI_MPI_IVE_CNN_LoadModel(argv[1], &model);
+    if (ret) {
+        fprintf(stderr, "CNN_LoadModel: 0x%x\n", ret);
+        goto cleanup_sys;
+    }
+
+    fprintf(stderr, "Model loaded: %ux%u type=%d, %d conv layers, %d classes\n",
+            model.u32Width, model.u32Height, model.enType,
+            model.u8ConvPoolLayerNum, model.u16ClassCount);
+    fprintf(stderr, "  ConvKernelBias: phys=0x%llx size=%u\n",
+            (unsigned long long)model.stConvKernelBias.u64PhyAddr, model.u32ConvKernelBiasSize);
+    fprintf(stderr, "  FCLWgtBias: phys=0x%llx size=%u\n",
+            (unsigned long long)model.stFCLWgtBias.u64PhyAddr, model.u32FCLWgtBiasSize);
+    fprintf(stderr, "  Total: %u bytes\n", model.u32TotalMemSize);
+    /* Dump model as hex to find missing fields */
+    fprintf(stderr, "  Raw model struct (%zu bytes):\n", sizeof(model));
+    uint8_t *mp = (uint8_t *)&model;
+    for (int i = 0; i < (int)sizeof(model) && i < 256; i += 16) {
+        fprintf(stderr, "    +%03x:", i);
+        for (int j = 0; j < 16 && i+j < (int)sizeof(model); j++)
+            fprintf(stderr, " %02x", mp[i+j]);
+        fprintf(stderr, "\n");
+    }
+
+    /* Prepare input image */
+    uint32_t w = model.u32Width;
+    uint32_t h = model.u32Height;
+    uint32_t stride = (w + 15) & ~15;
+
+    IVE_SRC_IMAGE_S src;
+    memset(&src, 0, sizeof(src));
+    src.enType = IVE_IMAGE_TYPE_U8C1;
+    src.u32Width = w;
+    src.u32Height = h;
+    src.au32Stride[0] = stride;
+
+    HI_U64 frm_p, frm_v;
+    uint32_t frm_size = stride * h;
+    HI_MPI_SYS_MmzAlloc(&frm_p, (void **)&frm_v, "F", NULL, frm_size);
+    src.au64PhyAddr[0] = frm_p;
+    src.au64VirAddr[0] = frm_v;
+
+    /* Fill with test pattern or load from file */
+    if (argc > 2) {
+        FILE *ff = fopen(argv[2], "rb");
+        if (ff) {
+            size_t got = fread((void *)(uintptr_t)frm_v, 1, frm_size, ff);
+            fclose(ff);
+            fprintf(stderr, "Loaded image: %s (%zu bytes)\n", argv[2], got);
+        } else {
+            memset((void *)(uintptr_t)frm_v, 128, frm_size);
+        }
+    } else {
+        memset((void *)(uintptr_t)frm_v, 128, frm_size);
+    }
+    HI_MPI_SYS_MmzFlushCache(frm_p, (void *)(uintptr_t)frm_v, frm_size);
+
+    /* Prepare FC output buffer */
+    IVE_DST_DATA_S dst;
+    memset(&dst, 0, sizeof(dst));
+    /* Width = last FC layer neuron count * sizeof(HI_S32) */
+    uint32_t fc_out_cnt = model.stFullConnect.au16LayerCnt[model.stFullConnect.u8LayerNum - 1];
+    dst.u32Width = fc_out_cnt * sizeof(HI_S32);
+    dst.u32Height = 1;  /* 1 input image */
+    dst.u32Stride = (dst.u32Width + 15) & ~15;
+    uint32_t dst_size = dst.u32Stride * dst.u32Height;
+    if (dst_size < 256) dst_size = 256;
+    HI_U64 dst_p, dst_v;
+    HI_MPI_SYS_MmzAlloc(&dst_p, (void **)&dst_v, "D", NULL, dst_size);
+    dst.u64PhyAddr = dst_p;
+    dst.u64VirAddr = dst_v;
+    memset((void *)(uintptr_t)dst_v, 0, dst_size);
+    HI_MPI_SYS_MmzFlushCache(dst_p, (void *)(uintptr_t)dst_v, dst_size);
+    fprintf(stderr, "FC output: %u neurons, width=%u stride=%u\n",
+            fc_out_cnt, dst.u32Width, dst.u32Stride);
+
+    /* CNN control — needs assist memory */
+    IVE_CNN_CTRL_S ctrl;
+    memset(&ctrl, 0, sizeof(ctrl));
+    ctrl.u32Num = 1;  /* 1 input image */
+    /* Allocate assist memory — needs to be large enough for CNN ping-pong buffers.
+     * u32TotalMemSize includes weights; the working buffer needs much more. */
+    uint32_t assist_size = model.u32TotalMemSize * 4 + 262144;
+    HI_U64 assist_p, assist_v;
+    HI_MPI_SYS_MmzAlloc(&assist_p, (void **)&assist_v, "A", NULL, assist_size);
+    ctrl.stMem.u64PhyAddr = assist_p;
+    ctrl.stMem.u64VirAddr = assist_v;
+    ctrl.stMem.u32Size = assist_size;
+
+    /* Run prediction */
+    IVE_HANDLE handle = 0;
+    fprintf(stderr, "Running CNN_Predict...\n");
+    ret = HI_MPI_IVE_CNN_Predict(&handle, &src, &model, &dst, &ctrl, HI_TRUE);
+    fprintf(stderr, "CNN_Predict ret=0x%x handle=%d\n", ret, handle);
+
+    if (ret == 0) {
+        /* Wait for completion */
+        HI_BOOL finished = HI_FALSE;
+        HI_S32 qret = HI_MPI_IVE_Query(handle, &finished, HI_TRUE);
+        int retries = 0;
+        while (qret == (HI_S32)0xa01d8041 && retries < 10000) {
+            usleep(100);
+            qret = HI_MPI_IVE_Query(handle, &finished, HI_TRUE);
+            retries++;
+        }
+        fprintf(stderr, "Query ret=0x%x finished=%d retries=%d\n", qret, finished, retries);
+
+        /* Read output */
+        HI_MPI_SYS_MmzFlushCache(dst_p, (void *)(uintptr_t)dst_v, dst_size);
+        uint8_t *out = (uint8_t *)(uintptr_t)dst_v;
+        fprintf(stderr, "Output (first 64 bytes):\n  ");
+        for (int i = 0; i < 64; i++) {
+            fprintf(stderr, "%02x ", out[i]);
+            if (i % 16 == 15) fprintf(stderr, "\n  ");
+        }
+        fprintf(stderr, "\n");
+
+        /* Get classification result */
+        IVE_SRC_DATA_S result_src;
+        memset(&result_src, 0, sizeof(result_src));
+        result_src.u64PhyAddr = dst_p;
+        result_src.u64VirAddr = dst_v;
+        result_src.u32Stride = dst.u32Stride;
+        result_src.u32Width = dst.u32Width;
+        result_src.u32Height = dst.u32Height;
+
+        IVE_DST_MEM_INFO_S result_dst;
+        memset(&result_dst, 0, sizeof(result_dst));
+        uint32_t result_size = 1024;
+        HI_U64 res_p, res_v;
+        HI_MPI_SYS_MmzAlloc(&res_p, (void **)&res_v, "R", NULL, result_size);
+        result_dst.u64PhyAddr = res_p;
+        result_dst.u64VirAddr = res_v;
+        result_dst.u32Size = result_size;
+        memset((void *)(uintptr_t)res_v, 0, result_size);
+
+        ret = HI_MPI_IVE_CNN_GetResult(&result_src, &result_dst, &model, &ctrl);
+        fprintf(stderr, "GetResult ret=0x%x\n", ret);
+        if (ret == 0) {
+            uint32_t *results = (uint32_t *)(uintptr_t)res_v;
+            fprintf(stderr, "Classification results:\n");
+            for (int i = 0; i < model.u16ClassCount && i < 20; i++) {
+                fprintf(stderr, "  class %d: label=%u confidence=%u\n",
+                        i, results[i*2], results[i*2+1]);
+            }
+        }
+        HI_MPI_SYS_MmzFree(res_p, (void *)(uintptr_t)res_v);
+    }
+
+    /* Cleanup */
+    HI_MPI_IVE_CNN_UnloadModel(&model);
+    HI_MPI_SYS_MmzFree(dst_p, (void *)(uintptr_t)dst_v);
+    HI_MPI_SYS_MmzFree(frm_p, (void *)(uintptr_t)frm_v);
+cleanup_sys:
+    HI_MPI_SYS_Exit();
+    return ret ? 1 : 0;
+}

--- a/qemu-boot/test-fc-model.c
+++ b/qemu-boot/test-fc-model.c
@@ -1,0 +1,367 @@
+/*
+ * Test custom FC model on IVE XNN — uses only vendor SDK functions
+ *
+ * Follows the exact call pattern from svp_alg_forward_slice:
+ *   mp_ive_svp_alg_proc_init → mpi_ive_xnn_loadmodel →
+ *   mpi_ive_xnn_forward_slice → HI_MPI_IVE_Query (retry loop) →
+ *   mpi_ive_xnn_unloadmodel → mp_ive_svp_alg_proc_exit
+ *
+ * No raw ioctls. No fd scanning. Just the libive.so functions.
+ *
+ * Build:
+ *   CC=~/git/firmware/output-hi3516ev300_lite/host/bin/arm-openipc-linux-musleabi-gcc
+ *   SDK=~/projects/cameras/sdk/Hi3516EV200_SDK_V1.0.1.2/mpp
+ *   LIBS=~/git/firmware/output-hi3516ev300_lite/target/usr/lib
+ *   $CC -O2 -o test-fc-model test-fc-model.c \
+ *       -I$SDK/include -L$LIBS -lmpi -live \
+ *       -lVoiceEngine -lupvqe -ldnvqe -lsecurec \
+ *       -Wl,-rpath,/usr/lib -Wl,--allow-shlib-undefined -lm
+ *
+ * Run: killall majestic; ./test-fc-model model.oms
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+
+/* mmap shim */
+#define PROT_READ 0x1
+#define PROT_WRITE 0x2
+#define MAP_SHARED 0x01
+#define MAP_FAILED ((void *)-1)
+int munmap(void *addr, size_t len);
+void *mmap(void *start, size_t len, int prot, int flags, int fd, uint32_t off) {
+    return (void *)syscall(SYS_mmap2, start, len, prot, flags, fd, off >> 12);
+}
+
+/* uclibc shims */
+int memcpy_s(void *d, size_t dn, const void *s, size_t n) { memcpy(d, s, n < dn ? n : dn); return 0; }
+int memset_s(void *d, size_t dn, int c, size_t n) { memset(d, c, n < dn ? n : dn); return 0; }
+int memmove_s(void *d, size_t dn, const void *s, size_t n) { memmove(d, s, n < dn ? n : dn); return 0; }
+int strncpy_s(char *d, size_t dn, const char *s, size_t n) { strncpy(d, s, n < dn ? n : dn); return 0; }
+int snprintf_s(char *d, size_t dn, size_t n, const char *f, ...) {
+    va_list a; va_start(a, f); int r = vsnprintf(d, dn, f, a); va_end(a); return r;
+}
+const unsigned short int *__ctype_b;
+size_t _stdlib_mb_cur_max(void) { return 0; }
+int __fputc_unlocked(int c, FILE *stream) { return fputc(c, stream); }
+int __fgetc_unlocked(FILE *stream) { return fgetc(stream); }
+
+#include "hi_type.h"
+#include "hi_common.h"
+#include "mpi_sys.h"
+#include "mpi_ive.h"
+
+typedef struct { HI_U64 phys, virt; HI_U32 size, pad; } xnn_mem_t;
+
+/* Private libive.so functions */
+extern HI_S32 mpi_ive_xnn_loadmodel(xnn_mem_t *model, xnn_mem_t *tmp, void *params);
+extern HI_S32 mpi_ive_xnn_forward_slice(
+    HI_S32 *handle, void *src, void *dst, void *model,
+    xnn_mem_t *tmp, void *report, void *ctrl, HI_S32 instant);
+extern HI_VOID mpi_ive_xnn_unloadmodel(void *params);
+extern HI_S32 mp_ive_svp_alg_proc_init(void *a, void *b);
+extern HI_VOID mp_ive_svp_alg_proc_exit(void);
+
+/* IVE_BLOB_S — 48 bytes */
+typedef struct {
+    HI_U32 type;
+    HI_U32 stride;
+    HI_U64 virt;
+    HI_U64 phys;
+    HI_U32 num;
+    HI_U32 reserved;
+    HI_U32 width;
+    HI_U32 height;
+    HI_U32 chn;
+    HI_U32 pad;
+} xnn_blob_t;
+
+static int find_segment(const uint8_t *data, int size) {
+    for (int off = 0x40; off < size - 80 && off < 0x200; off += 0x10) {
+        uint16_t s = *(uint16_t *)(data + off + 48);
+        uint16_t l = *(uint16_t *)(data + off + 50);
+        uint8_t sn = data[off + 52], dn = data[off + 53];
+        if (s >= 1 && s <= 16 && l >= 1 && l <= 500 && sn >= 1 && sn <= 16 && dn >= 1 && dn <= 16)
+            return off;
+    }
+    return -1;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <model.oms>\n", argv[0]);
+        return 1;
+    }
+
+    /* Read OMS file */
+    FILE *fp = fopen(argv[1], "rb");
+    if (!fp) { perror(argv[1]); return 1; }
+    fseek(fp, 0, SEEK_END);
+    long file_size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    uint8_t *file_data = malloc(file_size);
+    fread(file_data, 1, file_size, fp);
+    fclose(fp);
+
+    int seg_off = find_segment(file_data, file_size);
+    if (seg_off < 0) { fprintf(stderr, "No segment found\n"); return 1; }
+
+    uint32_t seg_size = *(uint32_t *)(file_data + seg_off + 4);
+    uint32_t tmp_size = *(uint32_t *)(file_data + seg_off + 12);
+    fprintf(stderr, "Segment at 0x%x, %u layers, tmp=%u\n",
+            seg_off, *(uint16_t *)(file_data + seg_off + 50), tmp_size);
+
+    /* Init */
+    HI_MPI_SYS_Exit();
+    HI_S32 ret = HI_MPI_SYS_Init();
+    if (ret) { fprintf(stderr, "SYS_Init: 0x%x\n", ret); return 1; }
+
+    uint8_t sa[16]={0}, sb[16]={0};
+    mp_ive_svp_alg_proc_init(sa, sb);
+
+    /* Alloc model in MMZ */
+    xnn_mem_t model_mem = {0};
+    uint32_t seg_data_size = file_size - seg_off;
+    HI_MPI_SYS_MmzAlloc(&model_mem.phys, (void **)&model_mem.virt, "M", NULL, seg_data_size);
+    model_mem.size = seg_data_size;
+    memcpy((void *)(uintptr_t)model_mem.virt, file_data + seg_off, seg_data_size);
+
+    /* Alloc tmp */
+    xnn_mem_t tmp_mem = {0};
+    HI_MPI_SYS_MmzAlloc(&tmp_mem.phys, (void **)&tmp_mem.virt, "T", NULL, tmp_size);
+    tmp_mem.size = tmp_size;
+
+    /* Load model */
+    uint8_t params[2160] = {0};
+    ret = mpi_ive_xnn_loadmodel(&model_mem, &tmp_mem, params);
+    if (ret) { fprintf(stderr, "loadmodel: 0x%x\n", ret); goto cleanup; }
+
+    /* Read input dimensions from model_params (src_node_arr[0]) */
+    uint32_t in_w = *(uint32_t *)(params + 0x14);  /* +20: width */
+    uint32_t in_h = *(uint32_t *)(params + 0x18);  /* +24: height */
+    uint32_t in_chn = *(uint32_t *)(params + 0x1C); /* +28: chn */
+
+    /* Read output dimensions from model_params (dst_node at +1232) */
+    uint32_t out_type = *(uint32_t *)(params + 1232); /* blob_type */
+    uint32_t out_w = *(uint32_t *)(params + 1236);
+    uint32_t out_h = *(uint32_t *)(params + 1240);
+    uint32_t out_chn = *(uint32_t *)(params + 1244);
+    /* Vendor check: stride >= align16(4 * width), always 4 bytes/element */
+    uint32_t out_stride = ((out_w * 4) + 15) & ~15;
+
+    fprintf(stderr, "Model: in=%ux%ux%u out=%ux%ux%u type=%u stride=%u\n",
+            in_w, in_h, in_chn, out_w, out_h, out_chn, out_type, out_stride);
+
+    /* Dump full model_params for debugging */
+    fprintf(stderr, "params dump (non-zero regions):\n");
+    for (int i = 0; i < 2160; i += 16) {
+        int nz = 0;
+        for (int j = 0; j < 16 && i+j < 2160; j++)
+            if (params[i+j]) nz++;
+        if (nz) {
+            fprintf(stderr, "  +%04d: ", i);
+            for (int j = 0; j < 16 && i+j < 2160; j++)
+                fprintf(stderr, "%02x ", params[i+j]);
+            fprintf(stderr, "\n");
+        }
+    }
+
+    /* Alloc frame (YUV420SP) */
+    uint32_t stride = (in_w + 15) & ~15;
+    uint32_t y_sz = stride * in_h;
+    uint32_t uv_sz = stride * in_h / 2;
+    HI_U64 frm_p, frm_v;
+    HI_MPI_SYS_MmzAlloc(&frm_p, (void **)&frm_v, "F", NULL, y_sz + uv_sz);
+    if (argc > 2) {
+        FILE *ff = fopen(argv[2], "rb");
+        if (ff) {
+            size_t got = fread((void *)(uintptr_t)frm_v, 1, y_sz + uv_sz, ff);
+            fclose(ff);
+            fprintf(stderr, "Loaded frame: %s (%zu bytes)\n", argv[2], got);
+        } else {
+            memset((void *)(uintptr_t)frm_v, 128, y_sz);
+            memset((void *)(uintptr_t)frm_v + y_sz, 128, uv_sz);
+        }
+    } else {
+        memset((void *)(uintptr_t)frm_v, 128, y_sz);
+        memset((void *)(uintptr_t)frm_v + y_sz, 128, uv_sz);
+    }
+    HI_MPI_SYS_MmzFlushCache(frm_p, (void *)(uintptr_t)frm_v, y_sz + uv_sz);
+
+    /* Alloc output */
+    uint32_t out_buf_size = out_stride * out_h * out_chn;
+    if (out_buf_size < 256) out_buf_size = 256;
+    HI_U64 out_p, out_v;
+    HI_MPI_SYS_MmzAlloc(&out_p, (void **)&out_v, "O", NULL, out_buf_size);
+    memset((void *)(uintptr_t)out_v, 0xAA, out_buf_size);
+    HI_MPI_SYS_MmzFlushCache(out_p, (void *)(uintptr_t)out_v, out_buf_size);
+
+    /* Fill tmp with 0xAA pattern */
+    memset((void *)(uintptr_t)tmp_mem.virt, 0xAA, tmp_size);
+    HI_MPI_SYS_MmzFlushCache(tmp_mem.phys, (void *)(uintptr_t)tmp_mem.virt, tmp_size);
+
+    /* Build forward args */
+    xnn_blob_t src = {0};
+    src.type = 2; /* YVU420SP */
+    src.stride = stride;
+    src.virt = frm_v;
+    src.phys = frm_p;
+    src.num = 1;
+    src.width = in_w;
+    src.height = in_h;
+    src.chn = in_chn ? in_chn : 3;
+
+    xnn_blob_t dst = {0};
+    dst.type = out_type ? out_type : 7;
+    dst.stride = out_stride;
+    dst.virt = out_v;
+    dst.phys = out_p;
+    dst.num = 1;
+    dst.width = out_w;
+    dst.height = out_h;
+    dst.chn = out_chn ? out_chn : 1;
+
+    /* ctrl: a5[0]=0, a5[1]=src_num, a5[2]=has_roi, a5[3]=dst_num */
+    uint32_t ctrl[4] = {0, 1, 0, 1};
+
+    HI_S32 handle = 0;
+
+    /* Verify struct layout */
+    fprintf(stderr, "sizeof(xnn_blob_t)=%zu\n", sizeof(xnn_blob_t));
+    fprintf(stderr, "src blob bytes: ");
+    for (int i = 0; i < (int)sizeof(xnn_blob_t); i++)
+        fprintf(stderr, "%02x ", ((uint8_t *)&src)[i]);
+    fprintf(stderr, "\ndst blob bytes: ");
+    for (int i = 0; i < (int)sizeof(xnn_blob_t); i++)
+        fprintf(stderr, "%02x ", ((uint8_t *)&dst)[i]);
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Running forward...\n");
+    ret = mpi_ive_xnn_forward_slice(
+        &handle, &src, &dst, params,
+        &tmp_mem, &dst, ctrl, 1);
+    fprintf(stderr, "forward ret=0x%x handle=%d\n", ret, handle);
+
+    /* Query loop — only if handle is non-zero (async task pending).
+     * handle=0 with ret=0 means synchronous completion (instant=1). */
+    if (ret == 0 && handle != 0) {
+        HI_BOOL finished = HI_FALSE;
+        HI_S32 qret = HI_MPI_IVE_Query(handle, &finished, HI_TRUE);
+        int retries = 0;
+        while (qret == (HI_S32)0xa01d8041 && retries < 10000) {
+            usleep(100);
+            qret = HI_MPI_IVE_Query(handle, &finished, HI_TRUE);
+            retries++;
+        }
+        fprintf(stderr, "query ret=0x%x finished=%d retries=%d\n", qret, finished, retries);
+    } else if (ret == 0) {
+        fprintf(stderr, "instant completion (handle=0), querying anyway...\n");
+        HI_BOOL finished = HI_FALSE;
+        HI_MPI_IVE_Query(handle, &finished, HI_TRUE);
+        fprintf(stderr, "query finished=%d\n", finished);
+        usleep(100000);
+    }
+
+    /* Read results */
+    HI_MPI_SYS_MmzFlushCache(tmp_mem.phys, (void *)(uintptr_t)tmp_mem.virt, tmp_size);
+    HI_MPI_SYS_MmzFlushCache(out_p, (void *)(uintptr_t)out_v, 65536);
+
+    /* Dump tmp buffer to file for offline analysis */
+    FILE *df = fopen("/tmp/tmp_dump.bin", "wb");
+    if (df) {
+        fwrite((void *)(uintptr_t)tmp_mem.virt, 1, tmp_size, df);
+        fclose(df);
+        fprintf(stderr, "Dumped %u bytes of tmp to /tmp/tmp_dump.bin\n", tmp_size);
+    }
+
+    /* Scan tmp for HW-written regions (not 0xAA), dump each */
+    int8_t *tmp = (int8_t *)(uintptr_t)tmp_mem.virt;
+    fprintf(stderr, "HW-written regions:\n");
+    int rs = -1;
+    for (uint32_t i = 0; i < tmp_size; i += 16) {
+        int changed = 0;
+        for (int j = 0; j < 16 && i+j < tmp_size; j++)
+            if ((uint8_t)tmp[i+j] != 0xAA) changed++;
+        if (changed && rs < 0) rs = i;
+        else if (!changed && rs >= 0) {
+            int sz = (int)i - rs;
+            fprintf(stderr, "  0x%04x-0x%04x (%d bytes)\n", rs, (int)i, sz);
+            /* Dump first 64 bytes */
+            fprintf(stderr, "    ");
+            for (int j = rs; j < rs + 64 && j < (int)i; j++) {
+                fprintf(stderr, "%02x ", (uint8_t)tmp[j]);
+                if ((j - rs) % 16 == 15) fprintf(stderr, "\n    ");
+            }
+            if (sz > 128) {
+                fprintf(stderr, "  ...\n    ");
+                for (int j = (int)i - 64; j < (int)i; j++) {
+                    fprintf(stderr, "%02x ", (uint8_t)tmp[j]);
+                    if ((j - ((int)i - 64)) % 16 == 15) fprintf(stderr, "\n    ");
+                }
+            }
+            rs = -1;
+        }
+    }
+    if (rs >= 0)
+        fprintf(stderr, "  0x%04x-end (%d bytes)\n", rs, (int)(tmp_size - rs));
+
+    /* Dump all HW-written regions with data */
+    rs = -1;
+    for (uint32_t i = 0; i < tmp_size; i += 16) {
+        int changed = 0;
+        for (int j = 0; j < 16 && i+j < tmp_size; j++)
+            if ((uint8_t)tmp[i+j] != 0xAA) changed++;
+        if (changed && rs < 0) rs = i;
+        else if (!changed && rs >= 0) {
+            int region_sz = i - rs;
+            fprintf(stderr, "  Region 0x%04x-0x%04x (%d bytes):", rs, (int)i, region_sz);
+            /* Dump first and last 32 bytes */
+            fprintf(stderr, "\n    first: ");
+            for (int j = rs; j < rs + 32 && j < (int)i; j++)
+                fprintf(stderr, "%02x ", (uint8_t)tmp[j]);
+            if (region_sz > 64) {
+                fprintf(stderr, "\n    last:  ");
+                for (int j = (int)i - 32; j < (int)i; j++)
+                    fprintf(stderr, "%02x ", (uint8_t)tmp[j]);
+            }
+            fprintf(stderr, "\n");
+            rs = -1;
+        }
+    }
+    if (rs >= 0) {
+        fprintf(stderr, "  Region 0x%04x-end:\n    last: ", rs);
+        int end = tmp_size < (uint32_t)(rs + 256) ? tmp_size : rs + 256;
+        for (int j = rs; j < end; j++)
+            fprintf(stderr, "%02x ", (uint8_t)tmp[j]);
+        fprintf(stderr, "\n");
+    }
+
+    /* Check output buffer */
+    uint8_t *ob = (uint8_t *)(uintptr_t)out_v;
+    int ob_changed = 0;
+    for (int i = 0; i < 256; i++) if (ob[i] != 0xAA) ob_changed++;
+    fprintf(stderr, "out_buf changed: %d/256\n", ob_changed);
+    if (ob_changed) {
+        fprintf(stderr, "out_buf: ");
+        for (int i = 0; i < 64; i++) fprintf(stderr, "%02x ", ob[i]);
+        fprintf(stderr, "\n");
+    }
+
+    /* Cleanup — unload may need two calls if forward left ref_cnt=2 */
+    mpi_ive_xnn_unloadmodel(params);
+    mpi_ive_xnn_unloadmodel(params);
+    HI_MPI_SYS_MmzFree(out_p, (void *)(uintptr_t)out_v);
+    HI_MPI_SYS_MmzFree(frm_p, (void *)(uintptr_t)frm_v);
+
+cleanup:
+    HI_MPI_SYS_MmzFree(tmp_mem.phys, (void *)(uintptr_t)tmp_mem.virt);
+    HI_MPI_SYS_MmzFree(model_mem.phys, (void *)(uintptr_t)model_mem.virt);
+    mp_ive_svp_alg_proc_exit();
+    free(file_data);
+    HI_MPI_SYS_Exit();
+    return 0;
+}

--- a/qemu-boot/test-fc-model.c
+++ b/qemu-boot/test-fc-model.c
@@ -278,6 +278,47 @@ int main(int argc, char **argv) {
         fprintf(stderr, "Dumped %u bytes of tmp to /tmp/tmp_dump.bin\n", tmp_size);
     }
 
+    /* Read HW task pointer and dump task chain via /dev/mem */
+    {
+        int memfd = open("/dev/mem", 2); /* O_RDWR */
+        if (memfd >= 0) {
+            /* Map IVE HW regs at 0x11320000 */
+            volatile uint32_t *regs = mmap(NULL, 0x100, PROT_READ, MAP_SHARED, memfd, 0x11320000);
+            if (regs != MAP_FAILED) {
+                uint32_t task_ptr = regs[4]; /* reg 0x10 = task pointer */
+                fprintf(stderr, "HW task_ptr=0x%08x\n", task_ptr);
+                munmap((void *)regs, 0x100);
+
+                if (task_ptr >= 0x42000000 && task_ptr < 0x44000000) {
+                    /* Map task chain region */
+                    uint32_t page = task_ptr & ~0xFFF;
+                    volatile uint8_t *task = mmap(NULL, 0x2000, PROT_READ, MAP_SHARED, memfd, page);
+                    if (task != MAP_FAILED) {
+                        uint32_t off = task_ptr - page;
+                        FILE *tf = fopen("/tmp/task_dump.bin", "wb");
+                        if (tf) {
+                            fwrite((void *)(task + off), 1, 0x1000, tf);
+                            fclose(tf);
+                            fprintf(stderr, "Dumped task chain to /tmp/task_dump.bin\n");
+                        }
+                        /* Print first 2 nodes */
+                        for (int n = 0; n < 2; n++) {
+                            fprintf(stderr, "Task node %d:\n", n);
+                            for (int r = 0; r < 128; r += 16) {
+                                fprintf(stderr, "  +%02x:", r);
+                                for (int b = 0; b < 16; b++)
+                                    fprintf(stderr, " %02x", task[off + n*128 + r + b]);
+                                fprintf(stderr, "\n");
+                            }
+                        }
+                        munmap((void *)task, 0x2000);
+                    }
+                }
+            }
+            close(memfd);
+        }
+    }
+
     /* Scan tmp for HW-written regions (not 0xAA), dump each */
     int8_t *tmp = (int8_t *)(uintptr_t)tmp_mem.virt;
     fprintf(stderr, "HW-written regions:\n");

--- a/qemu-boot/test-fc-model.c
+++ b/qemu-boot/test-fc-model.c
@@ -217,14 +217,14 @@ int main(int argc, char **argv) {
     src.chn = in_chn ? in_chn : 3;
 
     xnn_blob_t dst = {0};
-    dst.type = out_type ? out_type : 7;
+    dst.type = out_type; /* 0=S32, 7=U8, etc — use model's actual type */
     dst.stride = out_stride;
     dst.virt = out_v;
     dst.phys = out_p;
     dst.num = 1;
     dst.width = out_w;
     dst.height = out_h;
-    dst.chn = out_chn ? out_chn : 1;
+    dst.chn = out_chn;
 
     /* ctrl: a5[0]=0, a5[1]=src_num, a5[2]=has_roi, a5[3]=dst_num */
     uint32_t ctrl[4] = {0, 1, 0, 1};

--- a/qemu-boot/test-oms-load.c
+++ b/qemu-boot/test-oms-load.c
@@ -51,7 +51,10 @@ int __fgetc_unlocked(FILE *stream) { return fgetc(stream); }
 typedef struct { uint64_t phys, virt; uint32_t size, pad; } xnn_mem_t;
 
 extern int mpi_ive_xnn_loadmodel(void *model_mem, void *tmp_mem, void *model_params);
-extern int mpi_ive_xnn_forward_slice(void *buf);
+/* 8 args: handle, src, dst, model, tmp_buf, report, ctrl, instant */
+extern int mpi_ive_xnn_forward_slice(
+    void *handle, void *src, void *dst, void *model,
+    void *tmp, void *report, void *ctrl, int instant);
 extern void mpi_ive_xnn_unloadmodel(void *model_params);
 extern int mp_ive_svp_alg_proc_init(void *a, void *b);
 extern void mp_ive_svp_alg_proc_exit(void);
@@ -159,6 +162,39 @@ int main(int argc, char **argv) {
 
     if (ret == 0) {
         fprintf(stderr, "SUCCESS! Model loaded.\n");
+
+        /* Dump Xnn_Task buffer from vendor driver BEFORE forward */
+        {
+            FILE *mm = fopen("/proc/media-mem", "r");
+            if (mm) {
+                char line[256];
+                while (fgets(line, sizeof(line), mm)) {
+                    unsigned int p1, p2;
+                    char name[64] = {0};
+                    if (sscanf(line, "   |-MMB: phys(0x%x, 0x%x)%*[^,], length=%*[^,],%*[ ]name=\"%63[^\"]\"",
+                               &p1, &p2, name) == 3) {
+                        uint32_t len = p2 - p1 + 1;
+                        if (strstr(name, "Xnn") || strstr(name, "IVE_TEMP") || strstr(name, "IVE_QUEUE")) {
+                            void *v = HI_MPI_SYS_Mmap(p1, len);
+                            if (v) {
+                                uint32_t dumplen = len > 512 ? 512 : len;
+                                fprintf(stderr, "\n=== %s phys=0x%x len=%u (before forward) ===\n", name, p1, len);
+                                uint8_t *p = (uint8_t *)v;
+                                for (uint32_t i = 0; i < dumplen; i += 16) {
+                                    fprintf(stderr, "%04x:", i);
+                                    for (int j = 0; j < 16 && i+j < dumplen; j++)
+                                        fprintf(stderr, " %02x", p[i+j]);
+                                    fprintf(stderr, "\n");
+                                }
+                                HI_MPI_SYS_Munmap(v, len);
+                            }
+                        }
+                    }
+                }
+                fclose(mm);
+            }
+        }
+
         fprintf(stderr, "  model_params[0x04] (tmp_size): %u\n",
                 *(uint32_t *)(model_params + 0x04));
         fprintf(stderr, "  model_params[0x08] (src_num):  %u\n",
@@ -268,17 +304,8 @@ int main(int argc, char **argv) {
             /* is_instant: a1[602] = 602*4 = 2408 = 0x968 */
             *(uint32_t *)(fwd + 0x968) = 1;  /* synchronous */
 
-            /* Find IVE fd */
-            int ive_fd = -1;
-            char path[64], link[64];
-            for (int fd = 3; fd < 64; fd++) {
-                snprintf(path, sizeof(path), "/proc/self/fd/%d", fd);
-                int n = readlink(path, link, sizeof(link) - 1);
-                if (n > 0) { link[n] = '\0'; if (strstr(link, "ive")) { ive_fd = fd; break; } }
-            }
-
-            if (ive_fd >= 0) {
-                fprintf(stderr, "\nRunning forward (fd=%d, %ux%u)...\n", ive_fd, in_w, in_h);
+            {
+                fprintf(stderr, "\nRunning forward (%ux%u)...\n", in_w, in_h);
                 /* Verify buffer before ioctl */
                 fprintf(stderr, "  fwd+0x958: src=%u dst=%u\n",
                         *(uint32_t *)(fwd + 0x958), *(uint32_t *)(fwd + 0x95C));
@@ -286,13 +313,51 @@ int main(int argc, char **argv) {
                         *(uint32_t *)(fwd + 0x960), *(uint32_t *)(fwd + 0x968));
                 fprintf(stderr, "  fwd+0x340 dst_tpl: type=%u stride=%u\n",
                         *(uint32_t *)(fwd + 0x340), *(uint32_t *)(fwd + 0x344));
-                ret = ioctl(ive_fd, 0xc9704638, fwd);
-                fprintf(stderr, "  forward ret=%d\n", ret);
-                /* Wait for task completion via MPI API (handles ref_cnt cleanup) */
-                {
-                    int handle = *(int32_t *)fwd; /* handle from ioctl output */
+                /* Build args for mpi_ive_xnn_forward_slice (8-arg function).
+                 * It handles ioctl + task completion + ref_cnt cleanup. */
+                int32_t fwd_handle = 0;
+
+                /* src blob (48 bytes on stack) */
+                uint8_t src_blob[48];
+                memcpy(src_blob, fwd + 0x008, 48);
+
+                /* dst blob template */
+                uint8_t dst_blob[48];
+                memcpy(dst_blob, fwd + 0x340, 48);
+
+                /* ctrl: {padding, src_num, has_roi, dst_num, ...} from +0x958 */
+                uint32_t ctrl[4];
+                ctrl[0] = 0;  /* a5[0] */
+                ctrl[1] = 1;  /* a5[1] = src_num */
+                ctrl[2] = 0;  /* a5[2] = has_roi */
+                ctrl[3] = 1;  /* a5[3] = dst_num */
+
+                /* tmp_buf descriptor (24 bytes) */
+                xnn_mem_t fwd_tmp = tmp_mem;
+
+                ret = mpi_ive_xnn_forward_slice(
+                    &fwd_handle,    /* r0: handle out */
+                    src_blob,       /* r1: src blobs */
+                    dst_blob,       /* r2: dst blobs */
+                    model_params,   /* r3: model params from loadmodel */
+                    &fwd_tmp,       /* [sp+0]: tmp buffer */
+                    dst_blob,       /* [sp+4]: report/output blob */
+                    ctrl,           /* [sp+8]: ctrl */
+                    1);             /* [sp+12]: instant */
+                fprintf(stderr, "  forward ret=0x%x handle=%d\n", ret, fwd_handle);
+                /* Wait for completion — same pattern as svp_alg_forward_slice:
+                 * retry HI_MPI_IVE_Query with usleep(100) until not TIMEOUT */
+                if (ret == 0) {
                     int finished = 0;
-                    HI_MPI_IVE_Query(handle, &finished, 1 /* block */);
+                    int qret = HI_MPI_IVE_Query(fwd_handle, &finished, 1);
+                    int retries = 0;
+                    while (qret == (int)0xa01d8041 && retries < 1000) {
+                        usleep(100);
+                        qret = HI_MPI_IVE_Query(fwd_handle, &finished, 1);
+                        retries++;
+                    }
+                    fprintf(stderr, "  query ret=0x%x finished=%d retries=%d\n",
+                            qret, finished, retries);
                 }
 
                 /* Check tmp_buf for output */
@@ -383,7 +448,9 @@ int main(int argc, char **argv) {
             HI_MPI_SYS_MmzFree(frm_p, (void *)(uintptr_t)frm_v);
         }
 
+        /* Unload model — may need to call twice if forward incremented ref_cnt */
         mpi_ive_xnn_unloadmodel(model_params);
+        mpi_ive_xnn_unloadmodel(model_params); /* second call for ref_cnt=2 */
     } else {
         fprintf(stderr, "FAILED. Error 0x%x\n", ret);
         /* Common errors:

--- a/tools/oms_builder.py
+++ b/tools/oms_builder.py
@@ -145,7 +145,9 @@ def make_conv(input_c, input_h, input_w, output_c, output_h, output_w,
     # s[6..15] = desc[20..59] as u32 words
     struct.pack_into('<I', d, 20, arg_len_cumulative)   # s[6] = a1+24
     struct.pack_into('<I', d, 24, arg_offset)           # s[7] = a1+28
-    # s[8]=desc[28..31], s[9]=desc[32..35], s[10]=desc[36..39] — reserved
+    # s[8]=desc[28..31] → node[12]: critical for Conv weight loading
+    # Vendor has non-zero values here (e.g., 0x21D9B for first Conv layer)
+    struct.pack_into('<I', d, 28, arg_len_cumulative)  # s[8]: try arg_len as value
     struct.pack_into('<I', d, 40, in_tmp_offset)        # s[11] = a1+44
     struct.pack_into('<I', d, 44, out_tmp_offset)       # s[12] = a1+48
     # in_stride must be exactly align16(input_w) (vendor check: must equal X)
@@ -673,6 +675,9 @@ def build_conv_test(output_path):
     pad_data = b'\x80' * (output_c * 4)  # vendor uses exactly out_c × 4 bytes of 0x80
     weight_data = w.tobytes()
     weight_blob = bias_data + pad_data + weight_data
+    # Pad to minimum 288 bytes (vendor Conv minimum arg_len)
+    while len(weight_blob) < 288:
+        weight_blob += b'\x00'
     # Align total to 16 bytes
     while len(weight_blob) % 16:
         weight_blob += b'\x00'

--- a/tools/oms_builder.py
+++ b/tools/oms_builder.py
@@ -96,7 +96,8 @@ def make_preproc(input_h, input_w, input_c, out_tmp_offset, need_vgs=1):
 def make_conv(input_c, input_h, input_w, output_c, output_h, output_w,
               kernel_size, pool_mode, af_mode, arg_len_cumulative, arg_offset,
               in_tmp_offset, out_tmp_offset, layer_index,
-              in_fmt=0, out_fmt=1, in_bond_num=1):
+              in_fmt=0, out_fmt=1, in_bond_num=1,
+              requant_scale=0x26000, requant_mult=0x7fff):
     """Build an 80-byte Conv layer descriptor.
 
     Conv descriptor layout (from IDA RE of ive_xnn_check_conv_layer):
@@ -157,8 +158,15 @@ def make_conv(input_c, input_h, input_w, output_c, output_h, output_w,
     struct.pack_into('<I', d, 52, input_h * in_stride_w)  # s[14] = in_stride_c
     struct.pack_into('<I', d, 56, output_h * out_stride_w) # s[15] = out_stride_c
     # s[16] = {desc[60..61] as u16, desc[62] as byte}
+    d[60] = 128  # LOBYTE(s[16]) — output zero-point/activation (vendor=128)
     d[61] = kernel_size  # BYTE1 of LOWORD(s[16]) — MUST be 1 or 3
     d[62] = in_bond_num  # BYTE2(s[16])
+    # s[10] = desc[36..39] — negative shift mask (vendor uses 0xFFF80000 = -(1<<19))
+    struct.pack_into('<i', d, 36, -(1 << 19))
+    # s[17] = desc[64..67] — requantization scale (HIWORD=2, LOWORD=scale)
+    struct.pack_into('<I', d, 64, 0x20000 | (requant_scale & 0xFFFF))
+    # s[18] = desc[68..71] — requantization multiplier
+    struct.pack_into('<I', d, 68, requant_mult)
     # s[19] = {desc[72] as byte, desc[73..74] as u16}
     # desc[72] = is_bottom_from_user (1 if this Conv reads from model input)
     # desc[73..74] = input_node_name_id (which src_node this references)
@@ -338,7 +346,10 @@ def build_segment(layers_desc: bytes, weight_data: bytes,
     v70 = 32 * dst_num + v61  # layer desc start
 
     layer_desc_end = v70 + len(layers_desc)
-    weight_data_off = max(align16(layer_desc_end + 16), 1)  # must be >= 1
+    # For Conv models: arg_data goes right after descs, weight_data_off points elsewhere
+    # For FC models: weight_data_off points to the FC weight blob
+    arg_data_off = align16(layer_desc_end)
+    weight_data_off = max(align16(arg_data_off + len(weight_data) + 16), 1)
     weight_data_end = weight_data_off + len(weight_data)
     name_table_off = align16(weight_data_end + 16)
     segment_end = name_table_off + len(name_entries)
@@ -395,30 +406,27 @@ def build_segment(layers_desc: bytes, weight_data: bytes,
     # Layer descriptors
     seg[v70:v70 + len(layers_desc)] = layers_desc
 
-    # Fixup arg_offset fields: convert from weight-blob-relative to segment-relative
-    # by adding weight_data_off. This is needed because the HW uses
-    # model_phys + arg_offset directly to find weight data.
+    # Fixup arg_offset for each layer type:
+    # - Conv: arg_offset = weight_data_off (weight metadata right after descs)
+    # - FC: arg_offset += weight_data_off (relative to weight blob start)
     off = v70
     for _ in range(total_layers):
         ltype = seg[off]
-        if ltype == 0:  # Conv: arg_offset at desc+24 (4 bytes)
-            old = struct.unpack_from('<I', seg, off + 24)[0]
-            struct.pack_into('<I', seg, off + 24, old + weight_data_off)
+        if ltype == 0:  # Conv: arg_offset = arg_data_off (right after descs)
+            struct.pack_into('<I', seg, off + 24, arg_data_off)
             off += 80
-        elif ltype == 2:  # FC: arg_offset at desc+20 (4 bytes)
+        elif ltype == 2:  # FC: arg_offset relative to weight blob
             old = struct.unpack_from('<I', seg, off + 20)[0]
             struct.pack_into('<I', seg, off + 20, old + weight_data_off)
             off += 64
-        elif ltype == 4:  # Unpack: no weight data, don't patch
-            off += 64
-        elif ltype == 5:  # Preproc
-            off += 48
-        elif ltype == 1:  # Flatten
-            off += 48
-        else:
-            off += 80  # default
+        elif ltype == 4:  off += 64  # Unpack
+        elif ltype == 5:  off += 48  # Preproc
+        elif ltype == 1:  off += 48  # Flatten
+        else:             off += 80
 
-    # Weight data
+    # Weight/arg data: placed at arg_data_off (right after descs)
+    seg[arg_data_off:arg_data_off + len(weight_data)] = weight_data
+    # Also place at weight_data_off (vendor validation needs data here)
     seg[weight_data_off:weight_data_off + len(weight_data)] = weight_data
 
     # Name table
@@ -659,8 +667,15 @@ def build_conv_test(output_path):
     w[0, 0, 1, 1] = 1  # center pixel only
     b = np.zeros(output_c, dtype=np.int32)
 
-    # Weight blob: 1 byte pad + weights + bias
-    weight_blob = b'\x00' + w.tobytes() + b.tobytes()
+    # Weight blob (vendor format): int32 biases + 0x80 padding + int8 weights
+    # Vendor packs: [biases (out_c×4)] [0x80 pad (out_c×4)] [int8 weights] [align]
+    bias_data = b.tobytes()  # output_c × 4 bytes
+    pad_data = b'\x80' * (output_c * 4)  # vendor uses exactly out_c × 4 bytes of 0x80
+    weight_data = w.tobytes()
+    weight_blob = bias_data + pad_data + weight_data
+    # Align total to 16 bytes
+    while len(weight_blob) % 16:
+        weight_blob += b'\x00'
     weight_size = len(weight_blob)
     print(f'Conv test: {input_h}×{input_w}×{input_c} → 3×3 → {output_h}×{output_w}×{output_c}')
     print(f'Weight blob: {weight_size} bytes')
@@ -682,12 +697,13 @@ def build_conv_test(output_path):
     layers += make_preproc(input_h, input_w, 3, 0)
 
     # Layer 1: Conv 3×3
+    # arg_offset will be patched by build_segment to point to weight_data_off
     layers += make_conv(
         input_c=input_c, input_h=input_h, input_w=input_w,
         output_c=output_c, output_h=output_h, output_w=output_w,
         kernel_size=kernel_size, pool_mode=0, af_mode=0,
         arg_len_cumulative=weight_size,
-        arg_offset=1,  # skip 1-byte pad
+        arg_offset=0,  # will be patched to weight_data_off by build_segment
         in_tmp_offset=conv_in_off,
         out_tmp_offset=conv_out_off,
         layer_index=1)

--- a/tools/oms_builder.py
+++ b/tools/oms_builder.py
@@ -395,6 +395,29 @@ def build_segment(layers_desc: bytes, weight_data: bytes,
     # Layer descriptors
     seg[v70:v70 + len(layers_desc)] = layers_desc
 
+    # Fixup arg_offset fields: convert from weight-blob-relative to segment-relative
+    # by adding weight_data_off. This is needed because the HW uses
+    # model_phys + arg_offset directly to find weight data.
+    off = v70
+    for _ in range(total_layers):
+        ltype = seg[off]
+        if ltype == 0:  # Conv: arg_offset at desc+24 (4 bytes)
+            old = struct.unpack_from('<I', seg, off + 24)[0]
+            struct.pack_into('<I', seg, off + 24, old + weight_data_off)
+            off += 80
+        elif ltype == 2:  # FC: arg_offset at desc+20 (4 bytes)
+            old = struct.unpack_from('<I', seg, off + 20)[0]
+            struct.pack_into('<I', seg, off + 20, old + weight_data_off)
+            off += 64
+        elif ltype == 4:  # Unpack: no weight data, don't patch
+            off += 64
+        elif ltype == 5:  # Preproc
+            off += 48
+        elif ltype == 1:  # Flatten
+            off += 48
+        else:
+            off += 80  # default
+
     # Weight data
     seg[weight_data_off:weight_data_off + len(weight_data)] = weight_data
 
@@ -623,7 +646,7 @@ def build_conv_test(output_path):
     Uses identity-like weights (center=127, rest=0) so the Conv output
     is approximately 127× the input — predictable for HW verification.
     """
-    input_h, input_w = 8, 8  # small for easy debugging
+    input_h, input_w = 32, 32  # match reference Preproc (32×32)
     input_c = 1  # grayscale
     kernel_size = 3
     output_c = 1
@@ -648,7 +671,9 @@ def build_conv_test(output_path):
     conv_out_off = align16(preproc_out)
     unpack_in_off = conv_out_off
     unpack_out_off = align16(conv_out_off + align16(output_w) * output_h * output_c)
-    tmp_buf_size = unpack_out_off + 4096
+    # VGS preproc needs large working memory (~144*H*W + overhead)
+    vgs_overhead = input_h * input_w * 144 + 65536
+    tmp_buf_size = max(unpack_out_off + 4096, vgs_overhead)
 
     # Build layer descriptors
     layers = bytearray()

--- a/tools/oms_builder.py
+++ b/tools/oms_builder.py
@@ -356,9 +356,26 @@ def build_segment(layers_desc: bytes, weight_data: bytes,
     arg_data_off = align16(layer_desc_end)
     weight_data_off = max(align16(arg_data_off + len(weight_data) + 16), 1)
     weight_data_end = weight_data_off + len(weight_data)
-    # Reserve space for HW-transformed weights (same size as weight_data)
+    # Reserve space for HW int24 weights at s[8] offset.
+    # Format: 3-byte int24 = round(float_weight * 2^20), packed in 40-byte records
+    # Each record = one 2D filter (k*k weights * 3 bytes + padding to 40 bytes)
     hw_weight_off = align16(weight_data_end + 16)
-    hw_weight_end = hw_weight_off + len(weight_data)
+    # Compute hw weight blob size from layer descriptors
+    hw_weight_size = 0
+    _off = 0
+    for _ in range(total_layers):
+        if layers_desc[_off] == 0:  # Conv
+            _ic = struct.unpack_from('<H', layers_desc, _off + 8)[0]
+            _oc = struct.unpack_from('<H', layers_desc, _off + 14)[0]
+            _k = layers_desc[_off + 61]
+            hw_weight_size += _oc * _ic * 40  # 40 bytes per 2D filter
+            _off += 80
+        elif layers_desc[_off] == 5: _off += 48
+        elif layers_desc[_off] == 1: _off += 48
+        elif layers_desc[_off] == 2: _off += 64
+        elif layers_desc[_off] == 4: _off += 64
+        else: _off += 80
+    hw_weight_end = hw_weight_off + max(hw_weight_size, len(weight_data))
     name_table_off = align16(hw_weight_end + 16)
     segment_end = name_table_off + len(name_entries)
     segment_size = align16(segment_end)
@@ -439,6 +456,38 @@ def build_segment(layers_desc: bytes, weight_data: bytes,
     seg[arg_data_off:arg_data_off + len(weight_data)] = weight_data
     # Also place at weight_data_off (vendor validation needs data here)
     seg[weight_data_off:weight_data_off + len(weight_data)] = weight_data
+
+    # Generate int24 HW weights at hw_weight_off.
+    # Format: round(float_weight * 2^20) as 3-byte LE signed, in 40-byte records.
+    # For int8 source weights: float ≈ int8 / 127, so int24 ≈ int8 * (2^20 / 127) ≈ int8 * 8257
+    _off = v70
+    _hw_off = hw_weight_off
+    for _ in range(total_layers):
+        ltype = seg[_off]
+        if ltype == 0:  # Conv
+            _ic = struct.unpack_from('<H', seg, _off + 8)[0]
+            _oc = struct.unpack_from('<H', seg, _off + 14)[0]
+            _k = seg[_off + 61]
+            _arg_off = struct.unpack_from('<I', seg, _off + 24)[0]
+            # int8 weights start at arg_data + 64
+            for filt in range(_oc * _ic):
+                for w in range(_k * _k):
+                    w8 = seg[_arg_off + 64 + filt * _k * _k + w]
+                    if w8 > 127: w8 -= 256  # unsigned→signed
+                    # Convert: int24 = int8 * (2^20 / 127) for unit-scale int8
+                    w24 = int(round(w8 * (1 << 20) / 127.0))
+                    w24 = max(-8388608, min(8388607, w24))
+                    struct.pack_into('<i', seg, _hw_off + w * 3, 0)  # clear 4 bytes first
+                    seg[_hw_off + w*3] = w24 & 0xFF
+                    seg[_hw_off + w*3 + 1] = (w24 >> 8) & 0xFF
+                    seg[_hw_off + w*3 + 2] = (w24 >> 16) & 0xFF
+                _hw_off += 40  # advance to next 40-byte record
+            _off += 80
+        elif ltype == 5: _off += 48
+        elif ltype == 1: _off += 48
+        elif ltype == 2: _off += 64
+        elif ltype == 4: _off += 64
+        else: _off += 80
 
     # Name table
     seg[name_table_off:name_table_off + len(name_entries)] = name_entries

--- a/tools/oms_builder.py
+++ b/tools/oms_builder.py
@@ -145,9 +145,10 @@ def make_conv(input_c, input_h, input_w, output_c, output_h, output_w,
     # s[6..15] = desc[20..59] as u32 words
     struct.pack_into('<I', d, 20, arg_len_cumulative)   # s[6] = a1+24
     struct.pack_into('<I', d, 24, arg_offset)           # s[7] = a1+28
-    # s[8]=desc[28..31] → node[12]: critical for Conv weight loading
-    # Vendor has non-zero values here (e.g., 0x21D9B for first Conv layer)
-    struct.pack_into('<I', d, 28, arg_len_cumulative)  # s[8]: try arg_len as value
+    # s[8]=desc[28..31] → node[12]: offset to int8 weights within segment
+    # Vendor points this to the actual weight bytes (after biases+padding in arg_data)
+    # Set to 0 here; build_segment patches it to arg_data_off + bias_size + pad_size
+    struct.pack_into('<I', d, 28, 0)  # patched by build_segment
     struct.pack_into('<I', d, 40, in_tmp_offset)        # s[11] = a1+44
     struct.pack_into('<I', d, 44, out_tmp_offset)       # s[12] = a1+48
     # in_stride must be exactly align16(input_w) (vendor check: must equal X)
@@ -414,8 +415,10 @@ def build_segment(layers_desc: bytes, weight_data: bytes,
     off = v70
     for _ in range(total_layers):
         ltype = seg[off]
-        if ltype == 0:  # Conv: arg_offset = arg_data_off (right after descs)
+        if ltype == 0:  # Conv: patch arg_offset and s[8] (weight pointer)
             struct.pack_into('<I', seg, off + 24, arg_data_off)
+            # s[8] = offset to int8 weights within segment (always at arg+64)
+            struct.pack_into('<I', seg, off + 28, arg_data_off + 64)
             off += 80
         elif ltype == 2:  # FC: arg_offset relative to weight blob
             old = struct.unpack_from('<I', seg, off + 20)[0]
@@ -669,13 +672,14 @@ def build_conv_test(output_path):
     w[0, 0, 1, 1] = 1  # center pixel only
     b = np.zeros(output_c, dtype=np.int32)
 
-    # Weight blob (vendor format): int32 biases + 0x80 padding + int8 weights
-    # Vendor packs: [biases (out_c×4)] [0x80 pad (out_c×4)] [int8 weights] [align]
+    # Weight blob (vendor format): int8 weights always start at offset 64
+    # [int32 biases] [0x80 padding to offset 64] [int8 weights] [align]
     bias_data = b.tobytes()  # output_c × 4 bytes
-    pad_data = b'\x80' * (output_c * 4)  # vendor uses exactly out_c × 4 bytes of 0x80
+    pad_to_64 = 64 - len(bias_data)
+    pad_data = b'\x80' * pad_to_64  # pad with 0x80 up to offset 64
     weight_data = w.tobytes()
     weight_blob = bias_data + pad_data + weight_data
-    # Pad to minimum 288 bytes (vendor Conv minimum arg_len)
+    # Pad to minimum 288 bytes
     while len(weight_blob) < 288:
         weight_blob += b'\x00'
     # Align total to 16 bytes

--- a/tools/oms_builder.py
+++ b/tools/oms_builder.py
@@ -282,9 +282,9 @@ def make_unpack(out_c, out_h, out_w, in_tmp_offset, out_tmp_offset,
     struct.pack_into('<H', d, 10, out_w)
     # in_stride: internal format (int8/int32), needs >= out_w * elem_size
     in_stride = align16(max(out_w * 4, 16))
-    # out_stride: external format, computed as align16((out_fmt_sz * out_w) >> 3), min 16
-    # out_fmt=1 → 1 byte per elem → (1 * out_w) >> 3 → small; min is 16
-    out_stride = align16(max(out_w, 16))  # vendor minimum is out_w, 16-byte aligned
+    # out_stride: vendor node uses 4 bytes/element but the OMS descriptor
+    # validation expects align16(out_w). The node builder adjusts at runtime.
+    out_stride = align16(max(out_w, 16))
     struct.pack_into('<H', d, 12, in_stride)
     struct.pack_into('<H', d, 14, out_stride)
     struct.pack_into('<I', d, 16, out_h * in_stride)   # in_stride_c

--- a/tools/oms_builder.py
+++ b/tools/oms_builder.py
@@ -349,12 +349,17 @@ def build_segment(layers_desc: bytes, weight_data: bytes,
     v70 = 32 * dst_num + v61  # layer desc start
 
     layer_desc_end = v70 + len(layers_desc)
-    # For Conv models: arg_data goes right after descs, weight_data_off points elsewhere
-    # For FC models: weight_data_off points to the FC weight blob
+    # Layout: [descs] [arg_data] [weight_data] [hw_weight_area] [names]
+    # arg_data: Conv biases+pad+weights (right after descs)
+    # weight_data: bulk blob (for FC weights or vendor validation)
+    # hw_weight_area: free space for loadmodel to store transformed Conv weights
     arg_data_off = align16(layer_desc_end)
     weight_data_off = max(align16(arg_data_off + len(weight_data) + 16), 1)
     weight_data_end = weight_data_off + len(weight_data)
-    name_table_off = align16(weight_data_end + 16)
+    # Reserve space for HW-transformed weights (same size as weight_data)
+    hw_weight_off = align16(weight_data_end + 16)
+    hw_weight_end = hw_weight_off + len(weight_data)
+    name_table_off = align16(hw_weight_end + 16)
     segment_end = name_table_off + len(name_entries)
     segment_size = align16(segment_end)
 
@@ -415,10 +420,11 @@ def build_segment(layers_desc: bytes, weight_data: bytes,
     off = v70
     for _ in range(total_layers):
         ltype = seg[off]
-        if ltype == 0:  # Conv: patch arg_offset and s[8] (weight pointer)
+        if ltype == 0:  # Conv: patch arg_offset and s[8]
             struct.pack_into('<I', seg, off + 24, arg_data_off)
-            # s[8] = offset to int8 weights within segment (always at arg+64)
-            struct.pack_into('<I', seg, off + 28, arg_data_off + 64)
+            # s[8] = offset to HW weight area (free space for loadmodel to
+            # store transformed weights). Must be separate from arg_data.
+            struct.pack_into('<I', seg, off + 28, hw_weight_off)
             off += 80
         elif ltype == 2:  # FC: arg_offset relative to weight blob
             old = struct.unpack_from('<I', seg, off + 20)[0]


### PR DESCRIPTION
## Summary

Cumulative research work on reverse-engineering the vendor XNN/IVE weight pipeline. Three threads:

1. **`qemu-boot/kprobe_ive.c`** — kernel kprobe module that hooks vendor `drv_ive_write_regs` / `ive_start_task` to dump task phys, register state, model context (`g_svp_alg_xnn_ctx+0x1C0`), and tile tables. Used as ground truth for comparing vendor HW submits against `ive_neo`.
2. **`tools/oms_builder.py`** — matches vendor's Conv weight layout (weight-at-offset-64, `hw_weight_area`, int24 weight generation, `arg_offset` fix, Unpack stride fix). Confirmed via kprobe dumps that vendor Conv **is** weight-sensitive.
3. **Test binaries** — `qemu-boot/test-cnn-model.c`, `test-fc-model.c`, `test-oms-load.c` exercise the vendor CNN/FC APIs against generated `.oms` files and record observed HW behavior (e.g. `CNN API returns NOT_SUPPORT on Hi3516EV200`).

## Commits (11, oldest first)

- `96e0300` Fix OMS arg_offset and test binary for Conv models
- `7eb33d2` Add kprobe_ive module + Unpack stride fix in oms_builder
- `3482771` oms_builder: vendor-style Conv weight layout + kprobe improvements
- `37b7def` Breakthrough: vendor Conv IS weight-sensitive, confirmed by kprobe
- `c52491a` oms_builder: vendor Conv weight layout analysis, weight-at-offset-64
- `4a576d8` kprobe: found model_ctx_array at g_svp_alg_xnn_ctx+0x1C0
- `d5137a5` kprobe: dump model_ctx and tile tables from ive_start_task
- `51e9cd2` Breakthrough: vendor Conv IS weight-sensitive, confirmed by kprobe
- `add923e` oms_builder: add hw_weight_area, kprobe model memory dump
- `9240eb0` oms_builder: add int24 weight generation, verify weight format
- `7e8ef8b` test-cnn-model: CNN API returns NOT_SUPPORT on Hi3516EV200

## Scope

Touches only research tooling under `qemu-boot/` and `tools/` — no changes to the QEMU emulator tree under `qemu/`.

## Test plan

- [ ] `kprobe_ive.ko` loads on Hi3516EV300 target and logs expected vendor submits
- [ ] `tools/oms_builder.py` regenerates a Conv `.oms` that the vendor IVE driver accepts and runs weight-sensitively
- [ ] `test-cnn-model` / `test-fc-model` / `test-oms-load` behave as annotated in the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)