### PR TITLE
hisi: VI frame-producer device + EV300 wiring (MVP toward streaming)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -961,6 +961,15 @@ static const HisiSoCConfig hi3516ev300_soc = {
     .default_sensor     = "imx335",        /* Sony 5MP on EV300 ref boards */
     .hwrng_base         = 0x10080000,      /* HISEC_TRNG_CTRL (V4) */
     .hwrng_data_offset  = 0x204,
+    /* MVP video pipeline IRQ heartbeat — pulses VI_CAP0/VI_PROC0/VPSS
+     * at 25 Hz so the vendor MPP modules' IRQ handlers run and Majestic
+     * gets past its "Timeout from venc channel 0" loop.
+     * SPI numbers are GIC absolute IRQ - 32 (per /proc/interrupts the
+     * kernel shows GIC-75/76/78 for VI_CAP0/VI_PROC0/VPSS). */
+    .vi_fp_base         = 0x11FE0000,      /* unused gap above vedu/jpge */
+    .vi_fp_cap_irq      = 43,              /* VI_CAP0  = SPI 43 (GIC 75) */
+    .vi_fp_proc_irq     = 44,              /* VI_PROC0 = SPI 44 (GIC 76) */
+    .vi_fp_vpss_irq     = 46,              /* VPSS     = SPI 46 (GIC 78) */
     /* 128 MiB on-chip DDR3L (1Gb).  Kernel gets 32 MiB, vendor mmz.ko
      * claims 96 MiB at 0x42000000 — matches the canonical EV300 layout
      * documented in OpenIPC's /usr/bin/load_hisilicon. */
@@ -2546,6 +2555,18 @@ static void hisilicon_common_init(MachineState *machine,
         SysBusDevice *busdev = SYS_BUS_DEVICE(rng);
         sysbus_realize_and_unref(busdev, &error_fatal);
         sysbus_mmio_map(busdev, 0, c->hwrng_base);
+    }
+
+    /* VI frame producer — periodic VI_CAP/VI_PROC/VPSS IRQ heartbeat
+     * to wake the vendor MPP pipeline.  MVP, EV300 only for now. */
+    if (c->vi_fp_base) {
+        DeviceState *vifp = qdev_new("hisi-vi-fp");
+        SysBusDevice *busdev = SYS_BUS_DEVICE(vifp);
+        sysbus_realize_and_unref(busdev, &error_fatal);
+        sysbus_mmio_map(busdev, 0, c->vi_fp_base);
+        sysbus_connect_irq(busdev, 0, pic[c->vi_fp_cap_irq]);
+        sysbus_connect_irq(busdev, 1, pic[c->vi_fp_proc_irq]);
+        sysbus_connect_irq(busdev, 2, pic[c->vi_fp_vpss_irq]);
     }
 
     /* Watchdog (SP805-compatible, reuse cmsdk-apb-watchdog) */

--- a/qemu/hw/misc/hisi-vi-fp.c
+++ b/qemu/hw/misc/hisi-vi-fp.c
@@ -1,0 +1,246 @@
+/*
+ * HiSilicon Video Input Frame Producer (QEMU emulation helper).
+ *
+ * MVP scaffolding to wake the vendor VI / VPSS / VENC pipeline on QEMU.
+ *
+ * On real silicon the MIPI receiver delivers a CSI-2 frame to a VI capture
+ * buffer in DDR, and the VI hardware fires the VI_CAP IRQ (followed by
+ * VI_PROC then VPSS once the frame walks through the pipeline).  Without
+ * any of that hardware on QEMU the vendor VENC blob blocks forever in
+ * its "wait for next encoded frame" loop, hence Majestic's repeating
+ *   "Timeout from venc channel 0"
+ * messages.
+ *
+ * This device fires the VI_CAP / VI_PROC / VPSS IRQ lines on a periodic
+ * timer matching the configured sensor framerate (default 25 fps).  No
+ * MMIO contract — vendor VI / VPSS register state is whatever the RAM-
+ * backed regbanks behind 0x11000000 / 0x11200000 / 0x11400000 carry,
+ * which is "all zeros at reset, then whatever the vendor wrote".  The
+ * IRQ alone is enough to make the vendor's IRQ-route routines run; how
+ * far the pipeline gets is then a function of the regbank state.
+ *
+ * Wired only on hi3516ev300 as MVP (HisiSoCConfig.vi_fp_base != 0).
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * Written by Dmitry Ilyin
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/sysbus.h"
+#include "hw/irq.h"
+#include "hw/qdev-properties.h"
+#include "qemu/timer.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_VI_FP "hisi-vi-fp"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiViFpState, HISI_VI_FP)
+
+/* Tiny placeholder MMIO; sysbus requires at least one region but the
+ * guest has no driver for this address. */
+#define VI_FP_REGION_SIZE  0x100
+
+/* Inter-stage delay so VI_CAP -> VI_PROC -> VPSS arrive in plausible
+ * temporal order on the IRQ controller. */
+#define VI_FP_STAGE_DELAY_NS    1000   /* 1 us */
+
+struct HisiViFpState {
+    SysBusDevice parent_obj;
+    MemoryRegion iomem;
+
+    /* IRQ outputs, in pipeline order. */
+    qemu_irq irq_vi_cap;
+    qemu_irq irq_vi_proc;
+    qemu_irq irq_vpss;
+
+    /* Sensor framerate from QOM property (default 25 fps). */
+    uint32_t fps;
+
+    /* Periodic frame timer. */
+    QEMUTimer *frame_timer;
+
+    /* IRQ heartbeat enable.
+     *   Guest writes 1 to MMIO offset 0x000 to start the heartbeat
+     *   (typically from a userspace script after vendor MPP modules
+     *   are fully initialised — firing earlier hits NULL pointers
+     *   inside the vendor IRQ handlers).
+     *   Writing 0 stops it. */
+    uint32_t  enable;
+
+    /* Pulse counters for /sysctl-style introspection during bring-up. */
+    uint64_t  pulses;
+};
+
+/* MMIO map (16 bytes total):
+ *   0x000  CTRL    RW   bit 0 = enable IRQ heartbeat (start/stop)
+ *   0x004  STATUS  RO   pulse counter (low 32 bits)
+ *   0x008  FPS     RW   frames per second (overrides QOM property)
+ */
+#define VI_FP_REG_CTRL    0x000
+#define VI_FP_REG_STATUS  0x004
+#define VI_FP_REG_FPS     0x008
+
+static uint64_t hisi_vi_fp_read(void *opaque, hwaddr offset, unsigned size)
+{
+    HisiViFpState *s = HISI_VI_FP(opaque);
+
+    switch (offset) {
+    case VI_FP_REG_CTRL:
+        return s->enable;
+    case VI_FP_REG_STATUS:
+        return (uint32_t)(s->pulses & 0xFFFFFFFF);
+    case VI_FP_REG_FPS:
+        return s->fps;
+    }
+    return 0;
+}
+
+static void hisi_vi_fp_arm_timer(HisiViFpState *s)
+{
+    uint32_t period_ms = s->fps ? (1000U / s->fps) : 40U;
+    timer_mod(s->frame_timer,
+              qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL) + period_ms);
+}
+
+static void hisi_vi_fp_write(void *opaque, hwaddr offset,
+                             uint64_t val, unsigned size)
+{
+    HisiViFpState *s = HISI_VI_FP(opaque);
+
+    switch (offset) {
+    case VI_FP_REG_CTRL: {
+        uint32_t prev = s->enable;
+        s->enable = val & 1;
+        if (s->enable && !prev) {
+            qemu_log_mask(LOG_GUEST_ERROR,
+                          "hisi-vi-fp: heartbeat ENABLED at %u fps\n",
+                          s->fps);
+            hisi_vi_fp_arm_timer(s);
+        } else if (!s->enable && prev) {
+            qemu_log_mask(LOG_GUEST_ERROR,
+                          "hisi-vi-fp: heartbeat DISABLED (pulses=%llu)\n",
+                          (unsigned long long)s->pulses);
+            timer_del(s->frame_timer);
+            /* Drop any held-high IRQ lines so masked vendor handlers
+             * don't see a phantom level on rmmod. */
+            qemu_set_irq(s->irq_vi_cap, 0);
+            qemu_set_irq(s->irq_vi_proc, 0);
+            qemu_set_irq(s->irq_vpss, 0);
+        }
+        return;
+    }
+    case VI_FP_REG_FPS:
+        if (val) {
+            s->fps = val;
+        }
+        return;
+    }
+}
+
+static const MemoryRegionOps hisi_vi_fp_ops = {
+    .read = hisi_vi_fp_read,
+    .write = hisi_vi_fp_write,
+    .endianness = DEVICE_LITTLE_ENDIAN,
+    .valid.min_access_size = 4,
+    .valid.max_access_size = 4,
+};
+
+static void hisi_vi_fp_tick(void *opaque)
+{
+    HisiViFpState *s = HISI_VI_FP(opaque);
+
+    if (!s->enable) {
+        return;
+    }
+
+    /* GIC SPIs are configured level-sensitive in the vendor DT, so
+     * pulse() (raise+lower in the same step) is missed.  Drop the
+     * lines low then assert and HOLD them high; the next tick lowers
+     * them before re-asserting — the handler runs in between. */
+    qemu_set_irq(s->irq_vi_cap, 0);
+    qemu_set_irq(s->irq_vi_proc, 0);
+    qemu_set_irq(s->irq_vpss, 0);
+    qemu_set_irq(s->irq_vi_cap, 1);
+    qemu_set_irq(s->irq_vi_proc, 1);
+    qemu_set_irq(s->irq_vpss, 1);
+
+    s->pulses++;
+    if (s->pulses <= 5 || (s->pulses % 25) == 0) {
+        qemu_log_mask(LOG_GUEST_ERROR,
+                      "hisi-vi-fp: pulse #%llu fired VI_CAP/VI_PROC/VPSS\n",
+                      (unsigned long long)s->pulses);
+    }
+
+    /* Reschedule. */
+    hisi_vi_fp_arm_timer(s);
+}
+
+static void hisi_vi_fp_realize(DeviceState *dev, Error **errp)
+{
+    HisiViFpState *s = HISI_VI_FP(dev);
+
+    s->frame_timer = timer_new_ms(QEMU_CLOCK_VIRTUAL,
+                                  hisi_vi_fp_tick, s);
+    /* Don't start firing yet — guest must explicitly enable via
+     * MMIO write to VI_FP_REG_CTRL once the vendor MPP modules and
+     * Majestic are fully initialised.  Firing earlier hits NULL
+     * pointers inside vendor IRQ handlers (verified empirically:
+     * VI_DRV_IspIsr@open_vi.ko derefs NULL during insmod). */
+}
+
+static void hisi_vi_fp_init(Object *obj)
+{
+    HisiViFpState *s = HISI_VI_FP(obj);
+    SysBusDevice *sbd = SYS_BUS_DEVICE(obj);
+
+    memory_region_init_io(&s->iomem, obj, &hisi_vi_fp_ops, s,
+                          "hisi-vi-fp", VI_FP_REGION_SIZE);
+    sysbus_init_mmio(sbd, &s->iomem);
+
+    sysbus_init_irq(sbd, &s->irq_vi_cap);
+    sysbus_init_irq(sbd, &s->irq_vi_proc);
+    sysbus_init_irq(sbd, &s->irq_vpss);
+}
+
+static void hisi_vi_fp_reset(DeviceState *dev)
+{
+    HisiViFpState *s = HISI_VI_FP(dev);
+    s->pulses = 0;
+    s->enable = 0;
+    if (s->frame_timer) {
+        timer_del(s->frame_timer);
+    }
+    qemu_set_irq(s->irq_vi_cap, 0);
+    qemu_set_irq(s->irq_vi_proc, 0);
+    qemu_set_irq(s->irq_vpss, 0);
+}
+
+static const Property hisi_vi_fp_properties[] = {
+    DEFINE_PROP_UINT32("fps", HisiViFpState, fps, 25),
+};
+
+static void hisi_vi_fp_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+
+    dc->realize = hisi_vi_fp_realize;
+    device_class_set_legacy_reset(dc, hisi_vi_fp_reset);
+    device_class_set_props(dc, hisi_vi_fp_properties);
+}
+
+static const TypeInfo hisi_vi_fp_info = {
+    .name          = TYPE_HISI_VI_FP,
+    .parent        = TYPE_SYS_BUS_DEVICE,
+    .instance_size = sizeof(HisiViFpState),
+    .instance_init = hisi_vi_fp_init,
+    .class_init    = hisi_vi_fp_class_init,
+};
+
+static void hisi_vi_fp_register_types(void)
+{
+    type_register_static(&hisi_vi_fp_info);
+}
+
+type_init(hisi_vi_fp_register_types)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -193,6 +193,14 @@ typedef struct HisiSoCConfig {
     hwaddr          hwrng_base;        /* 0 = no HWRNG on this SoC */
     uint32_t        hwrng_data_offset; /* 0x204 V3+, 0x004 V2 */
 
+    /* VI frame producer — periodic VI/VPSS IRQ pulses to wake the
+     * vendor MPP pipeline so VENC stops timing out.  MVP scaffolding,
+     * wired only on hi3516ev300 for now. */
+    hwaddr          vi_fp_base;        /* 0 = no frame producer */
+    int             vi_fp_cap_irq;     /* GIC SPI for VI_CAP0 */
+    int             vi_fp_proc_irq;    /* GIC SPI for VI_PROC0 */
+    int             vi_fp_vpss_irq;    /* GIC SPI for VPSS */
+
     /* CPU soft-reset register offset in CRG (for SMP bringup) */
     uint32_t        cpu_srst_offset; /* 0 = disabled, e.g. 0x78 for CV500 */
 

--- a/qemu/setup.sh
+++ b/qemu/setup.sh
@@ -46,6 +46,7 @@ cp qemu/hw/misc/hisi-mipi-rx.c      "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-rtc.c          "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-ive.c          "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-hwrng.c        "$QEMU_DIR/hw/misc/"
+cp qemu/hw/misc/hisi-vi-fp.c        "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-fastboot.c     "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-gzip.c        "$QEMU_DIR/hw/misc/"
 cp qemu/hw/net/hisi-femac.c         "$QEMU_DIR/hw/net/"
@@ -134,7 +135,7 @@ fi
 
 # hw/misc/meson.build
 if ! grep -q hisi-sysctl "$QEMU_DIR/hw/misc/meson.build"; then
-    echo "system_ss.add(when: 'CONFIG_HISI_MISC', if_true: files('hisi-sysctl.c', 'hisi-crg.c', 'hisi-fmc.c', 'hisi-sfc350.c', 'hisi-himci.c', 'hisi-regbank.c', 'hisi-vedu.c', 'hisi-mipi-rx.c', 'hisi-rtc.c', 'hisi-ive.c', 'hisi-fastboot.c', 'hisi-gzip.c', 'hisi-hwrng.c'))" \
+    echo "system_ss.add(when: 'CONFIG_HISI_MISC', if_true: files('hisi-sysctl.c', 'hisi-crg.c', 'hisi-fmc.c', 'hisi-sfc350.c', 'hisi-himci.c', 'hisi-regbank.c', 'hisi-vedu.c', 'hisi-mipi-rx.c', 'hisi-rtc.c', 'hisi-ive.c', 'hisi-fastboot.c', 'hisi-gzip.c', 'hisi-hwrng.c', 'hisi-vi-fp.c'))" \
         >> "$QEMU_DIR/hw/misc/meson.build"
     echo "  patched hw/misc/meson.build"
 else
@@ -142,8 +143,11 @@ else
         sed -i "s/'hisi-gzip.c'/'hisi-gzip.c', 'hisi-hwrng.c'/" \
             "$QEMU_DIR/hw/misc/meson.build"
         echo "  hw/misc/meson.build: added hisi-hwrng.c"
-    else
-        echo "  hw/misc/meson.build already patched"
+    fi
+    if ! grep -q hisi-vi-fp "$QEMU_DIR/hw/misc/meson.build"; then
+        sed -i "s/'hisi-hwrng.c'/'hisi-hwrng.c', 'hisi-vi-fp.c'/" \
+            "$QEMU_DIR/hw/misc/meson.build"
+        echo "  hw/misc/meson.build: added hisi-vi-fp.c"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Adds `qemu/hw/misc/hisi-vi-fp.c` — a small SysBusDevice that fires the **VI_CAP0 / VI_PROC0 / VPSS** GIC SPI lines on a periodic timer, gated by a guest-controlled MMIO enable register. Wired only on `hi3516ev300`.

This is a foundational piece (MVP) toward making Majestic actually produce encoded frames on QEMU. With the previous PRs in place (#50 mem layout, #51/#53 sensor defaults, #54 HWRNG) Majestic gets all the way through MPP init and starts the RTSP server, but then loops on `Timeout from venc channel 0` because nothing fires the video-input IRQs that the vendor blob's pipeline waits for.

## What this does

- New SysBusDevice with 3 IRQ outputs and a 16-byte MMIO region:
  - `0x000` CTRL — bit 0 = enable IRQ heartbeat
  - `0x004` STATUS — pulse counter
  - `0x008` FPS — frames per second (default 25)
- On EV300, mapped at `0x11FE0000` (gap above vedu/jpge regbanks), IRQs connected to SPI 43 / 44 / 46 (GIC absolute 75 / 76 / 78 = VI_CAP0 / VI_PROC0 / VPSS per `/proc/interrupts`)
- Heartbeat is **disabled at reset**; the guest enables it explicitly via MMIO write once vendor MPP modules and Majestic's SDK init have completed
  - Verified: firing earlier hits NULL pointers in vendor IRQ handlers (`VI_DRV_IspIsr@open_vi.ko` derefs NULL during insmod)
- GIC SPIs are level-sensitive in the vendor DT, so `qemu_irq_pulse()` is missed; the tick handler drives the line low then asserts and holds it high until the next tick

## What this does NOT do (intentional MVP scope)

- **No actual frame data injection** — the device only fires IRQs.
- Vendor IRQ handlers ARE invoked (verified: handler PCs hit) but assert at `VI_COMM_ProcIrqRoute line 1993` because the underlying register state + MMZ buffer pointers a real frame would carry aren't populated. Without disassembling the ~MB of vendor blobs to learn the exact register protocol, full frame production isn't feasible in a single-PR scope.

## Use

```
# After vendor modules + majestic are running:
devmem 0x11FE0000 32 1   # enable heartbeat
devmem 0x11FE0000 32 0   # stop
```

## Test plan

- [x] Local: device registers, IRQ pulses fire (`hisi-vi-fp: pulse #N` log lines), kernel handler `VI_DRV_IspIsr` is reached when handler is installed.
- [x] Other 16 SoC machines: `vi_fp_base = 0` so device is not instantiated; no impact on existing CI.
- [ ] Future: pre-populate VI/VPSS regbank registers with realistic frame metadata + inject test pattern frames so vendor handlers complete instead of asserting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)