### PR TITLE
hisi-gmac: fix descriptor ring math for U-Boot's depth-2 queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,14 +205,8 @@ jobs:
             uboot_bin: u-boot-hi3516av100-universal.bin
             # AV100 (V2A) shares CV100's HISFC350 flash controller — must
             # set the flash-file global on hisi-sfc350, NOT hisi-fmc.
-            # See openhisilicon#59 (the issue's repro used the wrong
-            # device prefix and got 0x20-padding output).
+            # See openhisilicon#59.
             flash_type: hisi-sfc350
-            # AV100 uses GMAC (vs CV100/CV200/CV300's FEMAC); hisi-gmac's
-            # U-Boot probe links the PHY but ARP/ICMP doesn't complete.
-            # Settle for the smoke gate the issue's downstream sister
-            # repos already use ("gets past System startup").
-            uboot_smoke_only: true
 
           - name: hi3516cv300
             soc: hi3516cv300
@@ -420,29 +414,6 @@ jobs:
             fi
             sleep 0.5
           done
-
-          # Smoke-only mode: skip the network half of the test.  Used for
-          # SoCs where U-Boot itself runs but its U-Boot-side networking
-          # path doesn't complete in QEMU (e.g. AV100's hisi-gmac probe
-          # links the PHY but ARP/ICMP doesn't go through).  Matches the
-          # downstream gate shape ("gets past System startup") that
-          # OpenIPC/u-boot-{cv200,cv300} already use.
-          SMOKE_ONLY="${{ matrix.uboot_smoke_only || 'false' }}"
-          if [ "$SMOKE_ONLY" = "true" ]; then
-            exec 3>&-
-            kill $QEMU_PID 2>/dev/null || true
-            wait 2>/dev/null || true
-            rm -f /tmp/ub.in /tmp/ub.out
-
-            echo ""
-            if grep -q "autoboot" /tmp/uboot-ping.txt; then
-              echo "=== PASS: U-Boot smoke (reached autoboot) ==="
-            else
-              echo "=== FAIL: U-Boot smoke (no autoboot prompt) ==="
-              exit 1
-            fi
-            exit 0
-          fi
 
           # Interrupt autoboot (spam Ctrl-C until we see the prompt)
           for i in $(seq 1 20); do

--- a/qemu/hw/net/hisi-gmac.c
+++ b/qemu/hw/net/hisi-gmac.c
@@ -270,66 +270,63 @@ static void hisi_gmac_update_irq(HisiGmacState *s)
 /* ── Descriptor ring helpers ────────────────────────────────────────── */
 
 /*
- * Descriptor ring helpers.
+ * Descriptor ring layout.
  *
- * The kernel driver writes depth = DESC_NUM << DESC_WORD_SHIFT where
- * DESC_WORD_SHIFT is 2 (16-byte descriptors) or 3 (32-byte descriptors).
- * WR/RD pointers use byte offsets = index << DESC_BYTE_SHIFT where
- * DESC_BYTE_SHIFT = DESC_WORD_SHIFT + 2.
+ * The driver writes depth_reg = num_descriptors * (desc_size_bytes / 4)
+ * — i.e. queue extent measured in 32-bit words.  The WR/RD pointers
+ * are BYTE offsets into the queue and advance by DESC_SIZE per
+ * descriptor, wrapping at queue_size_bytes.
  *
- * DESC_NUM is always 1024, so: DESC_SIZE = depth_reg * 4 / 1024.
+ * Both U-Boot (HIGMAC_HWQ_TX_BQ_DEPTH=2) and the vendor kernel
+ * (HIGMAC_HWQ_TX_BQ_DEPTH=1024) use 32-byte descriptors on AV100 and
+ * 3519V101's higmac IP — DESC_SIZE is hardcoded 32 in the kernel's
+ * higmac.h.  We hardcode 32 here too.  (4-word/16-byte descriptors are
+ * a CONFIG_HIGMAC_DESC_4_WORD opt-in not used by default.)
  */
-#define HW_DESC_NUM     1024
+#define DESC_SIZE_BYTES         32
 
-/* Get descriptor size in bytes from the depth register value */
-static inline uint32_t hw_desc_size(uint32_t depth_reg)
+/* Queue size in bytes from the depth register value (queue size in
+ * words, so * 4).  0 if the driver hasn't programmed depth yet. */
+static inline uint32_t queue_size_bytes(uint32_t depth_reg)
 {
-    /* depth = 1024 * (desc_size / 4), so desc_size = depth * 4 / 1024 */
-    uint32_t ds = (depth_reg >> 8);  /* depth * 4 / 1024 = depth >> 8 */
-    return ds ? ds : 16;
+    return depth_reg * 4;
 }
 
-/* Convert WR/RD register (byte offset) to descriptor index */
-static inline uint32_t ptr_to_idx(uint32_t ptr, uint32_t depth_reg)
+/* Advance a byte-offset ring pointer by one descriptor, wrapping at
+ * queue_size_bytes.  Returns 0 if the queue is unsized. */
+static inline uint32_t ring_next_ptr(uint32_t ptr, uint32_t depth_reg)
 {
-    uint32_t ds = hw_desc_size(depth_reg);
-    return ptr / ds;
-}
-
-/* Convert descriptor index to WR/RD register value (byte offset) */
-static inline uint32_t idx_to_ptr(uint32_t idx, uint32_t depth_reg)
-{
-    return idx * hw_desc_size(depth_reg);
-}
-
-/* Advance a descriptor index by one, wrapping at HW_DESC_NUM */
-static inline uint32_t ring_next_idx(uint32_t idx)
-{
-    return (idx + 1) & (HW_DESC_NUM - 1);
+    uint32_t qsz = queue_size_bytes(depth_reg);
+    if (!qsz) {
+        return 0;
+    }
+    ptr += DESC_SIZE_BYTES;
+    if (ptr >= qsz) {
+        ptr = 0;
+    }
+    return ptr;
 }
 
 /* ── TX path: process packets from TX_BQ ring ───────────────────────── */
 
 static void hisi_gmac_tx(HisiGmacState *s)
 {
-    uint32_t ds;
-    uint32_t rd_idx, wr_idx;
+    uint32_t rd_ptr, wr_ptr;
     uint8_t buf[2048];
 
     if (!s->tx_bq_depth || !(s->port_en & BITS_TX_EN) || !s->desc_wr_rd_ena) {
         return;
     }
 
-    ds = hw_desc_size(s->tx_bq_depth);
-    rd_idx = ptr_to_idx(s->tx_bq_rd, s->tx_bq_depth);
-    wr_idx = ptr_to_idx(s->tx_bq_wr, s->tx_bq_depth);
+    rd_ptr = s->tx_bq_rd;
+    wr_ptr = s->tx_bq_wr;
 
-    while (rd_idx != wr_idx) {
-        uint32_t desc_addr = s->tx_bq_start + rd_idx * ds;
-        uint32_t desc[8]; /* up to 32 bytes */
+    while (rd_ptr != wr_ptr) {
+        uint32_t desc_addr = s->tx_bq_start + rd_ptr;
+        uint32_t desc[DESC_SIZE_BYTES / 4];
 
         dma_memory_read(&address_space_memory, desc_addr,
-                        desc, ds, MEMTXATTRS_UNSPECIFIED);
+                        desc, DESC_SIZE_BYTES, MEMTXATTRS_UNSPECIFIED);
 
         uint32_t data_addr = desc[0];
         uint32_t w1 = desc[1];
@@ -349,22 +346,19 @@ static void hisi_gmac_tx(HisiGmacState *s)
 
         /* Write completion descriptor to TX_RQ ring */
         if (s->tx_rq_depth) {
-            uint32_t rq_ds = hw_desc_size(s->tx_rq_depth);
-            uint32_t rq_idx = ptr_to_idx(s->tx_rq_wr, s->tx_rq_depth);
-            uint32_t rq_addr = s->tx_rq_start + rq_idx * rq_ds;
+            uint32_t rq_addr = s->tx_rq_start + s->tx_rq_wr;
 
             desc[1] = (w1 & ~(1u << 31));
             dma_memory_write(&address_space_memory, rq_addr,
-                             desc, rq_ds, MEMTXATTRS_UNSPECIFIED);
+                             desc, DESC_SIZE_BYTES, MEMTXATTRS_UNSPECIFIED);
 
-            rq_idx = ring_next_idx(rq_idx);
-            s->tx_rq_wr = idx_to_ptr(rq_idx, s->tx_rq_depth);
+            s->tx_rq_wr = ring_next_ptr(s->tx_rq_wr, s->tx_rq_depth);
         }
 
-        rd_idx = ring_next_idx(rd_idx);
+        rd_ptr = ring_next_ptr(rd_ptr, s->tx_bq_depth);
     }
 
-    s->tx_bq_rd = idx_to_ptr(rd_idx, s->tx_bq_depth);
+    s->tx_bq_rd = rd_ptr;
 
     /* Raise TX completion interrupt */
     if (s->tx_rq_wr != s->tx_rq_rd) {
@@ -401,14 +395,11 @@ static ssize_t hisi_gmac_receive(NetClientState *nc, const uint8_t *buf,
         return -1;
     }
 
-    uint32_t fq_ds = hw_desc_size(s->rx_fq_depth);
-    uint32_t fq_idx = ptr_to_idx(s->rx_fq_rd, s->rx_fq_depth);
-
     /* Pop a descriptor from RX_FQ */
-    uint32_t fq_addr = s->rx_fq_start + fq_idx * fq_ds;
-    uint32_t desc[8];
+    uint32_t fq_addr = s->rx_fq_start + s->rx_fq_rd;
+    uint32_t desc[DESC_SIZE_BYTES / 4];
     dma_memory_read(&address_space_memory, fq_addr,
-                    desc, fq_ds, MEMTXATTRS_UNSPECIFIED);
+                    desc, DESC_SIZE_BYTES, MEMTXATTRS_UNSPECIFIED);
 
     uint32_t data_addr = desc[0];
     uint32_t w1 = desc[1];
@@ -423,13 +414,10 @@ static ssize_t hisi_gmac_receive(NetClientState *nc, const uint8_t *buf,
                      buf, size, MEMTXATTRS_UNSPECIFIED);
 
     /* Advance RX_FQ read pointer */
-    fq_idx = ring_next_idx(fq_idx);
-    s->rx_fq_rd = idx_to_ptr(fq_idx, s->rx_fq_depth);
+    s->rx_fq_rd = ring_next_ptr(s->rx_fq_rd, s->rx_fq_depth);
 
     /* Push descriptor to RX_BQ with received length */
-    uint32_t bq_ds = hw_desc_size(s->rx_bq_depth);
-    uint32_t bq_idx = ptr_to_idx(s->rx_bq_wr, s->rx_bq_depth);
-    uint32_t bq_addr = s->rx_bq_start + bq_idx * bq_ds;
+    uint32_t bq_addr = s->rx_bq_start + s->rx_bq_wr;
 
     w1 = (w1 & 0x7FF) |
          ((uint32_t)size << 16) |
@@ -438,10 +426,9 @@ static ssize_t hisi_gmac_receive(NetClientState *nc, const uint8_t *buf,
     desc[1] = w1;
 
     dma_memory_write(&address_space_memory, bq_addr,
-                     desc, bq_ds, MEMTXATTRS_UNSPECIFIED);
+                     desc, DESC_SIZE_BYTES, MEMTXATTRS_UNSPECIFIED);
 
-    bq_idx = ring_next_idx(bq_idx);
-    s->rx_bq_wr = idx_to_ptr(bq_idx, s->rx_bq_depth);
+    s->rx_bq_wr = ring_next_ptr(s->rx_bq_wr, s->rx_bq_depth);
 
     /* Raise RX interrupt */
     s->raw_pmu_int |= RX_BQ_IN_INT;


### PR DESCRIPTION
## Summary

Follow-up to #74. That PR landed AV100 in CI but used a \`uboot_smoke_only\` workaround because the U-Boot ping path didn't complete on \`hisi-gmac\`. This PR fixes the actual GMAC bug instead of masking it, and removes the workaround.

### The bug

The previous \`hw_desc_size\` formula \`(depth_reg >> 8)\` assumed the queue depth was always 1024 descriptors (kernel default), inferring descriptor size as \`depth_reg * 4 / 1024\`. U-Boot's \`HIGMAC_HWQ_*_DEPTH\` is **2**, not 1024, so it programs \`depth_reg = 2 << 3 = 16\` — and our formula returned \`16 >> 8 = 0\`, falling back to a 16-byte descriptor size. Both U-Boot and the vendor kernel actually use 32-byte descriptors (\`DESC_SIZE = 32\` is hardcoded in \`higmac.h\`), so we'd read the WR/RD byte offsets at the wrong stride and write \`tx_bq_rd\` to an offset outside the valid 0..32 range. The next \`eth_send\` saw \`rd != wr\` and bailed with "tx bq is error!".

\`ring_next_idx\` had a related bug: it wrapped modulo a fixed 1024 (\`HW_DESC_NUM\`), which happened to work for the kernel by coincidence but ignored the programmed queue depth.

### The fix

Replace the broken queue helpers with byte-level ring arithmetic:

- \`DESC_SIZE_BYTES = 32\` — matches both the kernel and U-Boot drivers. (\`CONFIG_HIGMAC_DESC_4_WORD=y\` for 16-byte descriptors is an opt-in not used by default; comment notes the limitation.)
- \`queue_size_bytes(depth_reg) = depth_reg * 4\` — matches the encoding the driver actually uses (\`depth_reg = num_desc << 3\` for 8-word descriptors).
- \`ring_next_ptr\` advances by \`DESC_SIZE_BYTES\` and wraps at \`queue_size_bytes\` — works for any programmed depth.

Behaviour is unchanged for the kernel (depth=1024, qsize=32768, desc=32) — both old and new code agree on those values.

### Verification

\`\`\`
OpenIPC # setenv ipaddr 10.0.2.15
OpenIPC # setenv serverip 10.0.2.2
OpenIPC # setenv netmask 255.255.255.0
OpenIPC # ping 10.0.2.2
ETH0: PHY(phyaddr=1, rgmii) link UP: DUPLEX=FULL : SPEED=100M
MAC:   00-00-23-34-45-66
host 10.0.2.2 is alive
OpenIPC #
\`\`\`

(Previously the ping sat unacknowledged.)

### CI

Drop the \`uboot_smoke_only\` workaround for \`hi3516av100\` and the conditional in the CI step — AV100 now runs the same full \`ping 10.0.10.1\` ⇒ \`is alive\` gate as cv100/cv200/cv300/ev300.

## Test plan

- [x] \`bash qemu/setup.sh\` clean.
- [x] AV100 U-Boot ping returns \`host 10.0.2.2 is alive\` over slirp.
- [x] Linux behaviour unchanged: same depth/desc-size in old and new code (kernel uses depth=1024).
- [ ] CI green across all matrix entries.