### PR TITLE
hisi-i2c: clear TX FIFO on DATA1 write to fix vendor sensor probe sequence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,59 @@ jobs:
           path: ive-output.txt
           retention-days: 7
 
+  sofia-isp:
+    name: Sofia ISP regression (hi3516ev200, sc2315e)
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libfdt1 libglib2.0-0 libpixman-1-0 libslirp0 dnsmasq-base curl
+
+      - name: Download QEMU binary
+        uses: actions/download-artifact@v4
+        with:
+          name: qemu-arm
+          path: qemu-src/build/
+
+      - name: Make QEMU executable
+        run: chmod +x qemu-src/build/qemu-system-arm
+
+      - name: Download EV200 firmware
+        run: |
+          cd qemu-boot
+          curl -sL "https://github.com/OpenIPC/firmware/releases/download/latest/openipc.hi3516ev200-nor-lite.tgz" \
+              -o openipc.hi3516ev200-nor-lite.tgz
+          tar xzf openipc.hi3516ev200-nor-lite.tgz
+
+      - name: Run Sofia ISP regression test
+        timeout-minutes: 5
+        env:
+          # Tag of the qemu-hisilicon GitHub release that holds the
+          # Sofia binary, fonts, and isp-profile fixtures.  Bump when
+          # republishing.
+          FIXTURES_TAG: sofia-fixtures-v1
+          FIXTURES_REPO: ${{ github.repository }}
+          ISP_READY_TIMEOUT: 45
+          QEMU_TIMEOUT: 240
+        run: |
+          bash qemu-boot/sofia-isp-ci-test.sh
+
+      - name: Upload Sofia test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sofia-isp-log
+          path: |
+            /tmp/sofia-ci-*/qemu-output.txt
+            /tmp/sofia-ci-*/qemu-debug.log
+            /tmp/sofia-ci-*/http.log
+          retention-days: 7
+
   boot:
     name: Boot ${{ matrix.name }}
     needs: build

--- a/qemu-boot/run-ev200-sofia.sh
+++ b/qemu-boot/run-ev200-sofia.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+#
+# Boot emulated Hi3516EV200, mount the lab NFS share, modprobe the
+# vendor (XiongMai/Sofia) module chain, chroot into Sofia.  Drops the
+# user into an interactive shell after Sofia reaches "ISP Dev 0
+# running" — useful for poking at /utils/isp-profile, ipcinfo, the
+# Sofia HTTP API, etc.
+#
+# NOTE: Sofia's I2C-driven sensor init relies on the TX FIFO being
+# reset between transactions; without that, Sofia's per-probe extra
+# byte corrupts subsequent transactions.  Make sure qemu/hw/i2c/
+# hisi-i2c.c clears txf_len on DATA1 write (fixed 2026-04-25).
+#
+# The /utils/sofia_full/usr/Fonts/Font.bin shipped in the tarball is
+# a dangling symlink to /mnt/web/Fonts/Font.bin (real camera mounts
+# /mnt/web from a separate cramfs partition).  Without a real
+# Font.bin, Sofia asserts in FontManager.cpp:324.  We stage both
+# real Font.bin files (pulled from camera 10.216.128.106) from
+# /utils/sofia_fonts/ into the chroot before launching.
+#
+# Vendor sysroot, Font.bin, and the ARM static `isp-profile` binary
+# are expected on the NFS export at:
+#   10.216.128.227:/srv/nfsroot/sofia_full/   (Sofia + libs + /usr/Fonts)
+#   10.216.128.227:/srv/nfsroot/isp-profile   (ARM static, musl)
+#
+# On the host, that share is at /mnt/noc/.  Captures and other
+# artefacts written under /utils/ in the guest land in /mnt/noc/ on
+# the host automatically.
+#
+# Usage:
+#   bash qemu-boot/run-ev200-sofia.sh [--sensor sc2315e]
+#
+# Idempotent: if /utils is already an NFS mount and /tmp/vendor/Sofia
+# already exists, skip remount and untar so repeated runs are fast.
+# (Each fresh QEMU boot starts from scratch though — this only
+# matters across re-execs of the inline shell script after Sofia
+# exits or is killed.)
+#
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+SENSOR="${SENSOR:-sc2315e}"
+NFS_HOST="${NFS_HOST:-10.216.128.227}"
+NFS_PATH="${NFS_PATH:-/srv/nfsroot}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --sensor)   SENSOR="$2"; shift 2;;
+        --sensor=*) SENSOR="${1#--sensor=}"; shift;;
+        --nfs)      NFS_HOST="$2"; shift 2;;
+        *)          break;;
+    esac
+done
+
+# Inline guest setup script, fed to /bin/sh as PID 1 inside the guest.
+# After running, `exec sh -i` keeps stdin open so the user gets a
+# prompt back while Sofia continues running in the background.
+read -r -d '' GUEST_SETUP <<EOF || true
+set +e
+echo "===setup: mount essentials==="
+mount -t proc proc /proc 2>/dev/null
+mount -t tmpfs none /tmp
+mount -t devtmpfs none /dev 2>/dev/null
+
+echo "===setup: bring up eth0 (DHCP under SLIRP)==="
+udhcpc -q -i eth0 2>/dev/null || ifconfig eth0 10.0.2.15 netmask 255.255.255.0 up
+route add default gw 10.0.2.2 2>/dev/null
+
+echo "===setup: NFS mount /utils==="
+mkdir -p /utils
+if mount | grep -q ' /utils type nfs'; then
+    echo "already mounted"
+else
+    mount -o nolock,vers=3 ${NFS_HOST}:${NFS_PATH} /utils
+    [ \$? -ne 0 ] && { echo "NFS MOUNT FAILED"; exec sh -i; }
+fi
+
+echo "===setup: stage /tmp/vendor==="
+mkdir -p /tmp/vendor /tmp/vendor/proc /tmp/vendor/dev /tmp/vendor/tmp
+mkdir -p /tmp/vendor/mnt/custom/data/Fonts /tmp/vendor/mnt/mtd/Config /tmp/vendor/var
+mkdir -p /tmp/vendor/mnt/web/Fonts
+if [ ! -x /tmp/vendor/Sofia ]; then
+    cp -a /utils/sofia_full/. /tmp/vendor/
+    # Replace the dangling /usr/Fonts/Font.bin symlink (which points
+    # to /mnt/web/Fonts/Font.bin on real cameras) with real font
+    # blobs pulled from camera 10.216.128.106.
+    rm -f /tmp/vendor/usr/Fonts/Font.bin
+    cp /utils/sofia_fonts/Font.bin.web    /tmp/vendor/mnt/web/Fonts/Font.bin
+    cp /utils/sofia_fonts/Font.bin.custom /tmp/vendor/mnt/custom/data/Fonts/Font.bin
+    ln -sf /mnt/web/Fonts/Font.bin /tmp/vendor/usr/Fonts/Font.bin
+fi
+mount --bind /dev  /tmp/vendor/dev  2>/dev/null
+mount -t proc proc /tmp/vendor/proc 2>/dev/null
+
+echo "===setup: modprobe vendor chain==="
+cd /lib/modules/4.9.37/hisilicon
+# Module set lifted from the working previous-session sequence:
+# sys → rgn → vgs → mipi_rx → vi → isp → sensor i2c/spi → vpss →
+# chnl → vedu/rc/venc → codec → audio chain → pm/ive/pwm
+for m in sys_config hi_osal hi3516ev200_base hi3516ev200_sys \
+         hi3516ev200_rgn hi3516ev200_vgs hi_mipi_rx hi3516ev200_vi \
+         hi3516ev200_isp hi_sensor_i2c hi_sensor_spi \
+         hi3516ev200_vpss hi3516ev200_chnl hi3516ev200_vedu \
+         hi3516ev200_rc hi3516ev200_venc hi3516ev200_h264e \
+         hi3516ev200_h265e hi3516ev200_jpege \
+         hi3516ev200_aio hi3516ev200_ai hi3516ev200_ao \
+         hi3516ev200_aenc hi3516ev200_adec hi3516ev200_acodec \
+         hi3516ev200_pm hi3516ev200_ive hi_pwm; do
+    [ -e \${m}.ko ] || continue
+    case \$m in
+        sys_config) ARGS="chip=hi3516ev200 sensors=${SENSOR} g_cmos_yuv_flag=0 board=demo";;
+        hi_osal)    ARGS="anony=1 mmz_allocator=hisi mmz=anonymous,0,0x46000000,32M";;
+        hi3516ev200_vgs) ARGS="max_vgs_job=20 max_vgs_node=20 max_vgs_task=20";;
+        hi3516ev200_ive) ARGS="save_power=0";;
+        *)          ARGS="";;
+    esac
+    insmod \${m}.ko \$ARGS 2>&1 | head -2
+done
+
+echo "===setup: launch Sofia==="
+chroot /tmp/vendor /Sofia > /tmp/sofia.log 2>&1 &
+SPID=\$!
+echo "Sofia pid=\$SPID"
+
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25; do
+    sleep 1
+    if grep -q "ISP Dev 0 running" /tmp/sofia.log 2>/dev/null; then
+        echo "ISP READY at t=\${i}s"
+        break
+    fi
+    if ! kill -0 \$SPID 2>/dev/null; then
+        echo "Sofia DIED at t=\${i}s"
+        break
+    fi
+done
+
+echo "===Sofia status==="
+kill -0 \$SPID 2>/dev/null && echo ALIVE || echo DEAD
+echo "===tail /tmp/sofia.log==="
+tail -10 /tmp/sofia.log 2>/dev/null
+
+cat <<'TIPS'
+=========================================================
+Sofia is running.  Interactive tips:
+  /utils/isp-profile export /utils/isp-captures/${SENSOR}_qemu_day.isp ${SENSOR}
+  ipcinfo --short_sensor
+  i2cdetect -y -r 0
+  tail -20 /tmp/sofia.log
+  kill \$SPID                  # stop Sofia
+  exit                          # poweroff QEMU
+=========================================================
+TIPS
+
+exec sh -i
+EOF
+
+echo "Booting Hi3516EV200 with sensor=${SENSOR}…"
+echo "(Ctrl-A x to kill QEMU)"
+
+# Wait for the kernel to reach the /bin/sh prompt before piping the
+# setup script.  Without the lead-in sleep, our commands hit the
+# serial port before sh exists and are dropped on the floor.  After
+# the setup runs, `cat` keeps stdin open so the user gets an
+# interactive shell.
+{
+    sleep 8
+    printf '%s\n' "${GUEST_SETUP}"
+    cat
+} | env INIT=/bin/sh SENSOR="${SENSOR}" bash "${SCRIPT_DIR}/run-ev200.sh"

--- a/qemu-boot/run-ev200.sh
+++ b/qemu-boot/run-ev200.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Boot OpenIPC on emulated Hi3516EV200 (vendor-blob testing).
+#
+# Memory layout (mem=96M + mmz=…,0x46000000,32M) is now defined in the
+# SoC table (qemu/hw/arm/hisilicon.c) and injected automatically — do
+# not pass -m / mem= / mmz= here unless overriding.
+#
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+QEMU="$REPO_ROOT/qemu-src/build/qemu-system-arm"
+
+TAP="${TAP:-tap0}"
+if ip link show "$TAP" &>/dev/null 2>&1; then
+    NIC_ARGS="-nic tap,ifname=$TAP,script=no,downscript=no"
+    echo "Using bridged TAP networking ($TAP)"
+else
+    NIC_ARGS="-nic user"
+    echo "TAP not available; using SLIRP user-mode networking"
+fi
+
+INIT="${INIT:-}"
+SENSOR="${SENSOR:-}"
+
+MACHINE_ARGS="-M hi3516ev200"
+if [ -n "$SENSOR" ]; then
+    MACHINE_ARGS="-M hi3516ev200,sensor=$SENSOR"
+fi
+
+CMDLINE="console=ttyAMA0,115200 earlyprintk vdso=0 root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)"
+if [ -n "$INIT" ]; then
+    CMDLINE="$CMDLINE init=$INIT"
+fi
+
+exec "$QEMU" $MACHINE_ARGS \
+    -kernel "$SCRIPT_DIR/uImage.hi3516ev200" \
+    -initrd "$SCRIPT_DIR/rootfs.squashfs.hi3516ev200" \
+    -nographic -serial mon:stdio \
+    -append "$CMDLINE" \
+    $NIC_ARGS \
+    -d unimp,guest_errors -D "$SCRIPT_DIR/qemu-ev200.log" \
+    "$@"

--- a/qemu-boot/sofia-isp-ci-test.sh
+++ b/qemu-boot/sofia-isp-ci-test.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+#
+# Sofia ISP regression test — CI variant.
+#
+# Boots emulated Hi3516EV200 with sensor=sc2315e, modprobes the
+# vendor (XiongMai/Sofia) module chain, chroots into Sofia, watches
+# for the "ISP Dev 0 running" log line.  The guest fetches Sofia +
+# fonts + isp-profile from a small HTTP server running on the host
+# (no NFS dependency).
+#
+# Required fixtures (bundled in the qemu-hisilicon GitHub release
+# under tag $FIXTURES_TAG, default "sofia-fixtures-v1"):
+#   sofia_full.tar.gz  — Sofia binary + libs
+#   Font.bin.web       — vendor font for /mnt/web/Fonts/Font.bin
+#   Font.bin.custom    — vendor font for /mnt/custom/data/Fonts/Font.bin
+#   isp-profile        — ARM static binary (informational; we don't
+#                        need it for the regression check itself but
+#                        keep it for ad-hoc debugging on CI)
+#
+# Exit 0 if Sofia logs "ISP Dev 0 running" within ISP_READY_TIMEOUT
+# (default 30 s).  Exit non-zero with last 30 lines of QEMU output
+# otherwise.
+#
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+QEMU="${QEMU:-$REPO_ROOT/qemu-src/build/qemu-system-arm}"
+
+FIXTURES_TAG="${FIXTURES_TAG:-sofia-fixtures-v1}"
+FIXTURES_REPO="${FIXTURES_REPO:-widgetii/qemu-hisilicon}"
+FIXTURES_BASE_URL="${FIXTURES_BASE_URL:-https://github.com/${FIXTURES_REPO}/releases/download/${FIXTURES_TAG}}"
+
+ISP_READY_TIMEOUT="${ISP_READY_TIMEOUT:-30}"
+HTTP_PORT="${HTTP_PORT:-8765}"
+QEMU_TIMEOUT="${QEMU_TIMEOUT:-180}"
+
+WORK="${WORK:-$(mktemp -d -t sofia-ci-XXXXXX)}"
+SOFIA_LOG="$WORK/qemu-output.txt"
+
+cleanup() {
+    [ -n "$HTTP_PID" ] && kill "$HTTP_PID" 2>/dev/null || true
+    [ -n "$QEMU_PID" ] && kill "$QEMU_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==> Fetching Sofia fixtures from $FIXTURES_BASE_URL"
+mkdir -p "$WORK/fixtures"
+for f in sofia_full.tar.gz Font.bin.web Font.bin.custom isp-profile; do
+    curl -fsSL "$FIXTURES_BASE_URL/$f" -o "$WORK/fixtures/$f"
+done
+chmod +x "$WORK/fixtures/isp-profile"
+ls -la "$WORK/fixtures"
+
+echo "==> Starting host HTTP server on :$HTTP_PORT"
+python3 -m http.server "$HTTP_PORT" --directory "$WORK/fixtures" \
+    >"$WORK/http.log" 2>&1 &
+HTTP_PID=$!
+sleep 1
+
+echo "==> Booting Hi3516EV200 with sensor=sc2315e (timeout ${QEMU_TIMEOUT}s)"
+
+# Inline guest setup script — fed to /bin/sh as PID 1 inside the
+# guest.  Mirrors qemu-boot/run-ev200-sofia.sh except that it pulls
+# fixtures over HTTP from the SLIRP host (10.0.2.2) instead of NFS.
+GUEST_SETUP=$(cat <<'EOF'
+set +e
+echo "===setup: filesystems==="
+mount -t proc proc /proc 2>/dev/null
+mount -t tmpfs none /tmp
+
+echo "===setup: network==="
+udhcpc -q -i eth0 2>/dev/null || ifconfig eth0 10.0.2.15 netmask 255.255.255.0 up
+route add default gw 10.0.2.2 2>/dev/null
+
+echo "===setup: fetch fixtures==="
+mkdir -p /tmp/fixtures
+for f in sofia_full.tar.gz Font.bin.web Font.bin.custom isp-profile; do
+    wget -q "http://10.0.2.2:HTTP_PORT_PLACEHOLDER/$f" -O "/tmp/fixtures/$f" \
+        || { echo "WGET FAIL: $f"; exit 1; }
+done
+chmod +x /tmp/fixtures/isp-profile
+
+echo "===setup: stage /tmp/vendor==="
+mkdir -p /tmp/vendor/proc /tmp/vendor/dev /tmp/vendor/tmp \
+         /tmp/vendor/mnt/custom/data/Fonts /tmp/vendor/mnt/mtd/Config \
+         /tmp/vendor/mnt/web/Fonts /tmp/vendor/var
+gunzip < /tmp/fixtures/sofia_full.tar.gz | tar xf - -C /tmp/vendor/
+rm -f /tmp/vendor/usr/Fonts/Font.bin
+cp /tmp/fixtures/Font.bin.web    /tmp/vendor/mnt/web/Fonts/Font.bin
+cp /tmp/fixtures/Font.bin.custom /tmp/vendor/mnt/custom/data/Fonts/Font.bin
+ln -sf /mnt/web/Fonts/Font.bin /tmp/vendor/usr/Fonts/Font.bin
+mount --bind /dev  /tmp/vendor/dev  2>/dev/null
+mount -t proc proc /tmp/vendor/proc 2>/dev/null
+
+echo "===setup: modprobe vendor chain==="
+cd /lib/modules/4.9.37/hisilicon
+for m in sys_config hi_osal hi3516ev200_base hi3516ev200_sys \
+         hi3516ev200_rgn hi3516ev200_vgs hi_mipi_rx hi3516ev200_vi \
+         hi3516ev200_isp hi_sensor_i2c hi_sensor_spi \
+         hi3516ev200_vpss hi3516ev200_chnl hi3516ev200_vedu \
+         hi3516ev200_rc hi3516ev200_venc hi3516ev200_h264e \
+         hi3516ev200_h265e hi3516ev200_jpege \
+         hi3516ev200_aio hi3516ev200_ai hi3516ev200_ao \
+         hi3516ev200_aenc hi3516ev200_adec hi3516ev200_acodec \
+         hi3516ev200_pm hi3516ev200_ive hi_pwm; do
+    [ -e ${m}.ko ] || continue
+    case $m in
+        sys_config) ARGS="chip=hi3516ev200 sensors=sc2315e g_cmos_yuv_flag=0 board=demo";;
+        hi_osal)    ARGS="anony=1 mmz_allocator=hisi mmz=anonymous,0,0x46000000,32M";;
+        hi3516ev200_vgs) ARGS="max_vgs_job=20 max_vgs_node=20 max_vgs_task=20";;
+        hi3516ev200_ive) ARGS="save_power=0";;
+        *)          ARGS="";;
+    esac
+    insmod ${m}.ko $ARGS 2>&1 | head -2
+done
+
+echo "===setup: launch Sofia==="
+chroot /tmp/vendor /Sofia > /tmp/sofia.log 2>&1 &
+SPID=$!
+echo "Sofia pid=$SPID"
+
+for i in $(seq 1 ISP_READY_TIMEOUT_PLACEHOLDER); do
+    sleep 1
+    if grep -q "ISP Dev 0 running" /tmp/sofia.log 2>/dev/null; then
+        echo "ISP_DEV_0_RUNNING_DETECTED at t=${i}s"
+        break
+    fi
+    if ! kill -0 $SPID 2>/dev/null; then
+        echo "SOFIA_DIED at t=${i}s"
+        echo "===sofia.log tail==="
+        tail -30 /tmp/sofia.log
+        echo "===END_FAIL==="
+        poweroff -f 2>/dev/null
+        exit 1
+    fi
+done
+
+if ! grep -q "ISP_DEV_0_RUNNING_DETECTED" /proc/self/cmdline 2>/dev/null && \
+   ! grep -q "ISP Dev 0 running" /tmp/sofia.log 2>/dev/null; then
+    echo "ISP_NOT_READY_TIMEOUT"
+    echo "===sofia.log tail==="
+    tail -30 /tmp/sofia.log
+    echo "===END_FAIL==="
+    poweroff -f 2>/dev/null
+    exit 1
+fi
+
+echo "===END_OK==="
+poweroff -f 2>/dev/null
+EOF
+)
+
+# Substitute placeholders
+GUEST_SETUP="${GUEST_SETUP//HTTP_PORT_PLACEHOLDER/$HTTP_PORT}"
+GUEST_SETUP="${GUEST_SETUP//ISP_READY_TIMEOUT_PLACEHOLDER/$ISP_READY_TIMEOUT}"
+
+CMDLINE="console=ttyAMA0,115200 earlyprintk vdso=0 root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data) init=/bin/sh"
+
+{
+    sleep 8
+    printf '%s\n' "$GUEST_SETUP"
+} | timeout "$QEMU_TIMEOUT" "$QEMU" \
+    -M hi3516ev200,sensor=sc2315e \
+    -kernel "$SCRIPT_DIR/uImage.hi3516ev200" \
+    -initrd "$SCRIPT_DIR/rootfs.squashfs.hi3516ev200" \
+    -nographic -serial mon:stdio -nic user \
+    -append "$CMDLINE" \
+    -d unimp,guest_errors -D "$WORK/qemu-debug.log" \
+    > "$SOFIA_LOG" 2>&1 &
+QEMU_PID=$!
+
+wait $QEMU_PID || true
+QEMU_PID=
+
+echo
+if grep -q "ISP_DEV_0_RUNNING_DETECTED" "$SOFIA_LOG"; then
+    echo "=== PASS: Sofia reached 'ISP Dev 0 running' ==="
+    grep "ISP_DEV_0_RUNNING_DETECTED" "$SOFIA_LOG"
+    exit 0
+fi
+
+echo "=== FAIL: Sofia did NOT reach 'ISP Dev 0 running' within ${ISP_READY_TIMEOUT}s ==="
+echo "--- Last 60 lines of QEMU output ---"
+tail -60 "$SOFIA_LOG"
+exit 1

--- a/qemu/hw/i2c/hisi-i2c.c
+++ b/qemu/hw/i2c/hisi-i2c.c
@@ -189,9 +189,20 @@ static void hisi_i2c_do_start(HisiI2cState *s, bool restart)
         s->active = true;
         s->is_read = want_read;
     } else {
-        /* No slave acked — flag abort for guest. */
+        /*
+         * No slave acked — flag abort for guest.  Drain any TX FIFO
+         * bytes the guest queued for this aborted transaction;
+         * otherwise they pile up across consecutive failed probes
+         * (Sofia walks ~10 sensor addresses at startup, most NACK)
+         * and eventually corrupt the TX stream of subsequent
+         * successful transactions when the FIFO overflows.  Real
+         * hardware drivers typically reset the FIFO after an abort
+         * via a soft-reset register; clearing it on abort here gives
+         * equivalent behaviour without modelling that register.
+         */
         s->intr_raw |= INTR_ABORT_MASK;
         s->active = false;
+        s->txf_len = 0;
     }
 }
 
@@ -407,7 +418,18 @@ static void hisi_i2c_write(void *opaque, hwaddr offset,
         s->scl_l = value;
         break;
     case R_DATA1:
+        /*
+         * The kernel hibvt-i2c driver writes DATA1 once per transaction
+         * (before queueing TXF bytes and setting CTRL1.START).  Clear
+         * any TX FIFO leftovers from a previous program so this fresh
+         * transaction sees only its own bytes.  Without this, Sofia's
+         * sensor probe sequence (which intentionally queues 1 extra
+         * byte per write program — likely an SDK quirk that real HW
+         * tolerates because the FIFO is reset between transactions)
+         * gradually corrupts subsequent transactions.
+         */
         s->data1 = value & 0x3FF;
+        s->txf_len = 0;
         break;
     case R_TXF:
         if (s->txf_len < FIFO_DEPTH) {


### PR DESCRIPTION
## Summary

- PR #41's HiBVT I2C rewrite stopped clearing the TX FIFO when the kernel writes `DATA1` (the first register write of every transaction).  The old standalone model cleared it implicitly, and the kernel hibvt-i2c driver expects a fresh FIFO at the start of each program.
- Sofia's vendor I2C usage queues 1 extra byte per write program (an SDK quirk that real silicon tolerates because the hardware FIFO is reset between transactions).  Without the DATA1-write drain, that leftover byte gets prepended to the next program — Sofia's SC2315E ID register read came back as `0x60ff` (slave-addr byte 0x60 leaked from the FIFO + an out-of-range read for the second ID byte) instead of `0x2238`, and Sofia never reached `"ISP Dev 0 running"`.
- Two-line fix in `qemu/hw/i2c/hisi-i2c.c` (plus comments): clear `txf_len` on `R_DATA1` write, also defensively in `do_start()` abort path.
- `i2cdetect` probes (1 byte per program, no leftovers) were unaffected and continued to work, which is why the regression slipped past existing tests.

## Regression test

Adds `sofia-isp` CI job that:

- boots `-M hi3516ev200,sensor=sc2315e` on the OpenIPC EV200 firmware,
- modprobes the full XiongMai vendor module chain (sys, rgn, vgs, vi, isp, sensor i2c, vpss, codec, audio, pm, ive, pwm),
- chroots into the vendor Sofia binary,
- asserts the guest log line `"ISP Dev 0 running"` appears within 45 s.

Fixtures (Sofia binary + libs + Font.bin files + isp-profile ARM static) are bundled in the release tag [`sofia-fixtures-v1`](https://github.com/widgetii/qemu-hisilicon/releases/tag/sofia-fixtures-v1).  The CI test fetches them on a host-side `python3 -m http.server` and pipes them into the guest over SLIRP — no NFS / private artefact dependencies.

`qemu-boot/sofia-isp-ci-test.sh` is a self-contained shell script so failures can be reproduced locally with `FIXTURES_BASE_URL=http://localhost:9876 bash qemu-boot/sofia-isp-ci-test.sh` (run a `python3 -m http.server` over the four fixture files first).

Also adds two manual launchers used during development:

- `qemu-boot/run-ev200.sh` — minimal EV200 boot helper, mirrors `run-cv200.sh` / `run-ev300.sh`.
- `qemu-boot/run-ev200-sofia.sh` — interactive Sofia launcher (mounts the lab NFS share at `/utils`, stages Sofia, drops the user into a shell after `"ISP Dev 0 running"`).

## Test plan

- [x] Local smoke test: `bash qemu-boot/sofia-isp-ci-test.sh` reaches `ISP_DEV_0_RUNNING_DETECTED at t=3s`.
- [x] `isp-profile export` from the same boot captures a 7296-byte profile (md5 byte-identical to a real-camera capture).
- [x] `i2cdetect -y 0` still detects sc2315e at 0x30 (no regression on simple probes).
- [ ] CI green on this PR's `build`, `ive-test`, `boot:*`, and new `sofia-isp` jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)