### PR TITLE
ci: add OpenIPC NVR boot tests for Hi3536CV100 and Hi3536DV100

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,25 @@ jobs:
 
           # hi3516cv610 (V5) excluded: no OpenIPC firmware release yet
 
+          # NVR/DVR family — OpenIPC ships nor-lite firmware for 3 SoCs:
+          #   hi3520dv200, hi3536cv100, hi3536dv100.
+          # The latter two boot cleanly with the same -kernel/-initrd path
+          # used for IPC.  hi3520dv200 ships a Linux 3.0.8 build that
+          # exhibits the PL011-disabled-UART silent-hang same as Hi3536
+          # flagship / Hi3535 vendor 3.x kernels — excluded from CI until
+          # OpenIPC's linux fork moves to a newer kernel for that SoC
+          # (locally unblocked via the Linux 4.9 backport in
+          # reference_phase4_7_hi3520dv200.md).
+          - name: hi3536cv100
+            soc: hi3536cv100
+            machine: hi3536cv100
+            append: "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs"
+
+          - name: hi3536dv100
+            soc: hi3536dv100
+            machine: hi3536dv100
+            append: "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs"
+
     continue-on-error: ${{ matrix.allow_failure == true }}
 
     steps:


### PR DESCRIPTION
## Summary

OpenIPC ships nor-lite firmware for **3 NVR/DVR SoCs**:

| SoC | OpenIPC kernel | QEMU boot status |
|---|---|---|
| `hi3520dv200` | Linux 3.0.8 | ✗ silent hang at PL011-disabled-UART (same vendor 3.x blocker pattern as Hi3536 flagship/Hi3535) |
| `hi3536cv100` | Linux 3.18.20 | ✓ boots to `openipc-hi3536cv100 login:` |
| `hi3536dv100` | Linux 4.9.37 | ✓ boots to `openipc-hi3536dv100 login:` |

The two working firmwares fit the existing IPC boot matrix's
`-kernel`/`-initrd` + `root=/dev/ram0 rootfstype=squashfs` flow with no
per-SoC tweaks.  Adds them to the matrix.

`hi3520dv200` is left out with a comment pointing at the local Linux 4.9
backport (`reference_phase4_7_hi3520dv200.md`) — the boot in QEMU works
once OpenIPC's linux fork ships a newer-than-3.0 kernel for that SoC.

## Test plan
- [x] Locally verified `hi3536cv100` boot from OpenIPC nor-lite firmware via the same boot loop the CI uses (\"Welcome to OpenIPC / openipc-hi3536cv100 login:\")
- [x] Locally verified `hi3536dv100` boot from OpenIPC nor-lite firmware (\"openipc-hi3536dv100 login:\")
- [x] Both pass without `Wrong chip-id|hiunknown` regression triggers
- [x] CI workflow on this branch will exercise both at PR validation time

🤖 Generated with [Claude Code](https://claude.com/claude-code)