### PR TITLE
hi3520dv200: mirror PL011 PrimeCell IDs at end of vendor 0x10000 window (fixes #70)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2276,6 +2276,14 @@ static const HisiSoCConfig hi3520dv200_soc = {
      * before initialising UARTCR (relies on U-Boot to set CR=0x301). */
     .uart_pre_enable    = true,
 
+    /* HIL_AMBA_DEVICE() in vendor mach-hi3520d/core.c hardcodes a
+     * 0x10000 resource size for uart:0/uart:1, so the AMBA bus probes
+     * PrimeCell ID at the END of that window (offset 0xffe0/0xfff0).
+     * Mirror PL011 at base + 0xf000 so the IDs read back correctly and
+     * the AMBA driver binds — otherwise /dev/ttyAMA0 never appears and
+     * userspace can't open /dev/console (openhisilicon#70). */
+    .uart_window_size   = 0x10000,
+
     /* HiSilicon SF Ethernet (drivers/net/hieth-sf/) — vendor 3.0.x
      * kernel hangs in hieth_init (sys-hi3520d.c set_phy_valtage busy
      * waits on MDIO_RWCTRL bit 15) without this (openhisilicon#68). */
@@ -3584,11 +3592,35 @@ static void hisilicon_common_init(MachineState *machine,
 
     /* UARTs */
     for (n = 0; n < c->num_uarts; n++) {
+        DeviceState *uart;
         if (n == 0 && fastboot_mode) {
             uart0_irq = pic[c->uart_irqs[0]];
             continue;   /* UART0 PL011 created later by fastboot device */
         }
-        pl011_create(c->uart_bases[n], pic[c->uart_irqs[n]], serial_hd(n));
+        uart = pl011_create(c->uart_bases[n], pic[c->uart_irqs[n]],
+                            serial_hd(n));
+
+        /* If the SoC's vendor mach hardcodes a larger PL011 resource
+         * size, the AMBA bus probe reads PrimeCell ID at the END of
+         * that window — outside our 0x1000 PL011.  Alias only those
+         * 0x20 bytes (PERIPHID0..3 + PCELLID0..3, offsets 0xfe0..0xfff)
+         * to `base + window_size - 0x20`, so the AMBA driver sees the
+         * right IDs and binds, without leaking the full PL011 register
+         * block into the upper part of the window (which would let
+         * stray accesses there read RX bytes from UARTDR).  See
+         * openhisilicon#70. */
+        if (c->uart_window_size > 0x1000) {
+            MemoryRegion *pl011_mr =
+                sysbus_mmio_get_region(SYS_BUS_DEVICE(uart), 0);
+            MemoryRegion *alias = g_new0(MemoryRegion, 1);
+            char *name = g_strdup_printf("pl011-id-mirror-%d", n);
+            memory_region_init_alias(alias, OBJECT(uart), name,
+                                     pl011_mr, 0xfe0, 0x20);
+            memory_region_add_subregion(sysmem,
+                c->uart_bases[n] + c->uart_window_size - 0x20,
+                alias);
+            g_free(name);
+        }
     }
     /* Post-reset PL011 enable: writes UARTCR = UARTEN|TXE|RXE on the same
      * path U-Boot would on real silicon.  Required by SoCs whose vendor

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -237,6 +237,18 @@ typedef struct HisiSoCConfig {
      * PL011 driver's startup path sets UARTCR itself. */
     bool            uart_pre_enable;
 
+    /* PL011 MMIO window size — set when the vendor's mach amba_device
+     * resource is sized larger than the PL011's actual 0x1000 register
+     * block (Hi3520Dv200's HIL_AMBA_DEVICE macro hardcodes 0x10000).
+     * The AMBA bus probe reads PrimeCell ID at `tmp + size - 0x20` and
+     * `tmp + size - 0x10`, i.e. at the END of the resource — outside
+     * the PL011's modeled 0x1000 region for these SoCs, so periphid
+     * reads back as 0 and the AMBA driver fails to bind.  Real silicon
+     * mirrors PL011 across the larger window; we model that with an
+     * alias subregion at (base + window_size - 0x1000).
+     * 0 = use PL011's native 0x1000 (default). */
+    uint32_t        uart_window_size;
+
     /* HiSilicon SF (single-FIFO) Ethernet controller — used by Hi3520D
      * family and other vendor 3.0/3.4 kernels via drivers/net/hieth-sf/.
      * The vendor sys-hi3520d.c set_phy_valtage() / revise_led_shine()


### PR DESCRIPTION
## Summary

Vendor \`mach-hi3520d/core.c\` HIL_AMBA_DEVICE() hardcodes a 0x10000 resource size for uart:0/uart:1, so \`amba_device_register()\` reads PrimeCell ID at the **END** of the resource (offset 0xffe0/0xfff0). QEMU's PL011 only models a 0x1000 region — those reads fell on unmapped MMIO, returned 0, \`cid != AMBA_CID\`, periphid stayed 0, and the AMBA driver never bound. \`/dev/ttyAMA0\` was therefore absent from devtmpfs and userspace couldn't open \`/dev/console\`.

Real silicon mirrors PL011 across that wider window. This PR models the same: alias the 0x20 bytes of PrimeCell + Cell ID registers (PL011 offsets 0xfe0..0xfff) to \`base + window_size - 0x20\`. Only the IDs are aliased, so stray accesses elsewhere in the upper window don't fall through to \`UARTDR\`.

New \`uart_window_size\` SoC-config field; \`hi3520dv200_soc\` opts in at \`0x10000\`. Forward-compatible for any other vendor 3.0/3.4 mach files that hardcode a wider AMBA UART resource.

## Test plan

- [x] \`bash qemu/setup.sh\` — clean build of \`qemu-system-arm\` and \`qemu-system-aarch64\`.
- [x] Linux 3.0.8 \`hi3520d_full_defconfig\` boot now logs \`uart:0: ttyAMA0 at MMIO 0x20080000 (irq = 40) is a PL011 rev1\` and \`console [ttyAMA0] enabled, bootconsole disabled\`. Kernel runs through to \`Freeing init memory: 108K\` and forks \`/sbin/init\` from initramfs (verified with \`-serial file:\`).
- [x] Hi3536DV100 still boots to \`Welcome to HiLinux\` login (no regression).

## Caveats / not addressed by this PR

- With \`-serial mon:stdio\` the doubled output volume (CONFIG_DEBUG_LL printascii + AMBA pl011 console both writing to PL011 DR) appears to overwhelm the monitor mux on stdio and visible output stalls partway through boot; \`-monitor none -serial stdio\` or \`-serial file:\` show the full boot. Pre-existing, not introduced by this fix.
- The \`qemu-boot/initramfs.cpio.gz.hi3520dv200\` is missing \`/dev/null\`, so \`getty\` respawn-loops with \`can't open '/dev/null'\` after \`/sbin/init\` starts. Userspace/initramfs issue, not QEMU.