### PR TITLE
hisi: add hi3516av300 / hi3516av200 machines with IMX415 / IMX385 sensor defaults

### DIFF
--- a/qemu-boot/run-av200.sh
+++ b/qemu-boot/run-av200.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Boot OpenIPC on emulated Hi3516AV200 (1080p variant of 3519V101 family).
+#
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+QEMU="$REPO_ROOT/qemu-src/build/qemu-system-arm"
+
+exec "$QEMU" -M hi3516av200 \
+    -kernel "$SCRIPT_DIR/uImage.hi3516av200" \
+    -initrd "$SCRIPT_DIR/rootfs.squashfs.hi3516av200" \
+    -nographic -serial mon:stdio \
+    -append "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)" \
+    -nic user \
+    -d unimp,guest_errors -D "$SCRIPT_DIR/qemu-av200.log" \
+    "$@"

--- a/qemu-boot/run-av300.sh
+++ b/qemu-boot/run-av300.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Boot OpenIPC on emulated Hi3516AV300 (4K variant of CV500 family).
+#
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+QEMU="$REPO_ROOT/qemu-src/build/qemu-system-arm"
+
+exec "$QEMU" -M hi3516av300 \
+    -kernel "$SCRIPT_DIR/uImage.hi3516av300" \
+    -initrd "$SCRIPT_DIR/rootfs.squashfs.hi3516av300" \
+    -nographic -serial mon:stdio \
+    -append "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)" \
+    -nic user \
+    -d unimp,guest_errors -D "$SCRIPT_DIR/qemu-av300.log" \
+    "$@"

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -613,6 +613,118 @@ static const HisiSoCConfig hi3516cv500_soc = {
 };
 
 /*
+ * Hi3516AV300 (V4A): 2019, 4K smart-vision.  Dual Cortex-A7 @900MHz.
+ * Video: H.265/H.264, 4K(3840x2160)@30fps.  NPU: 1.0 TOPS.
+ * Same die family as CV500 (identical peripheral map, MMC, SRAM, IRQs);
+ * differs only in feature tier (4K + bigger NPU) and the SCSYSID family
+ * ID 0x3516A300 (vs CV500's 0x3516C500).
+ */
+static const HisiSoCConfig hi3516av300_soc = {
+    .name               = "hi3516av300",
+    .desc               = "HiSilicon Hi3516AV300 (Cortex-A7, dual-core, 4K)",
+    .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a7"),
+    .soc_id             = HISI_SOC_ID_AV300,
+    .default_sensor     = "imx415",        /* Sony 4K Starvis on AV300 ref boards */
+    /* Same memory layout as CV500: external DDR, 128 MiB typical. */
+    .ram_size_default   = 128 * MiB,
+    .kernel_mem_mb      = 32,
+    .extra_cmdline      = "mmz_allocator=hisi "
+                          "mmz=anonymous,0,0x82000000,96M",
+    .max_cpus           = 2,
+
+    .ram_base           = 0x80000000,
+    .sram_base          = 0x04010000,
+    .sram_size          = 40 * KiB,
+
+    .use_gic            = true,
+    .gic_dist_base      = 0x10301000,
+    .gic_cpu_base       = 0x10302000,
+    .gic_num_spi        = 128,
+
+    .sysctl_base        = 0x12020000,
+    .crg_base           = 0x12010000,
+
+    .num_uarts          = 3,
+    .uart_bases         = { 0x120A0000, 0x120A1000, 0x120A2000 },
+    .uart_irqs          = { 6, 7, 8 },
+
+    .num_timers         = 2,
+    .timer_bases        = { 0x12000000, 0x12001000 },
+    .timer_irqs         = { 1, 2 },
+
+    .num_spis           = 3,
+    .spi_bases          = { 0x120C0000, 0x120C1000, 0x120C2000 },
+    .spi_irqs           = { 68, 69, 70 },
+
+    .fmc_ctrl_base      = 0x10000000,
+    .fmc_mem_base       = 0x14000000,
+
+    .gpio_base          = 0x120D0000,
+    .gpio_count         = 11,
+    .gpio_stride        = 0x1000,
+    .gpio_irq_start     = 16,
+    .gpio_extras        = {
+        { 0x120DB000, 80 },
+    },
+
+    .femac_base         = 0x10010000,
+    .femac_irq          = 32,
+
+    .num_himci          = 3,
+    .himci_bases        = { 0x10100000, 0x100F0000, 0x10020000 },
+    .himci_irqs         = { 64, 30, 31 },
+
+    .num_i2c            = 7,
+    .i2c_bases          = { 0x120B0000, 0x120B1000, 0x120B2000, 0x120B3000,
+                            0x120B5000, 0x120B6000, 0x120B7000 },
+
+    .mipi_rx_base       = 0x113A0000,
+    .mipi_rx_irq        = 57,
+
+    .rtc_base           = 0x12080000,
+    .rtc_irq            = 5,
+
+    .vedu_base          = 0x11500000,
+    .jpge_base          = 0x11220000,
+    .vedu_irq           = 40,
+    .jpge_irq           = 36,
+
+    .wdt_base           = 0x12051000,
+    .wdt_irq            = -1,
+    .wdt_freq           = 3000000,
+
+    .num_crg_defaults   = 4,
+    .crg_defaults       = {
+        { 0x1B8, (1 << 0) | (1 << 1) | (1 << 2) | (1 << 18)
+               | (1 << 11) | (1 << 12) | (1 << 13)
+               | (1 << 14) | (1 << 15) | (1 << 16)
+               | (1 << 17) | (1 << 18) },
+        { 0x144, 0x02 },
+        { 0x16C, 0x02 },
+        { 0x78,  (1 << 2) | (1 << 4) },
+    },
+
+    .gzip_base          = 0x11200000,
+
+    .cpu_srst_offset    = 0x78,
+
+    .num_regbanks       = 11,
+    .regbanks           = {
+        { "hisi-misc",       0x12030000, 0x8000  },
+        { "hisi-ddr",        0x12060000, 0x10000 },
+        { "hisi-iocfg",      0x12040000, 0x10000 },
+        { "hisi-iocfg2",     0x10FF0000, 0x10000 },
+        { "hisi-pwm",        0x12070000, 0x10000 },
+        { "hisi-usb3",       0x100E0000, 0x10000 },
+        { "hisi-vi-cap",     0x11300000, 0x100000 },
+        { "hisi-vi-proc",    0x11000000, 0x40000 },
+        { "hisi-vpss",       0x11040000, 0x10000 },
+        { "hisi-aiao",       0x113B0000, 0x20000 },
+        { "hisi-npu",        0x11700000, 0x100000 },  /* 1.0 TOPS NPU */
+    },
+};
+
+/*
  * Hi3519V101 (V3A): ~2017, 4K professional.
  * CPU: Cortex-A17 @1.25GHz + Cortex-A7 @800MHz (big.LITTLE).
  * Video: H.265, 4-frame WDR, 4K@30fps + 2M@30fps simultaneous.
@@ -698,6 +810,106 @@ static const HisiSoCConfig hi3519v101_soc = {
     .num_crg_defaults   = 1,
     .crg_defaults       = {
         /* APLL ctrl_reg2: fbdiv=792, refdiv=24 → 792 MHz (prevents div-by-zero) */
+        { 0x04, (24 << 12) | 792 },
+    },
+
+    .num_regbanks       = 11,
+    .regbanks           = {
+        { "hisi-misc",       0x12030000, 0x10000 },
+        { "hisi-ddr",        0x12060000, 0x10000 },
+        { "hisi-iocfg",      0x12160000, 0x10000 },
+        { "hisi-pwm",        0x12130000, 0x10000 },
+        { "hisi-usb-ehci",   0x10120000, 0x10000 },
+        { "hisi-usb-ohci",   0x10110000, 0x10000 },
+        { "hisi-gmac",       0x10050000, 0x10000 },
+        { "hisi-vi-cap",     0x11380000, 0x100000 },
+        { "hisi-vou",        0x11000000, 0x20000 },
+        { "hisi-vpss",       0x11180000, 0x10000 },
+        { "hisi-aiao",       0x11080000, 0x10000 },
+    },
+};
+
+/*
+ * Hi3516AV200 (V3A): same die as 3519V101, distinguished by SCSYSID0
+ * sub-variant byte (5/6/0x15/0x16 per ipctool's get_chip_V3A).  Targets
+ * 5M@30fps + 720P@30fps cameras with the same big.LITTLE A17+A7 layout.
+ *
+ * Per the joint hi3519v101/hi3516av200 hardware guide ("未有特殊说明，
+ * Hi3516AV200 与Hi3519V101 完全一致"), every peripheral address, IRQ,
+ * GPIO count, and clock matches 3519V101.  Inherit everything via the
+ * 3519V101 layout; just swap SoC ID variant + default sensor.
+ */
+static const HisiSoCConfig hi3516av200_soc = {
+    .name               = "hi3516av200",
+    .desc               = "HiSilicon Hi3516AV200 (Cortex-A7, big.LITTLE die)",
+    .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a7"),
+    .soc_id             = HISI_SOC_ID_19V101,    /* shares family with 3519V101 */
+    .chipid_byte_layout = true,
+    .chip_variant       = 5,                     /* SCSYSID0 byte 5 = 3516AV200 */
+    .default_sensor     = "imx385",              /* Sony 1080p Starvis on AV200 ref boards */
+    .ram_size_default   = 256 * MiB,
+    .kernel_mem_mb      = 32,
+    .extra_cmdline      = "mmz_allocator=hisi "
+                          "mmz=anonymous,0,0x82000000,224M",
+
+    .ram_base           = 0x80000000,
+    .sram_base          = 0x04010000,
+    .sram_size          = 64 * KiB,
+
+    .use_gic            = true,
+    .gic_dist_base      = 0x10301000,
+    .gic_cpu_base       = 0x10302000,
+    .gic_num_spi        = 128,
+
+    .sysctl_base        = 0x12020000,
+    .crg_base           = 0x12010000,
+
+    .num_uarts          = 5,
+    .uart_bases         = { 0x12100000, 0x12101000, 0x12102000,
+                            0x12103000, 0x12104000 },
+    .uart_irqs          = { 4, 5, 6, 7, 8 },
+
+    .num_timers         = 2,
+    .timer_bases        = { 0x12000000, 0x12001000 },
+    .timer_irqs         = { 64, 66 },
+    .timer_freq         = 3000000,
+
+    .num_spis           = 4,
+    .spi_bases          = { 0x12120000, 0x12121000, 0x12122000, 0x12123000 },
+    .spi_irqs           = { 9, 10, 11, 12 },
+
+    .fmc_ctrl_base      = 0x10000000,
+    .fmc_mem_base       = 0x14000000,
+
+    .gpio_base          = 0x12140000,
+    .gpio_count         = 17,
+    .gpio_stride        = 0x1000,
+    .gpio_irq           = 43,
+
+    .num_himci          = 3,
+    .himci_bases        = { 0x100c0000, 0x100d0000, 0x100e0000 },
+    .himci_irqs         = { 23, 24, 13 },
+
+    .num_i2c            = 4,
+    .i2c_bases          = { 0x12110000, 0x12111000, 0x12112000, 0x12113000 },
+
+    .mipi_rx_base       = 0x11300000,
+    .mipi_rx_irq        = 28,
+
+    .rtc_base           = 0x12090000,
+    .rtc_irq            = 1,
+
+    .vedu_base          = 0x11280000,
+    .jpge_base          = 0x11200000,
+    .vedu_irq           = 37,
+    .jpge_irq           = 38,
+
+    .wdt_base           = 0x12080000,
+    .wdt_irq            = -1,
+    .wdt_freq           = 3000000,
+
+    .num_crg_defaults   = 1,
+    .crg_defaults       = {
         { 0x04, (24 << 12) | 792 },
     },
 
@@ -2407,6 +2619,12 @@ static void hisilicon_common_init(MachineState *machine,
             } else if (!strcmp(sensor_name, "imx291")) {
                 sensor = qdev_new("hisi-imx291");
                 i2c_addr = 0x1A;
+            } else if (!strcmp(sensor_name, "imx415")) {
+                sensor = qdev_new("hisi-imx415");
+                i2c_addr = 0x1A;
+            } else if (!strcmp(sensor_name, "imx385")) {
+                sensor = qdev_new("hisi-imx385");
+                i2c_addr = 0x1A;
             } else if (!strcmp(sensor_name, "f37")) {
                 sensor = qdev_new("hisi-f37");
                 i2c_addr = 0x40;
@@ -2458,10 +2676,10 @@ static void hisilicon_common_init(MachineState *machine,
                 i2c_addr = 0x30;
             } else {
                 error_report("Unknown sensor '%s' (supported: imx291, "
-                             "imx307, imx335, f37, gc2053, sp2305, "
-                             "mis2006, sc2235p, sc2235e, sc2315, sc2315e, "
-                             "sc2335, sc2239, sc307h, imx122, imx222; "
-                             "or 'none' to disable default)",
+                             "imx307, imx335, imx385, imx415, f37, "
+                             "gc2053, sp2305, mis2006, sc2235p, sc2235e, "
+                             "sc2315, sc2315e, sc2335, sc2239, sc307h, "
+                             "imx122, imx222; or 'none' to disable default)",
                              sensor_name);
                 exit(1);
             }
@@ -2588,7 +2806,9 @@ DEFINE_HISI_MACHINE("hi3516cv200", hi3516cv200, hi3516cv200_soc)
 DEFINE_HISI_MACHINE("hi3516av100", hi3516av100, hi3516av100_soc)
 DEFINE_HISI_MACHINE("hi3516cv300", hi3516cv300, hi3516cv300_soc)
 DEFINE_HISI_MACHINE("hi3516cv500", hi3516cv500, hi3516cv500_soc)
+DEFINE_HISI_MACHINE("hi3516av300", hi3516av300, hi3516av300_soc)
 DEFINE_HISI_MACHINE("hi3519v101", hi3519v101, hi3519v101_soc)
+DEFINE_HISI_MACHINE("hi3516av200", hi3516av200, hi3516av200_soc)
 DEFINE_HISI_MACHINE("hi3516ev300", hi3516ev300, hi3516ev300_soc)
 DEFINE_HISI_MACHINE("hi3516ev200", hi3516ev200, hi3516ev200_soc)
 DEFINE_HISI_MACHINE("hi3518ev300", hi3518ev300, hi3518ev300_soc)

--- a/qemu/hw/i2c/hisi-imx385.c
+++ b/qemu/hw/i2c/hisi-imx385.c
@@ -1,0 +1,151 @@
+/*
+ * Sony IMX385 image sensor I2C stub.
+ *
+ * Sony IMX385 is the 1080p Starvis sensor on Hi3516AV200/3519V101-class
+ * boards.  ipctool / vendor SDK detect IMX385 by reading a cluster of
+ * registers in the 0x3000-0x33FF window:
+ *   1. I2C addr 0x34 (8-bit) = 0x1A (7-bit slave addr)
+ *   2. 0x3004 == 0x10
+ *   3. 0x300C == 0x00 && 0x300E == 0x01
+ *   4. 0x300D == 0x00 && 0x3010 == 0x01 && 0x3011 == 0x00 &&
+ *      0x301E == 0x01 && 0x301F == 0x00
+ *   5. 0x3338 != 0x00   (else IMX225 is reported)
+ *
+ * The reset stub answers exactly that pattern; all other registers
+ * read back as 0xFF (uninitialized) so earlier branches in the probe
+ * (IMX347, IMX334, IMX335, IMX415, IMX291, IMX138 etc.) all fall
+ * through.
+ *
+ * Reference: ipctool/src/sensors.c detect_sony_sensor() lines 294-314
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * Written by Dmitry Ilyin
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/i2c/i2c.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_IMX385 "hisi-imx385"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiIMX385State, HISI_IMX385)
+
+#define IMX385_REG_BASE  0x3000
+#define IMX385_REG_COUNT 0x1000
+
+struct HisiIMX385State {
+    I2CSlave parent_obj;
+    uint8_t  reg_buf[2];
+    uint8_t  reg_ptr;
+    uint16_t cur_reg;
+    uint8_t  regs[IMX385_REG_COUNT];
+};
+
+static void hisi_imx385_reset_regs(HisiIMX385State *s)
+{
+    memset(s->regs, 0xFF, sizeof(s->regs));
+
+    /* IMX385 detection cluster */
+    s->regs[0x3004 - IMX385_REG_BASE] = 0x10;
+    s->regs[0x300C - IMX385_REG_BASE] = 0x00;
+    s->regs[0x300D - IMX385_REG_BASE] = 0x00;
+    s->regs[0x300E - IMX385_REG_BASE] = 0x01;
+    s->regs[0x3010 - IMX385_REG_BASE] = 0x01;
+    s->regs[0x3011 - IMX385_REG_BASE] = 0x00;
+    s->regs[0x301E - IMX385_REG_BASE] = 0x01;
+    s->regs[0x301F - IMX385_REG_BASE] = 0x00;
+    /* 0x3338 != 0 distinguishes IMX385 from IMX225 */
+    s->regs[0x3338 - IMX385_REG_BASE] = 0x01;
+
+    /* Avoid earlier-branch false matches:
+     *   IMX138 cluster also keys off READ(0xC)==0 && READ(0xE)==1, but
+     *   additionally requires READ(0xD)==0x20 — we hold 0x300D at 0,
+     *   so the IMX138 / IMX123 branches fall through. */
+}
+
+static int hisi_imx385_event(I2CSlave *i2c, enum i2c_event event)
+{
+    HisiIMX385State *s = HISI_IMX385(i2c);
+
+    switch (event) {
+    case I2C_START_SEND:
+        s->reg_ptr = 0;
+        break;
+    case I2C_START_RECV:
+        s->cur_reg = ((uint16_t)s->reg_buf[0] << 8) | s->reg_buf[1];
+        break;
+    default:
+        break;
+    }
+    return 0;
+}
+
+static int hisi_imx385_send(I2CSlave *i2c, uint8_t data)
+{
+    HisiIMX385State *s = HISI_IMX385(i2c);
+
+    if (s->reg_ptr < 2) {
+        s->reg_buf[s->reg_ptr++] = data;
+    } else {
+        uint16_t addr = ((uint16_t)s->reg_buf[0] << 8) | s->reg_buf[1];
+        if (addr >= IMX385_REG_BASE &&
+            addr < IMX385_REG_BASE + IMX385_REG_COUNT) {
+            s->regs[addr - IMX385_REG_BASE] = data;
+        }
+        s->reg_buf[1]++;
+        if (s->reg_buf[1] == 0) {
+            s->reg_buf[0]++;
+        }
+    }
+    return 0;
+}
+
+static uint8_t hisi_imx385_recv(I2CSlave *i2c)
+{
+    HisiIMX385State *s = HISI_IMX385(i2c);
+    uint8_t val = 0xFF;
+
+    if (s->cur_reg >= IMX385_REG_BASE &&
+        s->cur_reg < IMX385_REG_BASE + IMX385_REG_COUNT) {
+        val = s->regs[s->cur_reg - IMX385_REG_BASE];
+    }
+    s->cur_reg++;
+    return val;
+}
+
+static void hisi_imx385_reset(DeviceState *dev)
+{
+    HisiIMX385State *s = HISI_IMX385(dev);
+
+    s->reg_ptr = 0;
+    s->cur_reg = 0;
+    memset(s->reg_buf, 0, sizeof(s->reg_buf));
+    hisi_imx385_reset_regs(s);
+}
+
+static void hisi_imx385_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    I2CSlaveClass *k = I2C_SLAVE_CLASS(klass);
+
+    device_class_set_legacy_reset(dc, hisi_imx385_reset);
+    k->event = hisi_imx385_event;
+    k->recv  = hisi_imx385_recv;
+    k->send  = hisi_imx385_send;
+}
+
+static const TypeInfo hisi_imx385_info = {
+    .name          = TYPE_HISI_IMX385,
+    .parent        = TYPE_I2C_SLAVE,
+    .instance_size = sizeof(HisiIMX385State),
+    .class_init    = hisi_imx385_class_init,
+};
+
+static void hisi_imx385_register_types(void)
+{
+    type_register_static(&hisi_imx385_info);
+}
+
+type_init(hisi_imx385_register_types)

--- a/qemu/hw/i2c/hisi-imx415.c
+++ b/qemu/hw/i2c/hisi-imx415.c
@@ -1,0 +1,130 @@
+/*
+ * Sony IMX415 image sensor I2C stub.
+ *
+ * Sony IMX415 is the standard 4K Starvis sensor on Hi3516AV300-class
+ * boards.  ipctool / vendor SDK detect IMX415 by:
+ *   1. Setting I2C addr 0x34 (8-bit) = 0x1A (7-bit slave addr)
+ *   2. Reading reg 0x3B00: must be 0x2E (programmed) or 0x28 (POR default)
+ *
+ * Returning 0x28 at 0x3B00 satisfies the IMX415 branch.  All other
+ * registers read back as 0xFF (uninitialized) so earlier branches in
+ * the probe (IMX347, IMX334, IMX335, IMX322, IMX323) all fall through.
+ *
+ * Reference: ipctool/src/sensors.c detect_sony_sensor() lines 202-209
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * Written by Dmitry Ilyin
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/i2c/i2c.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_IMX415 "hisi-imx415"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiIMX415State, HISI_IMX415)
+
+#define IMX415_REG_BASE  0x3000
+#define IMX415_REG_COUNT 0x1000
+
+struct HisiIMX415State {
+    I2CSlave parent_obj;
+    uint8_t  reg_buf[2];
+    uint8_t  reg_ptr;
+    uint16_t cur_reg;
+    uint8_t  regs[IMX415_REG_COUNT];
+};
+
+static void hisi_imx415_reset_regs(HisiIMX415State *s)
+{
+    memset(s->regs, 0xFF, sizeof(s->regs));
+    /* IMX415 datasheet p.46: 0x3B00 default after reset is 0x28 */
+    s->regs[0x3B00 - IMX415_REG_BASE] = 0x28;
+}
+
+static int hisi_imx415_event(I2CSlave *i2c, enum i2c_event event)
+{
+    HisiIMX415State *s = HISI_IMX415(i2c);
+
+    switch (event) {
+    case I2C_START_SEND:
+        s->reg_ptr = 0;
+        break;
+    case I2C_START_RECV:
+        s->cur_reg = ((uint16_t)s->reg_buf[0] << 8) | s->reg_buf[1];
+        break;
+    default:
+        break;
+    }
+    return 0;
+}
+
+static int hisi_imx415_send(I2CSlave *i2c, uint8_t data)
+{
+    HisiIMX415State *s = HISI_IMX415(i2c);
+
+    if (s->reg_ptr < 2) {
+        s->reg_buf[s->reg_ptr++] = data;
+    } else {
+        uint16_t addr = ((uint16_t)s->reg_buf[0] << 8) | s->reg_buf[1];
+        if (addr >= IMX415_REG_BASE &&
+            addr < IMX415_REG_BASE + IMX415_REG_COUNT) {
+            s->regs[addr - IMX415_REG_BASE] = data;
+        }
+        s->reg_buf[1]++;
+        if (s->reg_buf[1] == 0) {
+            s->reg_buf[0]++;
+        }
+    }
+    return 0;
+}
+
+static uint8_t hisi_imx415_recv(I2CSlave *i2c)
+{
+    HisiIMX415State *s = HISI_IMX415(i2c);
+    uint8_t val = 0xFF;
+
+    if (s->cur_reg >= IMX415_REG_BASE &&
+        s->cur_reg < IMX415_REG_BASE + IMX415_REG_COUNT) {
+        val = s->regs[s->cur_reg - IMX415_REG_BASE];
+    }
+    s->cur_reg++;
+    return val;
+}
+
+static void hisi_imx415_reset(DeviceState *dev)
+{
+    HisiIMX415State *s = HISI_IMX415(dev);
+
+    s->reg_ptr = 0;
+    s->cur_reg = 0;
+    memset(s->reg_buf, 0, sizeof(s->reg_buf));
+    hisi_imx415_reset_regs(s);
+}
+
+static void hisi_imx415_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    I2CSlaveClass *k = I2C_SLAVE_CLASS(klass);
+
+    device_class_set_legacy_reset(dc, hisi_imx415_reset);
+    k->event = hisi_imx415_event;
+    k->recv  = hisi_imx415_recv;
+    k->send  = hisi_imx415_send;
+}
+
+static const TypeInfo hisi_imx415_info = {
+    .name          = TYPE_HISI_IMX415,
+    .parent        = TYPE_I2C_SLAVE,
+    .instance_size = sizeof(HisiIMX415State),
+    .class_init    = hisi_imx415_class_init,
+};
+
+static void hisi_imx415_register_types(void)
+{
+    type_register_static(&hisi_imx415_info);
+}
+
+type_init(hisi_imx415_register_types)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -223,8 +223,13 @@ typedef struct HisiSoCConfig {
 /* V3.5 generation (Cortex-A7 + GIC, but V3-era address map) */
 #define HISI_SOC_ID_CV500       0x3516C500
 
+/* V4A generation — same architecture as CV500 with 4K + bigger NPU */
+#define HISI_SOC_ID_AV300       0x3516A300
+
 /* V3A generation (Cortex-A7/A17 big.LITTLE + GIC, V3-era address map) */
 #define HISI_SOC_ID_19V101      0x35190101
+/* AV200 shares 19V101's family ID; sub-variant byte 5/6/0x15/0x16
+ * in SCSYSID0 distinguishes 3516AV200 from 3519V101 (0/1/2/0x11/0x12). */
 
 /*
  * V5 generation (Cortex-A7 MP2 + GIC, new 0x11xxxxxx address map, ~2023)

--- a/qemu/setup.sh
+++ b/qemu/setup.sh
@@ -53,6 +53,8 @@ cp qemu/hw/i2c/hisi-i2c.c          "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-imx335.c       "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-imx307.c       "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-imx291.c       "$QEMU_DIR/hw/i2c/"
+cp qemu/hw/i2c/hisi-imx415.c       "$QEMU_DIR/hw/i2c/"
+cp qemu/hw/i2c/hisi-imx385.c       "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-f37.c          "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-gc2053.c       "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-sp2305.c       "$QEMU_DIR/hw/i2c/"
@@ -184,7 +186,7 @@ fi
 
 # hw/i2c/meson.build
 if ! grep -q hisi-i2c "$QEMU_DIR/hw/i2c/meson.build"; then
-    echo "system_ss.add(when: 'CONFIG_HISI_I2C', if_true: files('hisi-i2c.c', 'hisi-i2c-v1.c', 'hisi-i2c-dw.c', 'hisi-imx335.c', 'hisi-imx307.c', 'hisi-imx291.c', 'hisi-f37.c', 'hisi-gc2053.c', 'hisi-sp2305.c', 'hisi-mis2006.c', 'hisi-smartsens.c'))" \
+    echo "system_ss.add(when: 'CONFIG_HISI_I2C', if_true: files('hisi-i2c.c', 'hisi-i2c-v1.c', 'hisi-i2c-dw.c', 'hisi-imx335.c', 'hisi-imx307.c', 'hisi-imx291.c', 'hisi-imx385.c', 'hisi-imx415.c', 'hisi-f37.c', 'hisi-gc2053.c', 'hisi-sp2305.c', 'hisi-mis2006.c', 'hisi-smartsens.c'))" \
         >> "$QEMU_DIR/hw/i2c/meson.build"
     echo "  patched hw/i2c/meson.build"
 else
@@ -203,6 +205,16 @@ else
         sed -i "s/'hisi-imx307.c'/'hisi-imx307.c', 'hisi-imx291.c'/" \
             "$QEMU_DIR/hw/i2c/meson.build"
         echo "  hw/i2c/meson.build: added hisi-imx291.c"
+    fi
+    if ! grep -q hisi-imx385 "$QEMU_DIR/hw/i2c/meson.build"; then
+        sed -i "s/'hisi-imx291.c'/'hisi-imx291.c', 'hisi-imx385.c'/" \
+            "$QEMU_DIR/hw/i2c/meson.build"
+        echo "  hw/i2c/meson.build: added hisi-imx385.c"
+    fi
+    if ! grep -q hisi-imx415 "$QEMU_DIR/hw/i2c/meson.build"; then
+        sed -i "s/'hisi-imx385.c'/'hisi-imx385.c', 'hisi-imx415.c'/" \
+            "$QEMU_DIR/hw/i2c/meson.build"
+        echo "  hw/i2c/meson.build: added hisi-imx415.c"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Two new HiSilicon machine targets, closing the gaps from the per-SoC default-sensor list (PR #51 / Issue #52):

- **hi3516av300** — V4A 4K, dual Cortex-A7 + 1.0 TOPS NPU. Same die family as CV500 (identical peripheral map, MMC, SRAM, IRQs); differs only in feature tier and family ID 0x3516A300. Default sensor: **IMX415** (Sony 4K Starvis).
- **hi3516av200** — V3A 1080p+720P big.LITTLE. Per the joint hi3519v101/hi3516av200 hardware guide, every peripheral matches 3519V101; AV200 is distinguished only by the SCSYSID0 sub-variant byte (5/6/0x15/0x16 per `ipctool/src/hal/hisi/hal_hisi.c::get_chip_V3A`). Default sensor: **IMX385** (Sony 1080p Starvis).

Two new Sony I2C sensor stubs at slave addr 0x1A:

- `hisi-imx415.c` — answers ipctool's IMX415 probe (reg `0x3B00 == 0x28`, POR default per IMX415 datasheet p.46).
- `hisi-imx385.c` — answers ipctool's IMX385 probe cluster (`0x3004=0x10`, `0x300C=0x00`, `0x300D=0x00`, `0x300E=0x01`, `0x3010=0x01`, `0x3011=0x00`, `0x301E=0x01`, `0x301F=0x00`, `0x3338=0x01`). Other regs default to 0xFF so earlier branches in `detect_sony_sensor()` (IMX347, IMX334, IMX335, IMX415, IMX291, IMX138, …) all fall through.

Reference: `ipctool/src/sensors.c::detect_sony_sensor()`, lines 202-209 (IMX415) and 294-314 (IMX385).

Plus the corresponding `qemu-boot/run-av300.sh` and `qemu-boot/run-av200.sh` boot scripts patterned after `run-cv500.sh`.

## Test plan

- [x] \`qemu-system-arm -machine help\` lists both new machines
- [x] \`qemu-system-arm -device help\` lists \`hisi-imx385\` and \`hisi-imx415\`
- [x] Both machines start with no kernel under \`-M hi3516av300\` / \`-M hi3516av200\` (no immediate crash)
- [ ] OpenIPC firmware boot — deferred until firmware images exist for these targets
- [ ] CI builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)