### PR TITLE
hisi-sysctl: per-SoC SCSYSID layout to fix V1-V3 chip-id detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,20 @@ jobs:
               echo ""
               echo "=== Boot successful: login prompt reached ==="
               kill $QEMU_PID 2>/dev/null || true
+
+              # Regression: openhisilicon#66 — Wrong chip-id: hiunknown.
+              # Caused by hisi-sysctl returning the packed 32-bit chip ID
+              # at SCSYSID0 for V1/V2/V2A/V3/V3A SoCs that use a byte
+              # layout on real silicon. Boot reaching login is not
+              # enough — the firmware's chip-id check must succeed too,
+              # otherwise load_hisilicon short-circuits before any
+              # vendor module loads.
+              if grep -qE "Wrong chip-id|hiunknown" boot-output.txt; then
+                echo "=== FAIL: chip-id detection broken (openhisilicon#66) ==="
+                grep -nE "Wrong chip-id|hiunknown" boot-output.txt
+                exit 1
+              fi
+              echo "=== Chip-id detection OK ==="
               exit 0
             fi
             sleep 1

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -116,6 +116,7 @@ static const HisiSoCConfig hi3516cv100_soc = {
     .desc               = "HiSilicon Hi3516CV100 (ARM926EJ-S)",
     .cpu_type           = ARM_CPU_TYPE_NAME("arm926"),
     .soc_id             = HISI_SOC_ID_CV100,
+    .chipid_byte_layout = true,            /* V1: byte-wise SCSYSID0..3 */
     /* 128 MiB DDR total, kernel gets 32 MiB — matches OpenIPC V1
      * firmware's load_hisilicon defaults (totalmem=64, osmem=32),
      * so mmz.ko's implicit 0x82000000 region is left untouched. */
@@ -222,6 +223,8 @@ static const HisiSoCConfig hi3516cv200_soc = {
     .desc               = "HiSilicon Hi3516CV200 (ARM926EJ-S)",
     .cpu_type           = ARM_CPU_TYPE_NAME("arm926"),
     .soc_id             = HISI_SOC_ID_CV200,
+    .chipid_byte_layout = true,            /* V2: byte-wise SCSYSID0..3 */
+    .chip_variant       = 1,               /* 1 = 3516CV200 (vs 2=18EV200, 3=18EV201) */
     /* 128 MiB DDR total, kernel gets 32 MiB — matches firmware's
      * load_hisilicon defaults (osmem=32), leaving mmz.ko's 32 MiB at
      * 0x82000000 free. */
@@ -325,6 +328,7 @@ static const HisiSoCConfig hi3516av100_soc = {
     .desc               = "HiSilicon Hi3516AV100 (Cortex-A7)",
     .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a7"),
     .soc_id             = HISI_SOC_ID_AV100,
+    .chipid_byte_layout = true,            /* V2A: byte-wise SCSYSID0..3 */
     /* Real AV100 boards ship 128 MiB DDR; OpenIPC firmware's
      * load_hisilicon defaults to osmem=32 so mmz.ko takes the upper
      * 96 MiB at 0x82000000.  Cap kernel at 32 MiB to avoid the
@@ -427,6 +431,7 @@ static const HisiSoCConfig hi3516cv300_soc = {
     .desc               = "HiSilicon Hi3516CV300 (ARM926EJ-S)",
     .cpu_type           = ARM_CPU_TYPE_NAME("arm926"),
     .soc_id             = HISI_SOC_ID_CV300,
+    .chipid_byte_layout = true,            /* V3: byte-wise SCSYSID0..3 */
     .ram_size_default   = 128 * MiB,   /* stock CV300 cameras ship 128 MiB */
 
     .ram_base           = 0x80000000,
@@ -605,6 +610,7 @@ static const HisiSoCConfig hi3519v101_soc = {
     .desc               = "HiSilicon Hi3519V101 (Cortex-A7)",
     .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a7"),
     .soc_id             = HISI_SOC_ID_19V101,
+    .chipid_byte_layout = true,            /* V3A: byte-wise SCSYSID0..3 */
     .ram_size_default   = 256 * MiB,   /* 4K/WDR boards typically ship 256 MiB */
 
     .ram_base           = 0x80000000,
@@ -2010,6 +2016,8 @@ static void hisilicon_common_init(MachineState *machine,
     {
         DeviceState *sysctl = qdev_new("hisi-sysctl");
         qdev_prop_set_uint32(sysctl, "soc-id", c->soc_id);
+        qdev_prop_set_bit(sysctl, "byte-layout-id", c->chipid_byte_layout);
+        qdev_prop_set_uint8(sysctl, "chip-variant", c->chip_variant);
         sysbus_realize_and_unref(SYS_BUS_DEVICE(sysctl), &error_fatal);
         sysbus_mmio_map(SYS_BUS_DEVICE(sysctl), 0, c->sysctl_base);
     }

--- a/qemu/hw/misc/hisi-sysctl.c
+++ b/qemu/hw/misc/hisi-sysctl.c
@@ -35,6 +35,8 @@ struct HisiSysctlState {
     SysBusDevice parent_obj;
     MemoryRegion iomem;
     uint32_t soc_id;
+    bool byte_layout;
+    uint8_t chip_variant;
     uint32_t regs[HISI_SYSCTL_NREGS];
 };
 
@@ -49,19 +51,34 @@ static uint64_t hisi_sysctl_read(void *opaque, hwaddr offset, unsigned size)
         return 0;
     case 0x8C: /* REG_SYSSTAT — boot mode (0 = SPI NOR boot) */
         return s->regs[0x8C / 4];
-    case 0xEE0: /* SCSYSID0 — full 32-bit chip ID */
-        /*
-         * Vendor SDK (e.g. EV200 sys.o SYS_HAL_GetChipID) reads this as
-         * a single u32 and expects the packed chip ID (e.g. 0x3516E200).
-         * On real silicon SCSYSID0..3 are four contiguous bytes; reading
-         * 0xEE0 as a word naturally yields the full ID. We return the
-         * whole 32-bit value here for the same reason.
-         */
-        return s->soc_id;
-    case 0xEE4: /* SCSYSID1 — second word of the SCSYSID block, unused */
+    /*
+     * SCSYSID0..3 chip identification block. Two layouts coexist:
+     *
+     *   word layout (V4+, e.g. EV200/EV300/CV500): SCSYSID0 returns the
+     *     full 32-bit packed ID (e.g. 0x3516E300); SCSYSID1..3 unused.
+     *     Vendor V4 sys.o SYS_HAL_GetChipID reads SCSYSID0 as one u32.
+     *
+     *   byte layout (V1/V2/V2A/V3/V3A): each register returns one byte
+     *     of the family ID, low byte first; SCSYSID0 also carries the
+     *     chip sub-variant byte at bits 24-31. ipctool's
+     *     hisi_detect_cpu() and the vendor V3 sys.ko's SYS_HAL_GetChipID
+     *     rely on this — the latter reads SCSYSID0 >> 24 as the variant
+     *     (0 = CV300, 1 = CV200, 4 = EV100, etc.).
+     *
+     * The active layout is chosen per-SoC via the byte-layout-id
+     * property (default = word); chip-variant supplies the sub-variant
+     * byte and defaults to 0.
+     */
+    case 0xEE0: /* SCSYSID0 */
+        return s->byte_layout
+            ? (((uint32_t)s->chip_variant << 24) | (s->soc_id & 0xff))
+            : s->soc_id;
+    case 0xEE4: /* SCSYSID1 */
+        return s->byte_layout ? ((s->soc_id >> 8) & 0xff) : 0;
     case 0xEE8: /* SCSYSID2 */
+        return s->byte_layout ? ((s->soc_id >> 16) & 0xff) : 0;
     case 0xEEC: /* SCSYSID3 */
-        return 0;
+        return s->byte_layout ? ((s->soc_id >> 24) & 0xff) : 0;
     default:
         if (offset < HISI_SYSCTL_MMIO_SIZE) {
             return s->regs[offset / 4];
@@ -109,6 +126,8 @@ static void hisi_sysctl_init(Object *obj)
 
 static const Property hisi_sysctl_properties[] = {
     DEFINE_PROP_UINT32("soc-id", HisiSysctlState, soc_id, 0),
+    DEFINE_PROP_BOOL("byte-layout-id", HisiSysctlState, byte_layout, false),
+    DEFINE_PROP_UINT8("chip-variant", HisiSysctlState, chip_variant, 0),
 };
 
 static void hisi_sysctl_class_init(ObjectClass *klass, const void *data)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -73,6 +73,25 @@ typedef struct HisiSoCConfig {
     hwaddr          sysctl_base;
     hwaddr          crg_base;
 
+    /*
+     * SCSYSID register layout selector.
+     *   false — V4+: SCSYSID0 returns the full 32-bit soc_id as a word.
+     *   true  — V1/V2/V2A/V3/V3A: SCSYSID0..3 each return one byte of
+     *           soc_id (low byte first), matching real silicon and the
+     *           layout expected by vendor V3 sys.ko / ipctool.
+     */
+    bool            chipid_byte_layout;
+
+    /*
+     * Chip sub-variant byte placed in SCSYSID0[31:24] when
+     * chipid_byte_layout is set.  ipctool / vendor sys.ko use it to
+     * disambiguate SoCs that share a family ID — e.g. 0x3518E200
+     * is CV200 (variant 1), 18EV200 (2), or 18EV201 (3).  A value of
+     * 0 covers CV300, AV100 and 19V101 whose default sub-variant maps
+     * to the expected chip name.
+     */
+    uint8_t         chip_variant;
+
     /* UARTs (PL011) */
     int             num_uarts;
     hwaddr          uart_bases[HISI_MAX_UARTS];


### PR DESCRIPTION
## Summary

- Re-introduce byte-wise `SCSYSID0..3` for V1/V2/V2A/V3/V3A SoCs while keeping #39's word layout for V4+. Adds a `chip-variant` byte for SoCs that share a family ID (CV200 = 1).
- Set the byte layout on `hi3516cv100`, `hi3516cv200`, `hi3516av100`, `hi3516cv300`, `hi3519v101`; CV200 also gets `chip_variant = 1`.
- Wire a CI regression assertion: any `Wrong chip-id` / `hiunknown` line in boot output now fails the matrix entry.

## Background

Fixes [openhisilicon#66](https://github.com/OpenIPC/openhisilicon/issues/66). On QEMU `hi3516cv300` the firmware printed `Wrong chip-id: hiunknown` and `load_hisilicon` aborted before any vendor module loaded, masking the real chain that PR [openhisilicon#63](https://github.com/OpenIPC/openhisilicon/pull/63) is trying to surface.

The bug: PR #39 made `SCSYSID0` return the full 32-bit `soc_id` for every SoC. That works for V4+ (vendor V4 `sys.o` reads it as a single u32), but regressed V1/V2/V2A/V3/V3A silicon. There the block is byte-wise — each register returns one byte of the family ID, and `SCSYSID0[31:24]` is the chip sub-variant byte. `ipctool`'s `hisi_detect_cpu()` and the vendor V3 `sys.ko`'s `SYS_HAL_GetChipID` both rely on this. With the packed-word emulation, ipctool took the V4 shortcut at `(SCSYSID[0] >> 16) & 0xff != 0`, looked up `family_id 0x3516C300` with `scsysid0 = 0x35` (the high byte of the packed ID), fell through `get_chip_V3`'s default → `"unknown"` → `"hi" + "unknown"` = `"hiunknown"`.

For CV200 (`0x3518E200`), even byte-layout-fixed, ipctool's `get_chip_V2()` needs a non-zero variant byte: `1 = 3516CV200`, `2 = 3518EV200`, `3 = 3518EV201`. Hence the per-SoC `chip_variant` field.

CV300/AV100/19V101 happen to use sub-variant `0`, which falls out for free.

## Test plan

- [x] `bash qemu-boot/run-cv300.sh` — `Wrong chip-id` gone; reaches `openipc-hi3516cv300 login:`.
- [x] `bash qemu-boot/run-cv200.sh` — `reserved value 0` gone; reaches `openipc-hi3516cv200 login:`.
- [x] `bash qemu-boot/run-av100.sh` — login reached, no chip-id error (variant 0 OK for AV100).
- [x] `bash qemu-boot/run-cv100.sh` — login reached; V1 detection path unaffected (uses `0x88`/`0x8C`, not SCSYSID).
- [x] `bash qemu-boot/run-ev300.sh` — V4 word layout still works (no PR #39 regression).
- [x] CI boot job's new `Wrong chip-id|hiunknown` assertion passes for every matrix entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)