### PR TITLE
hisi: don't inject SoC-default extra_cmdline when user overrides -m or mmz=

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2761,10 +2761,19 @@ static void hisilicon_common_init(MachineState *machine,
          */
         const char *user_cmdline = machine->kernel_cmdline ?: "";
         bool has_mem = strstr(user_cmdline, "mem=") != NULL;
+        bool has_mmz = strstr(user_cmdline, "mmz=") != NULL ||
+                       strstr(user_cmdline, "mmz_allocator=") != NULL;
+        /* If the user shrank -m below the SoC default, our SoC-default
+         * extra_cmdline (e.g. "mmz=anonymous,0,0x82000000,224M") would
+         * pin a CMA region past the actual end of memory and the kernel
+         * would panic before producing any console output.  Treat the
+         * smaller -m as opt-out from the default MMZ pin. */
+        bool ram_overridden = machine->ram_size < c->ram_size_default;
         bool has_extra = c->extra_cmdline &&
                          strstr(user_cmdline, c->extra_cmdline) != NULL;
         bool want_mem = c->kernel_mem_mb && !has_mem;
-        bool want_extra = c->extra_cmdline && !has_extra;
+        bool want_extra = c->extra_cmdline && !has_extra &&
+                          !has_mmz && !ram_overridden;
 
         if (want_mem || want_extra) {
             GString *cl = g_string_new(user_cmdline);


### PR DESCRIPTION
## Summary

Fix two regressions in OpenIPC/openhisilicon CI introduced by PR #50 (per-SoC RAM/MMZ defaults).

`hisilicon_common_init()` previously appended the SoC's default `mmz=` pin whenever the user's \`-append\` didn't already contain that exact string. Two CI scenarios got bitten:

1. **`QEMU boot (hi3519v101)`** — CI passes \`-m 64M -append "...mem=64M..."\`. Our 3519V101 default \`extra_cmdline\` pins MMZ as \`mmz=anonymous,0,0x82000000,224M\`. With \`-m 64M\`, RAM ends at \`0x84000000\`, so the 224 MiB CMA reservation at offset 32 MiB overran the actual end of memory and the kernel panicked **before producing any console output** (\`qemu-output.txt\` was empty except for the timeout message).
2. **`QEMU IVE ops regression`** — CI passes \`-m 128M -append "...mem=96M mmz_allocator=hisi mmz=anonymous,0,0x46000000,32M"\`. The user supplied a different `mmz=` pin, but `strstr()` didn't match the SoC-default exact string, so we appended a *second* `mmz=` line and the kernel got two conflicting CMA hints — same silent-CMA-crash symptom.

## Fix

Two new gates on `want_extra`:

```c
bool has_mmz = strstr(user_cmdline, "mmz=") != NULL ||
               strstr(user_cmdline, "mmz_allocator=") != NULL;
bool ram_overridden = machine->ram_size < c->ram_size_default;
bool want_extra = c->extra_cmdline && !has_extra &&
                  !has_mmz && !ram_overridden;
```

Either of `has_mmz` or `ram_overridden` means "user is opting out of the SoC-default MMZ layout" — injecting our default would corrupt theirs.

## Test plan

- [x] Local: `qemu-system-arm -M hi3519v101 -m 64M -kernel uImage.hi3519v101 -initrd rootfs.squashfs.hi3519v101 -append "console=ttyAMA0,115200 mem=64M root=/dev/ram0 rootfstype=squashfs"` now boots — kernel reports \`Memory: 38176K/65536K available\` and the cmdline is preserved exactly.
- [ ] Re-run openhisilicon CI after merge — both `QEMU boot (hi3519v101)` and `QEMU IVE ops regression` should pass again.
- [ ] widgetii/qemu-hisilicon CI — all per-machine boots should remain green (the new gates only **suppress** an injection that would otherwise overlay the user's layout; default behavior with no `-m` or `-append` overrides is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)