### PR TITLE
hisi: emulate on-die HWRNG/TRNG block per SoC (unblocks Majestic)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -228,6 +228,10 @@ static const HisiSoCConfig hi3516cv200_soc = {
     .soc_id             = HISI_SOC_ID_CV200,
     .chipid_byte_layout = true,            /* V2: byte-wise SCSYSID0..3 */
     .chip_variant       = 1,               /* 1 = 3516CV200 (vs 2=18EV200, 3=18EV201) */
+    /* V2 RNG_GEN block — different layout from V3+ HISEC_TRNG_CTRL,
+     * data register at +0x004 instead of +0x204. */
+    .hwrng_base         = 0x20280000,
+    .hwrng_data_offset  = 0x004,
     /* 64 MiB on-chip DDR2 (512Mb).  Kernel gets 32 MiB, vendor mmz.ko
      * claims the upper 32 MiB at 0x82000000. */
     .ram_size_default   = 64 * MiB,
@@ -438,6 +442,8 @@ static const HisiSoCConfig hi3516cv300_soc = {
     .soc_id             = HISI_SOC_ID_CV300,
     .chipid_byte_layout = true,            /* V3: byte-wise SCSYSID0..3 */
     .default_sensor     = "imx291",        /* Sony 1080p Starvis on V3 ref boards */
+    .hwrng_base         = 0x120C0000,      /* HISEC_TRNG_CTRL (V3) */
+    .hwrng_data_offset  = 0x204,
     /* CV300 has no on-chip DDR (external DDR3/3L up to 512 MiB).
      * Stock CV300 cameras ship 128 MiB.  Kernel gets 32 MiB, vendor
      * mmz.ko claims the upper 96 MiB at 0x82000000. */
@@ -509,6 +515,10 @@ static const HisiSoCConfig hi3516cv500_soc = {
     .desc               = "HiSilicon Hi3516CV500 (Cortex-A7, dual-core)",
     .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a7"),
     .soc_id             = HISI_SOC_ID_CV500,
+    /* HISEC_TRNG_CTRL block at 0x10090000 (RSA at 0x10080000 displaces
+     * TRNG up by 0x10000 vs V4); data register at +0x204. */
+    .hwrng_base         = 0x10090000,
+    .hwrng_data_offset  = 0x204,
     /* CV500 has no on-chip DDR (external DDR3(L)/DDR4 up to 1 GiB).
      * Stock CV500 cameras ship 128 MiB.  Kernel gets 32 MiB, vendor
      * mmz.ko claims the upper 96 MiB at 0x82000000. */
@@ -625,6 +635,9 @@ static const HisiSoCConfig hi3516av300_soc = {
     .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a7"),
     .soc_id             = HISI_SOC_ID_AV300,
     .default_sensor     = "imx415",        /* Sony 4K Starvis on AV300 ref boards */
+    /* Inherits CV500 family TRNG layout (no separate AV300 datasheet). */
+    .hwrng_base         = 0x10090000,
+    .hwrng_data_offset  = 0x204,
     /* Same memory layout as CV500: external DDR, 128 MiB typical. */
     .ram_size_default   = 128 * MiB,
     .kernel_mem_mb      = 32,
@@ -741,6 +754,8 @@ static const HisiSoCConfig hi3519v101_soc = {
     .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a7"),
     .soc_id             = HISI_SOC_ID_19V101,
     .chipid_byte_layout = true,            /* V3A: byte-wise SCSYSID0..3 */
+    .hwrng_base         = 0x120C0000,      /* HISEC_TRNG_CTRL (V3A) */
+    .hwrng_data_offset  = 0x204,
     /* 3519V101 has no on-chip DDR (external DDR4/3/3L up to 2 GiB dual).
      * 4K/WDR boards typically ship 256 MiB.  Kernel gets 32 MiB, vendor
      * mmz.ko claims the upper 224 MiB at 0x82000000. */
@@ -847,6 +862,8 @@ static const HisiSoCConfig hi3516av200_soc = {
     .chipid_byte_layout = true,
     .chip_variant       = 5,                     /* SCSYSID0 byte 5 = 3516AV200 */
     .default_sensor     = "imx385",              /* Sony 1080p Starvis on AV200 ref boards */
+    .hwrng_base         = 0x120C0000,            /* same as 3519V101 family */
+    .hwrng_data_offset  = 0x204,
     .ram_size_default   = 256 * MiB,
     .kernel_mem_mb      = 32,
     .extra_cmdline      = "mmz_allocator=hisi "
@@ -942,6 +959,8 @@ static const HisiSoCConfig hi3516ev300_soc = {
     .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a7"),
     .soc_id             = HISI_SOC_ID_EV300,
     .default_sensor     = "imx335",        /* Sony 5MP on EV300 ref boards */
+    .hwrng_base         = 0x10080000,      /* HISEC_TRNG_CTRL (V4) */
+    .hwrng_data_offset  = 0x204,
     /* 128 MiB on-chip DDR3L (1Gb).  Kernel gets 32 MiB, vendor mmz.ko
      * claims 96 MiB at 0x42000000 — matches the canonical EV300 layout
      * documented in OpenIPC's /usr/bin/load_hisilicon. */
@@ -1040,6 +1059,8 @@ static const HisiSoCConfig hi3516ev200_soc = {
     .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a7"),
     .soc_id             = HISI_SOC_ID_EV200,
     .default_sensor     = "imx307",        /* Sony 1080p Starvis on EV200 ref boards */
+    .hwrng_base         = 0x10080000,      /* HISEC_TRNG_CTRL (V4) */
+    .hwrng_data_offset  = 0x204,
     /* 64 MiB on-chip DDR2 (512Mb).  Kernel gets 32 MiB, vendor mmz.ko
      * claims the upper 32 MiB at 0x42000000 — matches the canonical
      * EV200 layout documented in OpenIPC's /usr/bin/load_hisilicon. */
@@ -1119,6 +1140,8 @@ static const HisiSoCConfig hi3518ev300_soc = {
     .desc               = "HiSilicon Hi3518EV300 (Cortex-A7)",
     .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a7"),
     .soc_id             = HISI_SOC_ID_18EV300,
+    .hwrng_base         = 0x10080000,      /* HISEC_TRNG_CTRL (V4) */
+    .hwrng_data_offset  = 0x204,
     /* 64 MiB on-chip DDR2 (512Mb).  Kernel gets 32 MiB, vendor mmz.ko
      * claims the upper 32 MiB at 0x42000000 — matches the canonical
      * 18EV300 layout documented in OpenIPC's /usr/bin/load_hisilicon. */
@@ -1195,6 +1218,8 @@ static const HisiSoCConfig hi3516dv200_soc = {
     .desc               = "HiSilicon Hi3516DV200 (Cortex-A7)",
     .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a7"),
     .soc_id             = HISI_SOC_ID_DV200,
+    .hwrng_base         = 0x10080000,      /* HISEC_TRNG_CTRL (V4) */
+    .hwrng_data_offset  = 0x204,
     /* DV200 has no on-chip DDR (external DDR3/3L up to 512 MiB).
      * Stock OpenIPC DV200 cameras ship 128 MiB.  Kernel gets 32 MiB,
      * vendor mmz.ko claims the upper 96 MiB at 0x42000000. */
@@ -1337,6 +1362,8 @@ static const HisiSoCConfig hi3516dv200_soc = {
     .wdt_base           = 0x12030000,                       \
     .wdt_irq            = 2,                                \
     .wdt_freq           = 3000000,                          \
+    .hwrng_base         = 0x10080000,                       \
+    .hwrng_data_offset  = 0x204,                            \
     .num_regbanks       = 15,                               \
     .regbanks           = {                                 \
         { "hisi-misc",       0x12028000, 0x8000  },         \
@@ -2509,6 +2536,16 @@ static void hisilicon_common_init(MachineState *machine,
         sysbus_mmio_map(busdev, 1, c->jpge_base);
         sysbus_connect_irq(busdev, 0, pic[c->vedu_irq]);
         sysbus_connect_irq(busdev, 1, pic[c->jpge_irq]);
+    }
+
+    /* Hardware True Random Number Generator
+     * (HISEC_TRNG_CTRL on V3+, RNG_GEN on V2) */
+    if (c->hwrng_base) {
+        DeviceState *rng = qdev_new("hisi-hwrng");
+        qdev_prop_set_uint32(rng, "data-offset", c->hwrng_data_offset);
+        SysBusDevice *busdev = SYS_BUS_DEVICE(rng);
+        sysbus_realize_and_unref(busdev, &error_fatal);
+        sysbus_mmio_map(busdev, 0, c->hwrng_base);
     }
 
     /* Watchdog (SP805-compatible, reuse cmsdk-apb-watchdog) */

--- a/qemu/hw/misc/hisi-hwrng.c
+++ b/qemu/hw/misc/hisi-hwrng.c
@@ -1,0 +1,158 @@
+/*
+ * HiSilicon Hardware True Random Number Generator (HWRNG / TRNG).
+ *
+ * Two register layouts exist in the silicon, both modelled here via the
+ * "data-offset" QOM property:
+ *
+ *   V3+ (HISEC_TRNG_CTRL block):
+ *     base + 0x000  HISEC_COM_TRNG_CTRL       — control (osc_sel, drbg_enable, …)
+ *     base + 0x204  HISEC_COM_TRNG_FIFO_DATA  — fresh random word per read
+ *     base + 0x208  HISEC_COM_TRNG_DATA_ST    — fifo_data_count [13:8]
+ *
+ *   V2 (RNG_GEN block on Hi3516CV200):
+ *     base + 0x000  RNG_CTRL
+ *     base + 0x004  RNG_FIFO_DATA
+ *     base + 0x008  RNG_STAT                  — rng_data_count [2:0]
+ *
+ * The OpenIPC out-of-tree driver (openhisilicon/kernel/hisi-hwrng) is
+ * naive: it ioremaps the data register directly and never checks the
+ * status register, so its behaviour is satisfied by always returning a
+ * fresh random word on data-register reads.  We additionally answer the
+ * status register with a non-empty FIFO indication so any future driver
+ * that polls properly will also see "data available".
+ *
+ * Random source: qemu_guest_getrandom_nofail() — cryptographic, never
+ * blocks the guest, exactly 4 bytes per access.
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * Written by Dmitry Ilyin
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/sysbus.h"
+#include "hw/qdev-properties.h"
+#include "qemu/log.h"
+#include "qemu/guest-random.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_HWRNG "hisi-hwrng"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiHwrngState, HISI_HWRNG)
+
+/* Datasheet allocation is 64 KiB across every documented variant. */
+#define HISI_HWRNG_REGION_SIZE  0x10000
+
+/* Status register sits 4 bytes above the data register on every variant. */
+#define HISI_HWRNG_STATUS_DELTA 0x004
+
+/* Pretend the FIFO has 32 words queued: V3+ uses fifo_data_count[13:8]
+ * (so value = 0x20 << 8), V2 uses rng_data_count[2:0] (low 3 bits = 7).
+ * We OR both fields so the same constant satisfies either layout. */
+#define HISI_HWRNG_STATUS_VALUE ((0x20u << 8) | 0x7u)
+
+struct HisiHwrngState {
+    SysBusDevice parent_obj;
+    MemoryRegion iomem;
+
+    /* QOM property: register-map variant.
+     *   0x204 — V3+ HISEC_TRNG_CTRL (CV300/CV500/3519V101/AV200/AV300/V4)
+     *   0x004 — V2  RNG_GEN         (CV200) */
+    uint32_t data_offset;
+
+    /* Last value written to the control register (offset 0x000).
+     * Real silicon has writable bits (osc_sel, drbg_enable, mix_enable,
+     * …); we don't model them but echo writes back so any driver that
+     * reads the control register doesn't see a surprise zero. */
+    uint32_t ctrl;
+};
+
+static uint64_t hisi_hwrng_read(void *opaque, hwaddr offset, unsigned size)
+{
+    HisiHwrngState *s = HISI_HWRNG(opaque);
+
+    if (offset == s->data_offset) {
+        uint32_t word;
+        qemu_guest_getrandom_nofail(&word, sizeof(word));
+        return word;
+    }
+
+    if (offset == s->data_offset + HISI_HWRNG_STATUS_DELTA) {
+        return HISI_HWRNG_STATUS_VALUE;
+    }
+
+    if (offset == 0x000) {
+        return s->ctrl;
+    }
+
+    qemu_log_mask(LOG_UNIMP,
+                  "hisi-hwrng: read from unimplemented offset 0x%" HWADDR_PRIx
+                  "\n", offset);
+    return 0;
+}
+
+static void hisi_hwrng_write(void *opaque, hwaddr offset, uint64_t val,
+                             unsigned size)
+{
+    HisiHwrngState *s = HISI_HWRNG(opaque);
+
+    if (offset == 0x000) {
+        s->ctrl = (uint32_t)val;
+        return;
+    }
+
+    qemu_log_mask(LOG_UNIMP,
+                  "hisi-hwrng: write 0x%" PRIx64 " to unimplemented offset "
+                  "0x%" HWADDR_PRIx "\n", val, offset);
+}
+
+static const MemoryRegionOps hisi_hwrng_ops = {
+    .read = hisi_hwrng_read,
+    .write = hisi_hwrng_write,
+    .endianness = DEVICE_LITTLE_ENDIAN,
+    .valid.min_access_size = 4,
+    .valid.max_access_size = 4,
+};
+
+static void hisi_hwrng_reset(DeviceState *dev)
+{
+    HisiHwrngState *s = HISI_HWRNG(dev);
+    s->ctrl = 0;
+}
+
+static void hisi_hwrng_init(Object *obj)
+{
+    HisiHwrngState *s = HISI_HWRNG(obj);
+    SysBusDevice *sbd = SYS_BUS_DEVICE(obj);
+
+    memory_region_init_io(&s->iomem, obj, &hisi_hwrng_ops, s,
+                          "hisi-hwrng", HISI_HWRNG_REGION_SIZE);
+    sysbus_init_mmio(sbd, &s->iomem);
+}
+
+static const Property hisi_hwrng_properties[] = {
+    DEFINE_PROP_UINT32("data-offset", HisiHwrngState, data_offset, 0x204),
+};
+
+static void hisi_hwrng_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+
+    device_class_set_legacy_reset(dc, hisi_hwrng_reset);
+    device_class_set_props(dc, hisi_hwrng_properties);
+}
+
+static const TypeInfo hisi_hwrng_info = {
+    .name          = TYPE_HISI_HWRNG,
+    .parent        = TYPE_SYS_BUS_DEVICE,
+    .instance_size = sizeof(HisiHwrngState),
+    .instance_init = hisi_hwrng_init,
+    .class_init    = hisi_hwrng_class_init,
+};
+
+static void hisi_hwrng_register_types(void)
+{
+    type_register_static(&hisi_hwrng_info);
+}
+
+type_init(hisi_hwrng_register_types)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -188,6 +188,11 @@ typedef struct HisiSoCConfig {
     /* Hardware GZIP decompressor */
     hwaddr          gzip_base;      /* 0 = no GZIP engine */
 
+    /* Hardware True Random Number Generator
+     * (HISEC_TRNG_CTRL on V3+, RNG_GEN on V2) */
+    hwaddr          hwrng_base;        /* 0 = no HWRNG on this SoC */
+    uint32_t        hwrng_data_offset; /* 0x204 V3+, 0x004 V2 */
+
     /* CPU soft-reset register offset in CRG (for SMP bringup) */
     uint32_t        cpu_srst_offset; /* 0 = disabled, e.g. 0x78 for CV500 */
 

--- a/qemu/setup.sh
+++ b/qemu/setup.sh
@@ -45,6 +45,7 @@ cp qemu/hw/misc/hisi-vedu.c         "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-mipi-rx.c      "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-rtc.c          "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-ive.c          "$QEMU_DIR/hw/misc/"
+cp qemu/hw/misc/hisi-hwrng.c        "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-fastboot.c     "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-gzip.c        "$QEMU_DIR/hw/misc/"
 cp qemu/hw/net/hisi-femac.c         "$QEMU_DIR/hw/net/"
@@ -133,11 +134,17 @@ fi
 
 # hw/misc/meson.build
 if ! grep -q hisi-sysctl "$QEMU_DIR/hw/misc/meson.build"; then
-    echo "system_ss.add(when: 'CONFIG_HISI_MISC', if_true: files('hisi-sysctl.c', 'hisi-crg.c', 'hisi-fmc.c', 'hisi-sfc350.c', 'hisi-himci.c', 'hisi-regbank.c', 'hisi-vedu.c', 'hisi-mipi-rx.c', 'hisi-rtc.c', 'hisi-ive.c', 'hisi-fastboot.c', 'hisi-gzip.c'))" \
+    echo "system_ss.add(when: 'CONFIG_HISI_MISC', if_true: files('hisi-sysctl.c', 'hisi-crg.c', 'hisi-fmc.c', 'hisi-sfc350.c', 'hisi-himci.c', 'hisi-regbank.c', 'hisi-vedu.c', 'hisi-mipi-rx.c', 'hisi-rtc.c', 'hisi-ive.c', 'hisi-fastboot.c', 'hisi-gzip.c', 'hisi-hwrng.c'))" \
         >> "$QEMU_DIR/hw/misc/meson.build"
     echo "  patched hw/misc/meson.build"
 else
-    echo "  hw/misc/meson.build already patched"
+    if ! grep -q hisi-hwrng "$QEMU_DIR/hw/misc/meson.build"; then
+        sed -i "s/'hisi-gzip.c'/'hisi-gzip.c', 'hisi-hwrng.c'/" \
+            "$QEMU_DIR/hw/misc/meson.build"
+        echo "  hw/misc/meson.build: added hisi-hwrng.c"
+    else
+        echo "  hw/misc/meson.build already patched"
+    fi
 fi
 
 # hw/net/Kconfig


### PR DESCRIPTION
## Summary

New `qemu/hw/misc/hisi-hwrng.c` — single SysBusDevice modeling the HiSilicon TRNG block on every documented SoC generation, parameterised by data-register offset (V3+ HISEC_TRNG_CTRL: `+0x204`, V2 RNG_GEN: `+0x004`). Reads at the data offset return 4 bytes from `qemu_guest_getrandom_nofail()`; reads at the status offset return a non-empty FIFO indicator so polled drivers also see data available.

Per-SoC base addresses lifted directly from the datasheet memory maps:

| SoC | hwrng_base | data offset |
|---|---|---|
| `hi3516cv200` (V2) | `0x20280000` | `+0x004` (RNG_GEN) |
| `hi3516cv300` (V3) | `0x120C0000` | `+0x204` |
| `hi3516cv500` (V3.5) | `0x10090000` | `+0x204` |
| `hi3516av300` (V4A, CV500 family) | `0x10090000` | `+0x204` |
| `hi3519v101` (V3A) | `0x120C0000` | `+0x204` |
| `hi3516av200` (V3A, 3519V101 family) | `0x120C0000` | `+0x204` |
| `hi3516ev200/EV300/18EV300/DV200` (V4) | `0x10080000` | `+0x204` |
| Goke V4 + V4-compat (gk7205v200/300, gk7202v300, gk7605v100, v500/v510/v530, v330) | same as V4 | via `HISI_V4_COMMON_PERIPH` macro |

V1 (CV100), V2A (AV100), V5 (CV608/CV610/CV613) have no TRNG documented in their datasheets and stay unmapped (`hwrng_base = 0`).

## Why

OpenIPC's `openhisilicon/kernel/hisi-hwrng` ioremaps `0x10080204` directly and reads it from a background kthread. Until now that physical address was unmapped on QEMU, so loading the module oopsed. Without the kthread feeding the kernel entropy pool, Majestic — which links `libevent` + `libevent_mbedtls` and needs entropy to bring up its HTTP server — would print its version banner and go silent forever waiting on `getrandom()`.

## Test plan

- [x] `qemu-system-arm -M hi3516ev300,sensor=none` boots to login
- [x] `insmod /lib/modules/4.9.37/extra/hisi-hwrng.ko` → `rc=0`, kthread `[hisi-hwrng]` alive, dmesg shows `random: fast init done`
- [x] `/proc/sys/kernel/random/entropy_avail`: 0 → 1299 in 4 s
- [x] `dd if=/dev/random bs=32 count=1` returns instantly with random bytes
- [x] **Majestic now gets past the banner**: starts HTTP server on `:::80`, loads config — only stops at sensor autodetection (which is `sensor=none` in this test, expected). Previous behavior: silent for 25 s after banner, then SIGTERM.
- [ ] Existing CI matrix: `hi3516ev300` boot job (`sensor=none`) still reaches login, all per-machine boots remain green. New device is gated on `hwrng_base != 0`, no impact on V1/V2A/V5 paths.

## Follow-up

To make this work out-of-the-box on real OpenIPC firmware boots, the firmware's `/etc/init.d/S35modules` (or a new init script) needs to load `hisi-hwrng.ko` before `S95majestic` runs. That's an OpenIPC firmware change, separate from this PR. Captured boot/test log saved to `qemu-boot/qemu-ev300-hwrng-success.log` for reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)