### PR TITLE
hisi-vi-fp: pre-populate VI capture/proc status regs + EV300 regbanks

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -1051,9 +1051,20 @@ static const HisiSoCConfig hi3516ev300_soc = {
         { 0x1bc, (1 << 12) | (1 << 13) },/* SPI0/1 clock enable */
     },
 
-    .num_regbanks       = 1,
+    /* Match real EV300 silicon — vendor open_vi.ko / open_vpss.ko /
+     * open_vedu.ko reach for these MMIO blocks; without backing
+     * regbank RAM their writes vanish and reads return 0, which
+     * the vendor IRQ handlers then mistake for a spurious IRQ and
+     * panic ("VI_COMM_ProcIrqRoute line 1993").  Layout from the
+     * V4 family map (also used by the Goke variants via the
+     * HISI_V4_COMMON_PERIPH macro) plus EV300-specific IVE. */
+    .num_regbanks       = 5,
     .regbanks           = {
-        { "hisi-ive",    0x11320000, 0x10000 },
+        { "hisi-vi-cap",     0x11000000, 0x200000 },
+        { "hisi-vi-proc",    0x11200000, 0x40000  },
+        { "hisi-vgs",        0x11300000, 0x10000  },
+        { "hisi-ive",        0x11320000, 0x10000  },
+        { "hisi-vpss",       0x11400000, 0x10000  },
     },
 };
 

--- a/qemu/hw/misc/hisi-vi-fp.c
+++ b/qemu/hw/misc/hisi-vi-fp.c
@@ -34,6 +34,7 @@
 #include "qemu/timer.h"
 #include "qemu/log.h"
 #include "qemu/module.h"
+#include "system/address-spaces.h"
 
 #define TYPE_HISI_VI_FP "hisi-vi-fp"
 OBJECT_DECLARE_SIMPLE_TYPE(HisiViFpState, HISI_VI_FP)
@@ -147,12 +148,64 @@ static const MemoryRegionOps hisi_vi_fp_ops = {
     .valid.max_access_size = 4,
 };
 
+/* "Frame-ready" status pokes — addresses that real silicon raises
+ * before firing the corresponding IRQ.  Reverse-engineered from
+ * /home/john-1/git/openhisilicon/kernel/vi/vi.o:
+ *
+ *   VI_HAL_GetProcIrqStatus(0) returns *(VI_PROC0_BASE + 0x310).
+ *   VI_HAL_IsProcIrqValid(status) returns (status != 0).
+ *   If invalid, VI_COMM_ProcIrqRoute panics at line 1993 — exactly
+ *   what we observed when firing IRQs without populating this register.
+ *
+ * Real-cam value (devmem on openipc-hi3516ev300.dlab.doty.ru, while
+ * Majestic is streaming): 0x06732001 — bit 0 = "frame done", bits 13-26
+ * appear to be a hw timing counter.  The register auto-clears on read.
+ *
+ * Setting any non-zero value satisfies IsProcIrqValid; we use the real
+ * captured value for fidelity. */
+static const struct {
+    hwaddr   addr;
+    uint32_t value;
+    const char *name;
+} hisi_vi_fp_pokes[] = {
+    { 0x11200310, 0x06732001, "VI_PROC0+0x310 (proc IRQ status)" },
+    /* VI_HAL_GetCapIntStatus(0) returns *(VI_CAP0_BASE + 0xF0).
+     * VI_DRV_IsCapValidInt(status) returns ((status & 0xF00) != 0).
+     * If invalid, the kernel decides the IRQ is spurious and after a
+     * few hits disables IRQ #42 — observed before this poke as
+     *   "Disabling IRQ #42"
+     * in dmesg.  Real silicon clears this register on read so it
+     * sampled as 0 over SSH; any value with bits 8-11 set satisfies
+     * the validity check. */
+    { 0x110000F0, 0x00000F00, "VI_CAP0+0xF0   (cap IRQ status, IsCapValidInt mask)" },
+};
+
 static void hisi_vi_fp_tick(void *opaque)
 {
     HisiViFpState *s = HISI_VI_FP(opaque);
+    int i;
 
     if (!s->enable) {
         return;
+    }
+
+    /* Pre-populate hardware status registers the vendor IRQ handlers
+     * read to validate the IRQ is real (otherwise they panic). */
+    for (i = 0; i < ARRAY_SIZE(hisi_vi_fp_pokes); i++) {
+        address_space_stl(&address_space_memory,
+                          hisi_vi_fp_pokes[i].addr,
+                          hisi_vi_fp_pokes[i].value,
+                          MEMTXATTRS_UNSPECIFIED, NULL);
+        if (s->pulses < 3) {
+            uint32_t rb = address_space_ldl(&address_space_memory,
+                                             hisi_vi_fp_pokes[i].addr,
+                                             MEMTXATTRS_UNSPECIFIED, NULL);
+            qemu_log_mask(LOG_GUEST_ERROR,
+                          "hisi-vi-fp: poke %s @0x%llx <- 0x%08x readback=0x%08x\n",
+                          hisi_vi_fp_pokes[i].name,
+                          (unsigned long long)hisi_vi_fp_pokes[i].addr,
+                          hisi_vi_fp_pokes[i].value, rb);
+        }
     }
 
     /* GIC SPIs are configured level-sensitive in the vendor DT, so


### PR DESCRIPTION
## Summary

Follow-up to #56. The MVP heartbeat fired the three IRQ lines but vendor `open_vi.ko` immediately read back hardware status registers to validate that an IRQ was real, and panicked or marked the IRQ spurious when those registers were zero:

- `VI_HAL_IsProcIrqValid(*(VI_PROC0+0x310))` returns false → `VI_COMM_ProcIrqRoute` panics at `vi.o:1993`.
- `VI_DRV_IsCapValidInt(*(VI_CAP0+0xF0))` returns false → kernel logs `Disabling IRQ #42` after a few unhandled hits.

This PR pre-populates both registers from the timer tick before raising the IRQ lines:
- `VI_PROC0+0x310 ← 0x06732001` (captured live from real EV300 silicon while Majestic was streaming).
- `VI_CAP0+0xF0  ← 0x00000F00` (any value with bits 8-11 set satisfies the `IsCapValidInt` mask).

The pokes only stick because `hi3516ev300_soc.regbanks` is extended from 1 → 5 to declare backing RAM for VI_CAP / VI_PROC / VGS / VPSS — previously only IVE was wired up, so any vendor write into those windows vanished and readbacks returned 0 regardless of poke values.

## Test plan

- [x] Heartbeat run on EV300 (`-M hi3516ev300,sensor=none`, manual MPP load with `mmz_allocator=hisi`, heartbeat enabled via `devmem 0x11FE0000 32 1`):
  - 14,700 pulses / zero `Disabling IRQ` / zero `panic` / zero `BUG` / zero `null deref`
  - Both pokes confirmed via per-tick readback (logged for first 3 pulses)
- [ ] Existing CI matrix still passes (no behavioural change for any other SoC since the new code only runs when the heartbeat is explicitly enabled)

## Caveat

At 25 fps the heartbeat saturates the IRQ path on QEMU; guest userspace can't progress far enough for Majestic to ask VENC for an encoded frame. Tuning that (timer rate / virtual-clock vs realtime / batched IRQs) is a separate problem from the spurious-IRQ fix landed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)