### PR TITLE
hi3520dv200: HIL2V200 L2 cache + PL011 UARTEN pre-enable (fixes #66)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2267,6 +2267,14 @@ static const HisiSoCConfig hi3520dv200_soc = {
     .rtc_base           = 0x20060000,
     .rtc_irq            = 0,
 
+    /* HiSilicon HIL2V200 L2 cache controller — vendor 3.0.x kernel hangs
+     * in l2cache_driver_init without this (openhisilicon#66). */
+    .l2cache_base       = 0x20700000,
+
+    /* PL011 UARTEN pre-enable — vendor 3.0.8 kernel writes to UARTDR
+     * before initialising UARTCR (relies on U-Boot to set CR=0x301). */
+    .uart_pre_enable    = true,
+
     /* CRG default register state — vendor get_bus_clk() reads CRG0 + CRG1
      * + A9_AXI_SCALE_REG to compute busclk = (24 MHz / refdiv * fbdiv) / 2.
      * With our regbank reads returning 0 the kernel divides by zero and
@@ -3326,6 +3334,38 @@ static void hisilicon_create_pl061(MemoryRegion *sysmem, hwaddr base,
     }
 }
 
+/* PL011 UARTCR = UARTEN | TXE | RXE: stamps every PL011 in the SoC config
+ * after device-level reset, which would otherwise zero UARTEN.  Lets vendor
+ * Linux 3.0/3.4/3.10 kernels print to console without a U-Boot stage that
+ * normally programs UARTCR before kernel handoff. */
+typedef struct {
+    Notifier notifier;
+    const HisiSoCConfig *c;
+} HisiUartPreEnableNotifier;
+
+static void hisi_uart_pre_enable_done(Notifier *n, void *opaque)
+{
+    HisiUartPreEnableNotifier *nf = container_of(n, HisiUartPreEnableNotifier,
+                                                 notifier);
+    const HisiSoCConfig *c = nf->c;
+    int i;
+
+    for (i = 0; i < c->num_uarts; i++) {
+        address_space_stl(&address_space_memory,
+                          c->uart_bases[i] + 0x30,
+                          0x301,    /* UARTCR = UARTEN | TXE | RXE */
+                          MEMTXATTRS_UNSPECIFIED, NULL);
+    }
+}
+
+static void hisi_register_uart_pre_enable_reset(const HisiSoCConfig *c)
+{
+    HisiUartPreEnableNotifier *nf = g_new0(HisiUartPreEnableNotifier, 1);
+    nf->notifier.notify = hisi_uart_pre_enable_done;
+    nf->c = c;
+    qemu_add_machine_init_done_notifier(&nf->notifier);
+}
+
 static void hisilicon_common_init(MachineState *machine,
                                   const HisiSoCConfig *c)
 {
@@ -3543,6 +3583,16 @@ static void hisilicon_common_init(MachineState *machine,
             continue;   /* UART0 PL011 created later by fastboot device */
         }
         pl011_create(c->uart_bases[n], pic[c->uart_irqs[n]], serial_hd(n));
+    }
+    /* Post-reset PL011 enable: writes UARTCR = UARTEN|TXE|RXE on the same
+     * path U-Boot would on real silicon.  Required by SoCs whose vendor
+     * Linux 3.0/3.4/3.10 PL011 driver writes to UARTDR before
+     * initialising UARTCR (Hi3520DV200, Hi3535, Hi3536 flagship);
+     * harmless elsewhere because newer drivers re-write CR during their
+     * startup path.  Registered as a qemu reset handler so the write
+     * lands AFTER PL011's own reset (which zeros UARTEN). */
+    if (c->uart_pre_enable) {
+        hisi_register_uart_pre_enable_reset(c);
     }
 
     /* Timers (SP804) */
@@ -3798,6 +3848,18 @@ static void hisilicon_common_init(MachineState *machine,
         sysbus_realize_and_unref(busdev, &error_fatal);
         sysbus_mmio_map(busdev, 0, c->xhci_base);
         sysbus_connect_irq(busdev, 0, pic[c->xhci_irq]);
+    }
+
+    /* HiSilicon HIL2V200 L2 cache controller — Hi3520D family.
+     * Required by vendor 3.0.x kernel's drivers/arm/mm/cache-hil2v200.c
+     * which polls REG_L2_RINT.AUTO_END after every maintenance op; a
+     * regbank stub returns 0 forever and the kernel hangs in
+     * l2cache_driver_init.  See openhisilicon#66. */
+    if (c->l2cache_base) {
+        DeviceState *l2 = qdev_new("hisi-l2cache");
+        SysBusDevice *busdev = SYS_BUS_DEVICE(l2);
+        sysbus_realize_and_unref(busdev, &error_fatal);
+        sysbus_mmio_map(busdev, 0, c->l2cache_base);
     }
 
     /* Generic register banks (pin mux, DDR PHY, PWM, etc.) */

--- a/qemu/hw/misc/hisi-l2cache.c
+++ b/qemu/hw/misc/hisi-l2cache.c
@@ -1,0 +1,156 @@
+/*
+ * HiSilicon HIL2V200 L2 cache controller — minimal QEMU emulation.
+ *
+ * Found on Hi3520D family (and openipc/linux:hisilicon-hi3520dv200's
+ * `arch/arm/mm/cache-hil2v200.c` driver, selected via CONFIG_CACHE_HIL2V200).
+ * Vendor MMIO at 0x20700000 size 0x10000.
+ *
+ * Driver pattern that this stub satisfies:
+ *
+ *   1. l2cache_init() writes 0 to REG_L2_CTRL (disable), then enables monitors,
+ *      then calls __l2cache_inv_all() which loops L2_WAY_NUM times calling
+ *      l2_invalid_auto(way):
+ *
+ *         reg = (way << BIT_L2_MAINT_AUTO_WAYADDRESS) | (0x1 << BIT_L2_MAINT_AUTO_START);
+ *         writel(reg, base + REG_L2_MAINT_AUTO);
+ *         while (!(readl(base + REG_L2_RINT) & (1 << BIT_L2_RINT_AUTO_END)))
+ *             ;
+ *         reg = readl(base + REG_L2_RINT);
+ *         writel(reg, base + REG_L2_INTCLR);
+ *
+ *   2. After all-ways-invalidated, writes 1 to REG_L2_CTRL (enable).
+ *
+ * The polling loop on REG_L2_RINT.AUTO_END is the hang point — a regbank
+ * stub returning 0 spins forever.  This model latches AUTO_END when the
+ * driver writes to REG_L2_MAINT_AUTO so the poll terminates immediately.
+ *
+ * Other operations (sync, clean range, invalidate range) write to
+ * different registers but follow the same trigger-then-wait-on-RINT
+ * pattern; we apply the same trick.
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/sysbus.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_L2CACHE "hisi-l2cache"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiL2CacheState, HISI_L2CACHE)
+
+#define HISI_L2CACHE_MMIO_SIZE   0x10000
+
+/* Register offsets (cache-hil2v200.h) */
+#define R_L2_CTRL                0x0000
+#define R_L2_AUCTRL              0x0004
+#define R_L2_STATUS              0x0008
+#define R_L2_INTMASK             0x0100
+#define R_L2_MINT                0x0104
+#define R_L2_RINT                0x0108
+#define R_L2_INTCLR              0x010C
+#define R_L2_SYNC                0x0200
+#define R_L2_INVALID             0x0210
+#define R_L2_CLEAN               0x0214
+#define R_L2_MAINT_AUTO          0x020C
+
+/* Bit positions in *_RINT registers */
+#define B_L2_RINT_AUTO_END       14
+
+struct HisiL2CacheState {
+    SysBusDevice parent_obj;
+    MemoryRegion iomem;
+    uint32_t regs[HISI_L2CACHE_MMIO_SIZE / 4];
+};
+
+static uint64_t hisi_l2cache_read(void *opaque, hwaddr offset, unsigned size)
+{
+    HisiL2CacheState *s = HISI_L2CACHE(opaque);
+
+    if (offset >= HISI_L2CACHE_MMIO_SIZE) {
+        return 0;
+    }
+    return s->regs[offset / 4];
+}
+
+static void hisi_l2cache_write(void *opaque, hwaddr offset,
+                               uint64_t val, unsigned size)
+{
+    HisiL2CacheState *s = HISI_L2CACHE(opaque);
+
+    if (offset >= HISI_L2CACHE_MMIO_SIZE) {
+        return;
+    }
+
+    switch (offset) {
+    case R_L2_MAINT_AUTO:
+    case R_L2_SYNC:
+    case R_L2_INVALID:
+    case R_L2_CLEAN:
+        /*
+         * Any maintenance trigger immediately latches AUTO_END in RINT
+         * so the driver's spin-wait completes on the first read.
+         */
+        s->regs[offset / 4] = (uint32_t)val;
+        s->regs[R_L2_RINT / 4] |= (1u << B_L2_RINT_AUTO_END);
+        break;
+
+    case R_L2_INTCLR:
+        /*
+         * Driver clears RINT bits by writing the current RINT value into
+         * INTCLR; honour the W1C semantics (clear matching bits in RINT).
+         */
+        s->regs[R_L2_RINT / 4] &= ~(uint32_t)val;
+        s->regs[offset / 4] = (uint32_t)val;
+        break;
+
+    default:
+        s->regs[offset / 4] = (uint32_t)val;
+        break;
+    }
+}
+
+static const MemoryRegionOps hisi_l2cache_ops = {
+    .read = hisi_l2cache_read,
+    .write = hisi_l2cache_write,
+    .endianness = DEVICE_LITTLE_ENDIAN,
+    .valid.min_access_size = 4,
+    .valid.max_access_size = 4,
+};
+
+static void hisi_l2cache_init(Object *obj)
+{
+    HisiL2CacheState *s = HISI_L2CACHE(obj);
+
+    memory_region_init_io(&s->iomem, obj, &hisi_l2cache_ops, s,
+                          TYPE_HISI_L2CACHE, HISI_L2CACHE_MMIO_SIZE);
+    sysbus_init_mmio(SYS_BUS_DEVICE(obj), &s->iomem);
+}
+
+static void hisi_l2cache_reset(DeviceState *dev)
+{
+    HisiL2CacheState *s = HISI_L2CACHE(dev);
+    memset(s->regs, 0, sizeof(s->regs));
+}
+
+static void hisi_l2cache_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    device_class_set_legacy_reset(dc, hisi_l2cache_reset);
+}
+
+static const TypeInfo hisi_l2cache_info = {
+    .name          = TYPE_HISI_L2CACHE,
+    .parent        = TYPE_SYS_BUS_DEVICE,
+    .instance_size = sizeof(HisiL2CacheState),
+    .instance_init = hisi_l2cache_init,
+    .class_init    = hisi_l2cache_class_init,
+};
+
+static void hisi_l2cache_register_types(void)
+{
+    type_register_static(&hisi_l2cache_info);
+}
+
+type_init(hisi_l2cache_register_types)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -221,6 +221,22 @@ typedef struct HisiSoCConfig {
     int             xhci_slots;     /* 0 = default 4 */
     int             xhci_intrs;     /* 0 = default 1 */
 
+    /* HiSilicon HIL2V200 L2 cache controller — used by Hi3520D family
+     * (CONFIG_CACHE_HIL2V200).  Vendor 3.0.x driver hangs in early init
+     * polling REG_L2_RINT.AUTO_END after writing maintenance ops.  The
+     * `hisi-l2cache` model latches AUTO_END on every maintenance write
+     * so the spin-wait completes immediately. */
+    hwaddr          l2cache_base;   /* 0 = no L2 cache controller */
+
+    /* PL011 UARTEN pre-enable — set true when the SoC ships vendor Linux
+     * 3.0/3.4/3.10 kernels that rely on U-Boot to set UARTCR before
+     * jumping to the kernel.  Real boards' U-Boot writes UARTCR=0x301
+     * (UARTEN | TXE | RXE).  Without this, those kernels write to UART
+     * with UARTEN clear and we see "PL011 data written to disabled UART"
+     * with no console output.  Linux 3.18+ and 4.9 don't need this — the
+     * PL011 driver's startup path sets UARTCR itself. */
+    bool            uart_pre_enable;
+
     /* Hardware True Random Number Generator
      * (HISEC_TRNG_CTRL on V3+, RNG_GEN on V2) */
     hwaddr          hwrng_base;        /* 0 = no HWRNG on this SoC */

--- a/qemu/setup.sh
+++ b/qemu/setup.sh
@@ -49,6 +49,7 @@ cp qemu/hw/misc/hisi-hwrng.c        "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-vi-fp.c        "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-fastboot.c     "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-gzip.c        "$QEMU_DIR/hw/misc/"
+cp qemu/hw/misc/hisi-l2cache.c     "$QEMU_DIR/hw/misc/"
 cp qemu/hw/net/hisi-femac.c         "$QEMU_DIR/hw/net/"
 cp qemu/hw/net/hisi-gmac.c          "$QEMU_DIR/hw/net/"
 cp qemu/hw/i2c/hisi-i2c.c          "$QEMU_DIR/hw/i2c/"
@@ -150,7 +151,7 @@ fi
 
 # hw/misc/meson.build
 if ! grep -q hisi-sysctl "$QEMU_DIR/hw/misc/meson.build"; then
-    echo "system_ss.add(when: 'CONFIG_HISI_MISC', if_true: files('hisi-sysctl.c', 'hisi-crg.c', 'hisi-fmc.c', 'hisi-sfc350.c', 'hisi-himci.c', 'hisi-regbank.c', 'hisi-vedu.c', 'hisi-mipi-rx.c', 'hisi-rtc.c', 'hisi-ive.c', 'hisi-fastboot.c', 'hisi-gzip.c', 'hisi-hwrng.c', 'hisi-vi-fp.c'))" \
+    echo "system_ss.add(when: 'CONFIG_HISI_MISC', if_true: files('hisi-sysctl.c', 'hisi-crg.c', 'hisi-fmc.c', 'hisi-sfc350.c', 'hisi-himci.c', 'hisi-regbank.c', 'hisi-vedu.c', 'hisi-mipi-rx.c', 'hisi-rtc.c', 'hisi-ive.c', 'hisi-fastboot.c', 'hisi-gzip.c', 'hisi-hwrng.c', 'hisi-vi-fp.c', 'hisi-l2cache.c'))" \
         >> "$QEMU_DIR/hw/misc/meson.build"
     echo "  patched hw/misc/meson.build"
 else
@@ -163,6 +164,11 @@ else
         sed -i "s/'hisi-hwrng.c'/'hisi-hwrng.c', 'hisi-vi-fp.c'/" \
             "$QEMU_DIR/hw/misc/meson.build"
         echo "  hw/misc/meson.build: added hisi-vi-fp.c"
+    fi
+    if ! grep -q hisi-l2cache "$QEMU_DIR/hw/misc/meson.build"; then
+        sed -i "s/'hisi-vi-fp.c'/'hisi-vi-fp.c', 'hisi-l2cache.c'/" \
+            "$QEMU_DIR/hw/misc/meson.build"
+        echo "  hw/misc/meson.build: added hisi-l2cache.c"
     fi
 fi
 


### PR DESCRIPTION
## Summary

- New `hisi-l2cache` device models the HiSilicon HIL2V200 L2 cache controller. The vendor 3.0.x driver loops on `REG_L2_RINT.AUTO_END` after each maintenance op; a regbank stub returns 0 forever and the kernel hangs in `l2cache_driver_init`. The model latches AUTO_END on every maintenance write and honours W1C on `REG_L2_INTCLR`.
- New `uart_pre_enable` SoC-config flag registers a machine-init-done notifier that writes `UARTCR = UARTEN | TXE | RXE` to every PL011 in the SoC. This stands in for U-Boot, which programs UARTCR before kernel handoff on real silicon. Vendor Linux 3.0/3.4/3.10 PL011 drivers don't set UARTEN themselves, so without this they write to UARTDR while UARTEN is clear and produce no console output.
- `hi3520dv200_soc` opts into both (`l2cache_base = 0x20700000`, `uart_pre_enable = true`); other SoCs are unaffected.

## Test plan

- [x] `bash qemu/setup.sh` — clean build, both `qemu-system-arm` and `qemu-system-aarch64`.
- [x] `qemu-boot/run-hi3520dv200.sh` boots a locally-built Linux 3.0.8 (`hi3520d_full_defconfig`) past `L2cache cache controller enabled` and `Serial: AMBA PL011 UART driver` registration.
- [x] Spot-checked Hi3536DV100 still boots to `Welcome to HiLinux` login (no regression on existing machines).

## Notes

The schema additions are forward-compatible: Hi3520Dv300/Dv400 (same HIL2V200 + same UART quirk) can opt in later by setting `l2cache_base` and `uart_pre_enable`. CI for hi3520dv200 with the OpenIPC nightly firmware is still gated — that build hangs after this fix as well; it appears to be a kernel-side rather than QEMU-side issue and should be tracked separately.