### PR TITLE
hi3520dv200: stub hieth-sf Ethernet MMIO (fixes #68)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2275,6 +2275,11 @@ static const HisiSoCConfig hi3520dv200_soc = {
      * before initialising UARTCR (relies on U-Boot to set CR=0x301). */
     .uart_pre_enable    = true,
 
+    /* HiSilicon SF Ethernet (drivers/net/hieth-sf/) — vendor 3.0.x
+     * kernel hangs in hieth_init (sys-hi3520d.c set_phy_valtage busy
+     * waits on MDIO_RWCTRL bit 15) without this (openhisilicon#68). */
+    .hieth_sf_base      = 0x10090000,
+
     /* CRG default register state — vendor get_bus_clk() reads CRG0 + CRG1
      * + A9_AXI_SCALE_REG to compute busclk = (24 MHz / refdiv * fbdiv) / 2.
      * With our regbank reads returning 0 the kernel divides by zero and
@@ -3860,6 +3865,19 @@ static void hisilicon_common_init(MachineState *machine,
         SysBusDevice *busdev = SYS_BUS_DEVICE(l2);
         sysbus_realize_and_unref(busdev, &error_fatal);
         sysbus_mmio_map(busdev, 0, c->l2cache_base);
+    }
+
+    /* HiSilicon SF (single-FIFO) Ethernet controller — Hi3520D family.
+     * Vendor 3.0.x drivers/net/hieth-sf/sys-hi3520d.c set_phy_valtage()
+     * busy-loops with no timeout on MDIO_RWCTRL bit 15.  This stub
+     * latches that bit on writes and returns 0xFFFF on PHY-data reads
+     * so autoscan finds nothing and the probe exits with -ENODEV.  See
+     * openhisilicon#68. */
+    if (c->hieth_sf_base) {
+        DeviceState *eth = qdev_new("hisi-hieth-sf");
+        SysBusDevice *busdev = SYS_BUS_DEVICE(eth);
+        sysbus_realize_and_unref(busdev, &error_fatal);
+        sysbus_mmio_map(busdev, 0, c->hieth_sf_base);
     }
 
     /* Generic register banks (pin mux, DDR PHY, PWM, etc.) */

--- a/qemu/hw/net/hisi-hieth-sf.c
+++ b/qemu/hw/net/hisi-hieth-sf.c
@@ -1,0 +1,145 @@
+/*
+ * HiSilicon SF (single-FIFO) Ethernet controller — minimal QEMU stub.
+ *
+ * Found on Hi3520D / Hi3536C / Hi3536DV100 family (per
+ * openipc/linux:hisilicon-hi3520dv200's `drivers/net/hieth-sf/`,
+ * selected via CONFIG_HIETH=y).  Vendor MMIO at 0x10090000 size 0x10000.
+ *
+ * The driver hang we satisfy here is in arch/arm/.../sys-hi3520d.c
+ * `set_phy_valtage()` and `revise_led_shine()`, both of which do:
+ *
+ *     do {
+ *         writel(reg_value, IO_MDIO_RWCTRL);
+ *         udelay(10);
+ *     } while (!(readl(IO_MDIO_RWCTRL) & (0x1 << 15)));
+ *
+ * with no timeout — a regbank stub returning 0 spins forever.  Hardware
+ * sets bit 15 of MDIO_RWCTRL when the MDIO operation completes, so this
+ * model latches bit 15 of MDIO_RWCTRL on every write, making the busy
+ * wait exit on the next read.
+ *
+ * Other operations (PHY ID reads via hieth_mdio_read, register settings,
+ * GLB_SOFT_RESET writes) follow store-then-poll-or-just-store patterns
+ * that a flat regbank handles correctly.  We return 0xFFFF for
+ * MDIO_RO_DATA so PHY autoscan sees "no PHY" and the driver exits the
+ * probe with -ENODEV instead of touching DMA descriptors.  The kernel
+ * prints "no dev probed" and continues booting; that's enough for shell.
+ *
+ * No TX/RX path is modeled — `-nic user` does not attach to this device.
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/sysbus.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+
+#define TYPE_HISI_HIETH_SF "hisi-hieth-sf"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiHiethSfState, HISI_HIETH_SF)
+
+#define HISI_HIETH_SF_MMIO_SIZE   0x10000
+
+/* Register offsets (drivers/net/hieth-sf/{mdio,glb}.h) */
+#define R_MDIO_RWCTRL            0x1100
+#define R_MDIO_RO_DATA           0x1104
+
+#define B_MDIO_READY             15
+
+struct HisiHiethSfState {
+    SysBusDevice parent_obj;
+    MemoryRegion iomem;
+    uint32_t regs[HISI_HIETH_SF_MMIO_SIZE / 4];
+};
+
+static uint64_t hisi_hieth_sf_read(void *opaque, hwaddr offset, unsigned size)
+{
+    HisiHiethSfState *s = HISI_HIETH_SF(opaque);
+
+    if (offset >= HISI_HIETH_SF_MMIO_SIZE) {
+        return 0;
+    }
+
+    switch (offset) {
+    case R_MDIO_RO_DATA:
+        /*
+         * 0xFFFF on every read register (e.g. PHY ID 1 / 2) makes the
+         * Linux PHY framework treat each PHY address as absent, so
+         * mdiobus_scan finds nothing and phy_connect returns -ENODEV.
+         */
+        return 0xFFFF;
+
+    default:
+        return s->regs[offset / 4];
+    }
+}
+
+static void hisi_hieth_sf_write(void *opaque, hwaddr offset,
+                                uint64_t val, unsigned size)
+{
+    HisiHiethSfState *s = HISI_HIETH_SF(opaque);
+
+    if (offset >= HISI_HIETH_SF_MMIO_SIZE) {
+        return;
+    }
+
+    switch (offset) {
+    case R_MDIO_RWCTRL:
+        /*
+         * Latch the "operation done" bit so the no-timeout busy waits in
+         * sys-hi3520d.c (set_phy_valtage / revise_led_shine) and the
+         * timed waits in mdio.c wait_mdio_ready() exit on first read.
+         */
+        s->regs[offset / 4] = (uint32_t)val | (1u << B_MDIO_READY);
+        break;
+
+    default:
+        s->regs[offset / 4] = (uint32_t)val;
+        break;
+    }
+}
+
+static const MemoryRegionOps hisi_hieth_sf_ops = {
+    .read = hisi_hieth_sf_read,
+    .write = hisi_hieth_sf_write,
+    .endianness = DEVICE_LITTLE_ENDIAN,
+    .valid.min_access_size = 4,
+    .valid.max_access_size = 4,
+};
+
+static void hisi_hieth_sf_init(Object *obj)
+{
+    HisiHiethSfState *s = HISI_HIETH_SF(obj);
+
+    memory_region_init_io(&s->iomem, obj, &hisi_hieth_sf_ops, s,
+                          TYPE_HISI_HIETH_SF, HISI_HIETH_SF_MMIO_SIZE);
+    sysbus_init_mmio(SYS_BUS_DEVICE(obj), &s->iomem);
+}
+
+static void hisi_hieth_sf_reset(DeviceState *dev)
+{
+    HisiHiethSfState *s = HISI_HIETH_SF(dev);
+    memset(s->regs, 0, sizeof(s->regs));
+}
+
+static void hisi_hieth_sf_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    device_class_set_legacy_reset(dc, hisi_hieth_sf_reset);
+}
+
+static const TypeInfo hisi_hieth_sf_info = {
+    .name          = TYPE_HISI_HIETH_SF,
+    .parent        = TYPE_SYS_BUS_DEVICE,
+    .instance_size = sizeof(HisiHiethSfState),
+    .instance_init = hisi_hieth_sf_init,
+    .class_init    = hisi_hieth_sf_class_init,
+};
+
+static void hisi_hieth_sf_register_types(void)
+{
+    type_register_static(&hisi_hieth_sf_info);
+}
+
+type_init(hisi_hieth_sf_register_types)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -237,6 +237,16 @@ typedef struct HisiSoCConfig {
      * PL011 driver's startup path sets UARTCR itself. */
     bool            uart_pre_enable;
 
+    /* HiSilicon SF (single-FIFO) Ethernet controller — used by Hi3520D
+     * family and other vendor 3.0/3.4 kernels via drivers/net/hieth-sf/.
+     * The vendor sys-hi3520d.c set_phy_valtage() / revise_led_shine()
+     * busy-wait on MDIO_RWCTRL bit 15 with no timeout; a regbank stub
+     * spins forever.  The `hisi-hieth-sf` model latches that bit on
+     * MDIO_RWCTRL writes so the polling loop exits, and returns 0xFFFF
+     * for MDIO_RO_DATA so PHY autoscan finds nothing and the probe
+     * fails gracefully (no DMA-ring init).  No NIC packet path. */
+    hwaddr          hieth_sf_base; /* 0 = no HiSilicon SF Ethernet */
+
     /* Hardware True Random Number Generator
      * (HISEC_TRNG_CTRL on V3+, RNG_GEN on V2) */
     hwaddr          hwrng_base;        /* 0 = no HWRNG on this SoC */

--- a/qemu/setup.sh
+++ b/qemu/setup.sh
@@ -52,6 +52,7 @@ cp qemu/hw/misc/hisi-gzip.c        "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-l2cache.c     "$QEMU_DIR/hw/misc/"
 cp qemu/hw/net/hisi-femac.c         "$QEMU_DIR/hw/net/"
 cp qemu/hw/net/hisi-gmac.c          "$QEMU_DIR/hw/net/"
+cp qemu/hw/net/hisi-hieth-sf.c      "$QEMU_DIR/hw/net/"
 cp qemu/hw/i2c/hisi-i2c.c          "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-imx335.c       "$QEMU_DIR/hw/i2c/"
 cp qemu/hw/i2c/hisi-imx307.c       "$QEMU_DIR/hw/i2c/"
@@ -97,6 +98,7 @@ config HISILICON
     select HISI_MISC
     select HISI_FEMAC
     select HISI_GMAC
+    select HISI_HIETH_SF
     select I2C
     select HISI_I2C
     select CMSDK_APB_WATCHDOG
@@ -116,8 +118,8 @@ else
     else
         echo "  hw/arm/Kconfig already patched"
     fi
-    # DVR/NVR additions: HISI_GMAC + AHCI / USB EHCI/OHCI/XHCI sysbus.
-    for sym in HISI_GMAC AHCI_SYSBUS USB_EHCI_SYSBUS USB_OHCI_SYSBUS USB_XHCI_SYSBUS; do
+    # DVR/NVR additions: HISI_GMAC + HISI_HIETH_SF + AHCI / USB sysbus.
+    for sym in HISI_GMAC HISI_HIETH_SF AHCI_SYSBUS USB_EHCI_SYSBUS USB_OHCI_SYSBUS USB_XHCI_SYSBUS; do
         if ! awk '/^config HISILICON$/,/^$/' "$QEMU_DIR/hw/arm/Kconfig" \
                 | grep -q "select $sym"; then
             sed -i "/^config HISILICON$/,/^$/ {
@@ -181,6 +183,9 @@ config HISI_FEMAC
 
 config HISI_GMAC
     bool
+
+config HISI_HIETH_SF
+    bool
 KCONFIG
     echo "  patched hw/net/Kconfig"
 else
@@ -191,8 +196,14 @@ config HISI_GMAC
     bool
 KCONFIG
         echo "  hw/net/Kconfig: added HISI_GMAC"
-    else
-        echo "  hw/net/Kconfig already patched"
+    fi
+    if ! grep -q "config HISI_HIETH_SF" "$QEMU_DIR/hw/net/Kconfig"; then
+        cat >> "$QEMU_DIR/hw/net/Kconfig" <<'KCONFIG'
+
+config HISI_HIETH_SF
+    bool
+KCONFIG
+        echo "  hw/net/Kconfig: added HISI_HIETH_SF"
     fi
 fi
 
@@ -210,6 +221,13 @@ if ! grep -q hisi-gmac "$QEMU_DIR/hw/net/meson.build"; then
     echo "  patched hw/net/meson.build (gmac)"
 else
     echo "  hw/net/meson.build already has gmac"
+fi
+if ! grep -q hisi-hieth-sf "$QEMU_DIR/hw/net/meson.build"; then
+    echo "system_ss.add(when: 'CONFIG_HISI_HIETH_SF', if_true: files('hisi-hieth-sf.c'))" \
+        >> "$QEMU_DIR/hw/net/meson.build"
+    echo "  patched hw/net/meson.build (hieth-sf)"
+else
+    echo "  hw/net/meson.build already has hieth-sf"
 fi
 
 # hw/i2c/Kconfig


### PR DESCRIPTION
## Summary

- New `hisi-hieth-sf` device — minimal stub for the HiSilicon SF (single-FIFO) Ethernet controller used by Hi3520D family vendor 3.0.x kernels via `drivers/net/hieth-sf/`.
- Latches `MDIO_RWCTRL` ready bit (15) on writes so the no-timeout busy waits in `sys-hi3520d.c` (`set_phy_valtage`, `revise_led_shine`) exit on the next read.
- Returns `0xFFFF` on `MDIO_RO_DATA` reads so the Linux PHY framework treats every PHY address as absent — `mdiobus_scan` finds nothing and `phy_connect` exits with `-ENODEV`. Probe prints `no dev probed!` and boot continues. No DMA-ring init, no TX/RX path, no `-nic` peer.
- New `hieth_sf_base` SoC-config field; `hi3520dv200_soc` opts in at `0x10090000`. Forward-compatible for Hi3520Dv300/Dv400, Hi3536C and other vendor-3.0/3.4 SoCs that ship the same driver.

## What this fixes

This PR closes one specific QEMU-side gap: the no-timeout MDIO busy-wait that previously made `hieth_init` never return on `-M hi3520dv200`. After this patch, the same Linux 3.0.8 build that previously hung inside `hieth_init` runs every remaining initcall and reaches `Freeing init memory: 140K`.

## What this does *not* fix (still no login prompt)

The local 3.0.8 + `qemu-boot/initramfs.cpio.gz.hi3520dv200` combination still doesn't reach a shell — but for reasons unrelated to `hieth-sf`:

- The kernel logs `rootfs image is not initramfs (junk in compressed archive); looks like an initrd` and treats the cpio.gz as a block-device initrd rather than unpacking it into rootfs.
- It then logs `Warning: unable to open an initial console.` and stops producing output after `Freeing init memory: 140K` because there is no userspace `/sbin/init` to run.

Both are kernel/initramfs-shape issues, not QEMU peripheral gaps; they'll need a separate change to either repack the cpio.gz in a form this 3.0.y `populate_rootfs()` accepts or to swap to a squashfs+`root=/dev/ram0` boot path.

## Test plan

- [x] `bash qemu/setup.sh` — clean build of `qemu-system-arm` and `qemu-system-aarch64`.
- [x] Linux 3.0.8 `hi3520d_full_defconfig` boot reaches `Freeing init memory: 140K` (previously hung in `hieth_init`); `hieth` driver exits cleanly with `no dev probed!`.
- [x] Hi3536DV100 still boots to `Welcome to HiLinux` login (no regression).