### PR TITLE
hisilicon: wire up HW gzip on hi3516ev200, hi3518ev300, hi3516dv200, Goke V4 (fixes #60)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2276,6 +2276,14 @@ static const HisiSoCConfig hi3520dv200_soc = {
      * before initialising UARTCR (relies on U-Boot to set CR=0x301). */
     .uart_pre_enable    = true,
 
+    /* HIL_AMBA_DEVICE() in vendor mach-hi3520d/core.c hardcodes a
+     * 0x10000 resource size for uart:0/uart:1, so the AMBA bus probes
+     * PrimeCell ID at the END of that window (offset 0xffe0/0xfff0).
+     * Mirror PL011 at base + 0xf000 so the IDs read back correctly and
+     * the AMBA driver binds — otherwise /dev/ttyAMA0 never appears and
+     * userspace can't open /dev/console (openhisilicon#70). */
+    .uart_window_size   = 0x10000,
+
     /* HiSilicon SF Ethernet (drivers/net/hieth-sf/) — vendor 3.0.x
      * kernel hangs in hieth_init (sys-hi3520d.c set_phy_valtage busy
      * waits on MDIO_RWCTRL bit 15) without this (openhisilicon#68). */
@@ -3584,11 +3592,35 @@ static void hisilicon_common_init(MachineState *machine,
 
     /* UARTs */
     for (n = 0; n < c->num_uarts; n++) {
+        DeviceState *uart;
         if (n == 0 && fastboot_mode) {
             uart0_irq = pic[c->uart_irqs[0]];
             continue;   /* UART0 PL011 created later by fastboot device */
         }
-        pl011_create(c->uart_bases[n], pic[c->uart_irqs[n]], serial_hd(n));
+        uart = pl011_create(c->uart_bases[n], pic[c->uart_irqs[n]],
+                            serial_hd(n));
+
+        /* If the SoC's vendor mach hardcodes a larger PL011 resource
+         * size, the AMBA bus probe reads PrimeCell ID at the END of
+         * that window — outside our 0x1000 PL011.  Alias only those
+         * 0x20 bytes (PERIPHID0..3 + PCELLID0..3, offsets 0xfe0..0xfff)
+         * to `base + window_size - 0x20`, so the AMBA driver sees the
+         * right IDs and binds, without leaking the full PL011 register
+         * block into the upper part of the window (which would let
+         * stray accesses there read RX bytes from UARTDR).  See
+         * openhisilicon#70. */
+        if (c->uart_window_size > 0x1000) {
+            MemoryRegion *pl011_mr =
+                sysbus_mmio_get_region(SYS_BUS_DEVICE(uart), 0);
+            MemoryRegion *alias = g_new0(MemoryRegion, 1);
+            char *name = g_strdup_printf("pl011-id-mirror-%d", n);
+            memory_region_init_alias(alias, OBJECT(uart), name,
+                                     pl011_mr, 0xfe0, 0x20);
+            memory_region_add_subregion(sysmem,
+                c->uart_bases[n] + c->uart_window_size - 0x20,
+                alias);
+            g_free(name);
+        }
     }
     /* Post-reset PL011 enable: writes UARTCR = UARTEN|TXE|RXE on the same
      * path U-Boot would on real silicon.  Required by SoCs whose vendor

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -1146,6 +1146,13 @@ static const HisiSoCConfig hi3516ev200_soc = {
     .wdt_base           = 0x12030000,
     .wdt_irq            = 2,
     .wdt_freq           = 3000000,
+
+    /* HiSilicon HW gzip decompressor — same V4 IP / address as ev300.
+     * U-Boot's u-boot-z.bin uses it during early boot; without it the
+     * vendor lib/hw_dec/hw_decompress_hi3516ev200.c times out with
+     * "Uncompress hardware decompress overtime!" before reaching the
+     * U-Boot banner.  See openhisilicon#60. */
+    .gzip_base          = 0x11310000,
 };
 
 /*
@@ -1227,6 +1234,13 @@ static const HisiSoCConfig hi3518ev300_soc = {
     .wdt_base           = 0x12030000,
     .wdt_irq            = 2,
     .wdt_freq           = 3000000,
+
+    /* HiSilicon HW gzip decompressor — same V4 IP / address as ev300.
+     * U-Boot's u-boot-z.bin uses it during early boot; without it the
+     * vendor lib/hw_dec/hw_decompress_hi3518ev300.c times out with
+     * "Uncompress hardware decompress overtime!" before reaching the
+     * U-Boot banner.  See openhisilicon#60. */
+    .gzip_base          = 0x11310000,
 };
 
 /*
@@ -1305,6 +1319,13 @@ static const HisiSoCConfig hi3516dv200_soc = {
     .wdt_base           = 0x12030000,
     .wdt_irq            = 2,
     .wdt_freq           = 3000000,
+
+    /* HiSilicon HW gzip decompressor — same V4 IP / address as ev300.
+     * U-Boot's u-boot-z.bin uses it during early boot; without it the
+     * vendor lib/hw_dec/hw_decompress_hi3516dv200.c times out with
+     * "Uncompress hardware decompress overtime!" before reaching the
+     * U-Boot banner.  See openhisilicon#60. */
+    .gzip_base          = 0x11310000,
 };
 
 /*
@@ -1383,6 +1404,13 @@ static const HisiSoCConfig hi3516dv200_soc = {
     .wdt_base           = 0x12030000,                       \
     .wdt_irq            = 2,                                \
     .wdt_freq           = 3000000,                          \
+    /* Same V4 HW gzip decompressor as Hi3516EV200/EV300/  \
+     * 18EV300/DV200 — needed by u-boot-z.bin's            \
+     * hw_decompress_*.c during early boot.  Same IP &     \
+     * register block on Goke rebrands (verified against   \
+     * GKIPC SDK gk7205v[23]00/hw_decompress.c).  See      \
+     * openhisilicon#60. */                                 \
+    .gzip_base          = 0x11310000,                       \
     .hwrng_base         = 0x10080000,                       \
     .hwrng_data_offset  = 0x204,                            \
     .num_regbanks       = 15,                               \

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -237,6 +237,18 @@ typedef struct HisiSoCConfig {
      * PL011 driver's startup path sets UARTCR itself. */
     bool            uart_pre_enable;
 
+    /* PL011 MMIO window size — set when the vendor's mach amba_device
+     * resource is sized larger than the PL011's actual 0x1000 register
+     * block (Hi3520Dv200's HIL_AMBA_DEVICE macro hardcodes 0x10000).
+     * The AMBA bus probe reads PrimeCell ID at `tmp + size - 0x20` and
+     * `tmp + size - 0x10`, i.e. at the END of the resource — outside
+     * the PL011's modeled 0x1000 region for these SoCs, so periphid
+     * reads back as 0 and the AMBA driver fails to bind.  Real silicon
+     * mirrors PL011 across the larger window; we model that with an
+     * alias subregion at (base + window_size - 0x1000).
+     * 0 = use PL011's native 0x1000 (default). */
+    uint32_t        uart_window_size;
+
     /* HiSilicon SF (single-FIFO) Ethernet controller — used by Hi3520D
      * family and other vendor 3.0/3.4 kernels via drivers/net/hieth-sf/.
      * The vendor sys-hi3520d.c set_phy_valtage() / revise_led_shine()


### PR DESCRIPTION
## Summary

\`hi3516ev300_soc\` already declared \`.gzip_base = 0x11310000\` so its \`u-boot-z.bin\` reaches the U-Boot banner. The other V4 SoCs that share the same HW gzip IP didn't, and their u-boot died at \`Uncompress hardware decompress overtime!\` before producing any banner.

This PR adds \`.gzip_base = 0x11310000\` for:
- \`hi3516ev200_soc\`
- \`hi3518ev300_soc\`
- \`hi3516dv200_soc\`
- \`HISI_V4_COMMON_PERIPH\` macro (covers Goke V4 rebrands gk7205v200/v300, gk7202v300, gk7605v100, plus the Goke next-gen 7205V500/V510/V530 / 7202V330 — all share the same IP per GKIPC SDK \`gk7205v[23]00/hw_decompress.c\`).

## Test plan

- [x] \`bash qemu/setup.sh\` — clean build of \`qemu-system-arm\` and \`qemu-system-aarch64\`.
- [x] Reproduced the issue's repro on master vs this branch with OpenIPC \`u-boot-{soc}-universal.bin\` flashed at offset 0:

| SoC | master | this branch |
|---|---|---|
| hi3516ev200 | \`Uncompress hardware decompress overtime! Fail!\` | \`Uncompress Ok!\` → \`U-Boot 2016.11-...\` |
| hi3516ev300 | \`Uncompress Ok!\` (already worked) | \`Uncompress Ok!\` (still works) |
| hi3518ev300 | \`Uncompress hardware decompress overtime! Fail!\` | \`Uncompress Ok!\` → \`U-Boot 2016.11-...\` |
| hi3516dv200 | (untested before) | \`Uncompress Ok!\` → \`U-Boot 2016.11-...\` |

## Caveat (out of scope for this PR)

Goke u-boot binaries from OpenIPC's release artifacts (\`u-boot-gk7205v200/v300-universal.bin\` etc.) **still don't reach \`System startup\`** on \`-M gk7205v200\` / \`-M gk7205v300\` / \`-M gk7202v300\` / \`-M gk7605v100\` — boot stays silent, no UART output. That's a separate early-boot gap (likely SoC-ID validation or DDR init differing from the HiSilicon original) and should be tracked separately. The gzip fix is necessary for these once that's resolved, so I've included it preemptively in the shared macro.