### PR TITLE
hisilicon: add hi3518av100 / hi3518cv100 / hi3518ev100 (V1, CV100 siblings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,19 @@ targeting QEMU v10.2.0. Boots unmodified [OpenIPC](https://openipc.org/) firmwar
 and vendor SDK kernels to a full Linux userspace on all supported platforms.
 
 Builds two QEMU targets:
-- `qemu-system-arm` — 25 IPC + 12 DVR/NVR + 1 STB (ARMv7-A)
+- `qemu-system-arm` — 28 IPC + 12 DVR/NVR + 1 STB (ARMv7-A)
 - `qemu-system-aarch64` — 1 STB (ARMv8-A, Hi3798CV200 Cortex-A53)
 
-## Supported Machines (37 total)
+## Supported Machines (40 total)
 
 ### IPC family — V1 through V5 (`qemu-system-arm`)
 
 | Machine | Generation | CPU | IRQ | Kernel | Boot tested |
 |---------|-----------|-----|-----|--------|-------------|
 | `hi3516cv100` | V1 | ARM926EJ-S | VIC | 3.0.8 | yes |
+| `hi3518av100` | V1 | ARM926EJ-S | VIC | 3.0.8 | yes |
+| `hi3518cv100` | V1 | ARM926EJ-S | VIC | 3.0.8 | yes |
+| `hi3518ev100` | V1 | ARM926EJ-S | VIC | 3.0.8 | yes |
 | `hi3516cv200` | V2 | ARM926EJ-S | VIC | 4.9.37 | yes |
 | `hi3516av100` | V2A | Cortex-A7 | GIC | 4.9.37 | yes |
 | `hi3516dv100` | V2A | Cortex-A7 | GIC | 4.9.37 | yes |
@@ -57,7 +60,7 @@ Builds two QEMU targets:
 | `hi3796mv100` | `qemu-system-arm` | Cortex-A7 quad | 4.9.37 backported from vendor 3.10 (HiSTB) | yes |
 | `hi3798cv200` | `qemu-system-aarch64` | **Cortex-A53 quad** (ARMv8) | mainline Linux 7.1 + Poplar DT | yes |
 
-All 37 machines build; **37/37 boot to a shell prompt** with kernels
+All 40 machines build; **40/40 boot to a shell prompt** with kernels
 and rootfs artifacts staged in `qemu-boot/run-<machine>.sh`.
 
 ### V5 Model Suffix → Chip ID Mapping

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -117,6 +117,8 @@ static const HisiSoCConfig hi3516cv100_soc = {
     .cpu_type           = ARM_CPU_TYPE_NAME("arm926"),
     .soc_id             = HISI_SOC_ID_CV100,
     .chipid_byte_layout = true,            /* V1: byte-wise SCSYSID0..3 */
+    /* ipctool get_chip_V1(): writes 3 to 0x88, expects 1 read back. */
+    .v1_chip_id_88      = 1,
     .default_sensor     = "imx122",        /* Sony 3-wire SPI on V1 ref boards */
     /* 64 MiB on-chip DDR2 (512Mb).  Kernel gets 32 MiB, vendor mmz.ko
      * claims the upper 32 MiB at 0x82000000 — matches OpenIPC V1
@@ -200,6 +202,275 @@ static const HisiSoCConfig hi3516cv100_soc = {
      * hardware during init.  Without mapped regions, reads return 0
      * from QEMU's "unimplemented" handler, causing poll loops to hang.
      */
+    .num_regbanks       = 8,
+    .regbanks           = {
+        { "hisi-misc",   0x20120000, 0x10000 },
+        { "hisi-ddr",    0x20110000, 0x10000 },
+        { "hisi-pwm",    0x20130000, 0x10000 },
+        { "hisi-nandc",  0x10000000, 0x10000 },
+        { "hisi-viu",    0x20580000, 0x40000 },
+        { "hisi-vpss",   0x20600000, 0x10000 },
+        { "hisi-vedu",   0x20620000, 0x10000 },
+        { "hisi-aiao",   0x20650000, 0x10000 },
+    },
+};
+
+/*
+ * Hi3518AV100 (V1): die-identical to Hi3516CV100 — same ARM926EJ-S,
+ * same V1-era 0x20xxxxxx address map, same HISFC350 flash, same
+ * peripheral layout.  Per ipctool's hal_hisi.c get_chip_V1():
+ * write 3 to sysctl_base + 0x88 and read back: 3 → "3518AV100".
+ * Shipped under the same OpenIPC u-boot-hi3516cv100 tree.
+ */
+static const HisiSoCConfig hi3518av100_soc = {
+    .name               = "hi3518av100",
+    .desc               = "HiSilicon Hi3518AV100 (ARM926EJ-S, CV100 sibling)",
+    .cpu_type           = ARM_CPU_TYPE_NAME("arm926"),
+    .soc_id             = HISI_SOC_ID_CV100,
+    .chipid_byte_layout = true,
+    .v1_chip_id_88      = 3,                /* 18AV100 marker */
+    .default_sensor     = "imx122",
+    .ram_size_default   = 64 * MiB,
+    .kernel_mem_mb      = 32,
+    .extra_cmdline      = "mmz_allocator=hisi "
+                          "mmz=anonymous,0,0x82000000,32M",
+
+    .ram_base           = 0x80000000,
+    .sram_base          = 0x04010000,
+    .sram_size          = 64 * KiB,
+
+    .use_gic            = false,
+    .vic_base           = 0x10140000,
+
+    .sysctl_base        = 0x20050000,
+    .crg_base           = 0x20030000,
+
+    .num_uarts          = 3,
+    .uart_bases         = { 0x20080000, 0x20090000, 0x200A0000 },
+    .uart_irqs          = { 5, 5, 25 },
+
+    .num_timers         = 2,
+    .timer_bases        = { 0x20000000, 0x20010000 },
+    .timer_irqs         = { 3, 4 },
+    .timer_freq         = 50000000,
+
+    .num_spis           = 2,
+    .spi_bases          = { 0x200C0000, 0x200E0000 },
+    .spi_irqs           = { 6, 7 },
+
+    .fmc_ctrl_base      = 0x10010000,
+    .fmc_mem_base       = 0x58000000,
+    .fmc_type           = "hisi-sfc350",
+
+    .gpio_base          = 0x20140000,
+    .gpio_count         = 12,
+    .gpio_stride        = 0x10000,
+    .gpio_irq           = 31,
+
+    .dma_base           = 0x100D0000,
+    .dma_irq            = 14,
+
+    .femac_base         = 0x10090000,
+    .femac_irq          = 12,
+
+    .num_himci          = 1,
+    .himci_bases        = { 0x10020000 },
+    .himci_irqs         = { 18 },
+
+    .num_i2c            = 1,
+    .i2c_bases          = { 0x200D0000 },
+    .i2c_type           = "hisi-i2c-v1",
+
+    .wdt_base           = 0x20040000,
+    .wdt_irq            = -1,
+    .wdt_freq           = 3000000,
+
+    .num_crg_defaults   = 4,
+    .crg_defaults       = {
+        { 0x00, (1 << 24) | (1 << 27) },
+        { 0x04, (1 << 12) | 46 },
+        { 0x10, (1 << 24) | (1 << 27) },
+        { 0x14, (3 << 12) | 25 },
+    },
+
+    .num_regbanks       = 8,
+    .regbanks           = {
+        { "hisi-misc",   0x20120000, 0x10000 },
+        { "hisi-ddr",    0x20110000, 0x10000 },
+        { "hisi-pwm",    0x20130000, 0x10000 },
+        { "hisi-nandc",  0x10000000, 0x10000 },
+        { "hisi-viu",    0x20580000, 0x40000 },
+        { "hisi-vpss",   0x20600000, 0x10000 },
+        { "hisi-vedu",   0x20620000, 0x10000 },
+        { "hisi-aiao",   0x20650000, 0x10000 },
+    },
+};
+
+/*
+ * Hi3518CV100 (V1): die-identical to Hi3516CV100; ipctool identifies
+ * it via sysctl_base + 0x8C bits[14:8] == 0x10.
+ */
+static const HisiSoCConfig hi3518cv100_soc = {
+    .name               = "hi3518cv100",
+    .desc               = "HiSilicon Hi3518CV100 (ARM926EJ-S, CV100 sibling)",
+    .cpu_type           = ARM_CPU_TYPE_NAME("arm926"),
+    .soc_id             = HISI_SOC_ID_CV100,
+    .chipid_byte_layout = true,
+    .v1_chip_id_8c      = 0x10 << 8,        /* bits[14:8] = 0x10 → 3518CV100 */
+    .default_sensor     = "imx122",
+    .ram_size_default   = 64 * MiB,
+    .kernel_mem_mb      = 32,
+    .extra_cmdline      = "mmz_allocator=hisi "
+                          "mmz=anonymous,0,0x82000000,32M",
+
+    .ram_base           = 0x80000000,
+    .sram_base          = 0x04010000,
+    .sram_size          = 64 * KiB,
+
+    .use_gic            = false,
+    .vic_base           = 0x10140000,
+
+    .sysctl_base        = 0x20050000,
+    .crg_base           = 0x20030000,
+
+    .num_uarts          = 3,
+    .uart_bases         = { 0x20080000, 0x20090000, 0x200A0000 },
+    .uart_irqs          = { 5, 5, 25 },
+
+    .num_timers         = 2,
+    .timer_bases        = { 0x20000000, 0x20010000 },
+    .timer_irqs         = { 3, 4 },
+    .timer_freq         = 50000000,
+
+    .num_spis           = 2,
+    .spi_bases          = { 0x200C0000, 0x200E0000 },
+    .spi_irqs           = { 6, 7 },
+
+    .fmc_ctrl_base      = 0x10010000,
+    .fmc_mem_base       = 0x58000000,
+    .fmc_type           = "hisi-sfc350",
+
+    .gpio_base          = 0x20140000,
+    .gpio_count         = 12,
+    .gpio_stride        = 0x10000,
+    .gpio_irq           = 31,
+
+    .dma_base           = 0x100D0000,
+    .dma_irq            = 14,
+
+    .femac_base         = 0x10090000,
+    .femac_irq          = 12,
+
+    .num_himci          = 1,
+    .himci_bases        = { 0x10020000 },
+    .himci_irqs         = { 18 },
+
+    .num_i2c            = 1,
+    .i2c_bases          = { 0x200D0000 },
+    .i2c_type           = "hisi-i2c-v1",
+
+    .wdt_base           = 0x20040000,
+    .wdt_irq            = -1,
+    .wdt_freq           = 3000000,
+
+    .num_crg_defaults   = 4,
+    .crg_defaults       = {
+        { 0x00, (1 << 24) | (1 << 27) },
+        { 0x04, (1 << 12) | 46 },
+        { 0x10, (1 << 24) | (1 << 27) },
+        { 0x14, (3 << 12) | 25 },
+    },
+
+    .num_regbanks       = 8,
+    .regbanks           = {
+        { "hisi-misc",   0x20120000, 0x10000 },
+        { "hisi-ddr",    0x20110000, 0x10000 },
+        { "hisi-pwm",    0x20130000, 0x10000 },
+        { "hisi-nandc",  0x10000000, 0x10000 },
+        { "hisi-viu",    0x20580000, 0x40000 },
+        { "hisi-vpss",   0x20600000, 0x10000 },
+        { "hisi-vedu",   0x20620000, 0x10000 },
+        { "hisi-aiao",   0x20650000, 0x10000 },
+    },
+};
+
+/*
+ * Hi3518EV100 (V1): die-identical to Hi3516CV100; ipctool identifies
+ * it via either sysctl_base + 0x8C bits[14:8] == 0x57 OR
+ * sysctl_base + 0x88 == 2.  We populate both for robustness.
+ */
+static const HisiSoCConfig hi3518ev100_soc = {
+    .name               = "hi3518ev100",
+    .desc               = "HiSilicon Hi3518EV100 (ARM926EJ-S, CV100 sibling)",
+    .cpu_type           = ARM_CPU_TYPE_NAME("arm926"),
+    .soc_id             = HISI_SOC_ID_CV100,
+    .chipid_byte_layout = true,
+    .v1_chip_id_88      = 2,                /* 18EV100 marker */
+    .v1_chip_id_8c      = 0x57 << 8,        /* bits[14:8] = 0x57 → 3518EV100 */
+    .default_sensor     = "imx122",
+    .ram_size_default   = 64 * MiB,
+    .kernel_mem_mb      = 32,
+    .extra_cmdline      = "mmz_allocator=hisi "
+                          "mmz=anonymous,0,0x82000000,32M",
+
+    .ram_base           = 0x80000000,
+    .sram_base          = 0x04010000,
+    .sram_size          = 64 * KiB,
+
+    .use_gic            = false,
+    .vic_base           = 0x10140000,
+
+    .sysctl_base        = 0x20050000,
+    .crg_base           = 0x20030000,
+
+    .num_uarts          = 3,
+    .uart_bases         = { 0x20080000, 0x20090000, 0x200A0000 },
+    .uart_irqs          = { 5, 5, 25 },
+
+    .num_timers         = 2,
+    .timer_bases        = { 0x20000000, 0x20010000 },
+    .timer_irqs         = { 3, 4 },
+    .timer_freq         = 50000000,
+
+    .num_spis           = 2,
+    .spi_bases          = { 0x200C0000, 0x200E0000 },
+    .spi_irqs           = { 6, 7 },
+
+    .fmc_ctrl_base      = 0x10010000,
+    .fmc_mem_base       = 0x58000000,
+    .fmc_type           = "hisi-sfc350",
+
+    .gpio_base          = 0x20140000,
+    .gpio_count         = 12,
+    .gpio_stride        = 0x10000,
+    .gpio_irq           = 31,
+
+    .dma_base           = 0x100D0000,
+    .dma_irq            = 14,
+
+    .femac_base         = 0x10090000,
+    .femac_irq          = 12,
+
+    .num_himci          = 1,
+    .himci_bases        = { 0x10020000 },
+    .himci_irqs         = { 18 },
+
+    .num_i2c            = 1,
+    .i2c_bases          = { 0x200D0000 },
+    .i2c_type           = "hisi-i2c-v1",
+
+    .wdt_base           = 0x20040000,
+    .wdt_irq            = -1,
+    .wdt_freq           = 3000000,
+
+    .num_crg_defaults   = 4,
+    .crg_defaults       = {
+        { 0x00, (1 << 24) | (1 << 27) },
+        { 0x04, (1 << 12) | 46 },
+        { 0x10, (1 << 24) | (1 << 27) },
+        { 0x14, (3 << 12) | 25 },
+    },
+
     .num_regbanks       = 8,
     .regbanks           = {
         { "hisi-misc",   0x20120000, 0x10000 },
@@ -3787,6 +4058,8 @@ static void hisilicon_common_init(MachineState *machine,
         qdev_prop_set_uint32(sysctl, "soc-id", c->soc_id);
         qdev_prop_set_bit(sysctl, "byte-layout-id", c->chipid_byte_layout);
         qdev_prop_set_uint8(sysctl, "chip-variant", c->chip_variant);
+        qdev_prop_set_uint32(sysctl, "v1-chip-id-88", c->v1_chip_id_88);
+        qdev_prop_set_uint32(sysctl, "v1-chip-id-8c", c->v1_chip_id_8c);
         sysbus_realize_and_unref(SYS_BUS_DEVICE(sysctl), &error_fatal);
         sysbus_mmio_map(SYS_BUS_DEVICE(sysctl), 0, c->sysctl_base);
     }
@@ -4444,6 +4717,9 @@ static void hisi_machine_set_sensor(Object *obj, const char *value,
                             arm_machine_interfaces)
 
 DEFINE_HISI_MACHINE("hi3516cv100", hi3516cv100, hi3516cv100_soc)
+DEFINE_HISI_MACHINE("hi3518av100", hi3518av100, hi3518av100_soc)
+DEFINE_HISI_MACHINE("hi3518cv100", hi3518cv100, hi3518cv100_soc)
+DEFINE_HISI_MACHINE("hi3518ev100", hi3518ev100, hi3518ev100_soc)
 DEFINE_HISI_MACHINE("hi3516cv200", hi3516cv200, hi3516cv200_soc)
 DEFINE_HISI_MACHINE("hi3516av100", hi3516av100, hi3516av100_soc)
 DEFINE_HISI_MACHINE("hi3516dv100", hi3516dv100, hi3516dv100_soc)

--- a/qemu/hw/misc/hisi-sysctl.c
+++ b/qemu/hw/misc/hisi-sysctl.c
@@ -37,6 +37,21 @@ struct HisiSysctlState {
     uint32_t soc_id;
     bool byte_layout;
     uint8_t chip_variant;
+    /*
+     * V1-family chip identification registers.  ipctool's get_chip_V1()
+     * reads SCSYSID0 (giving family ID 0x35180100) and then disambiguates
+     * the four V1 variants via two non-standard registers:
+     *   0x88 — read-only chip ID byte (1 = 3516CV100, 2 = 3518EV100,
+     *          3 = 3518AV100); driver writes 3 first then reads back,
+     *          but real silicon ignores the write.
+     *   0x8C — read-only field with bits[14:8] holding a chip-specific
+     *          tag (0x10 = 3518CV100, 0x57 = 3518EV100); takes priority
+     *          over 0x88 when matched.
+     * Both default to 0 (= "match nothing"); per-SoC machine init sets
+     * the value that lets ipctool identify the chip.
+     */
+    uint32_t v1_chip_id_88;
+    uint32_t v1_chip_id_8c;
     uint32_t regs[HISI_SYSCTL_NREGS];
 };
 
@@ -49,8 +64,12 @@ static uint64_t hisi_sysctl_read(void *opaque, hwaddr offset, unsigned size)
         return s->regs[0];
     case 0x04: /* SC_SYSRES — system reset (write-only, read returns 0) */
         return 0;
-    case 0x8C: /* REG_SYSSTAT — boot mode (0 = SPI NOR boot) */
-        return s->regs[0x8C / 4];
+    case 0x88: /* V1 chip ID register (read-only, write-ignored) */
+        return s->v1_chip_id_88;
+    case 0x8C: /* V1 chip ID + REG_SYSSTAT (boot mode) — bits[14:8] hold
+                * the chip tag (0x10 / 0x57); other bits unused (= 0 =
+                * SPI NOR boot mode). */
+        return s->v1_chip_id_8c | s->regs[0x8C / 4];
     /*
      * SCSYSID0..3 chip identification block. Two layouts coexist:
      *
@@ -99,6 +118,8 @@ static void hisi_sysctl_write(void *opaque, hwaddr offset,
                       (uint32_t)val);
         qemu_system_reset_request(SHUTDOWN_CAUSE_GUEST_RESET);
         break;
+    case 0x88: /* V1 chip ID register — read-only, drop writes */
+        break;
     default:
         if (offset < HISI_SYSCTL_MMIO_SIZE) {
             s->regs[offset / 4] = (uint32_t)val;
@@ -128,6 +149,8 @@ static const Property hisi_sysctl_properties[] = {
     DEFINE_PROP_UINT32("soc-id", HisiSysctlState, soc_id, 0),
     DEFINE_PROP_BOOL("byte-layout-id", HisiSysctlState, byte_layout, false),
     DEFINE_PROP_UINT8("chip-variant", HisiSysctlState, chip_variant, 0),
+    DEFINE_PROP_UINT32("v1-chip-id-88", HisiSysctlState, v1_chip_id_88, 0),
+    DEFINE_PROP_UINT32("v1-chip-id-8c", HisiSysctlState, v1_chip_id_8c, 0),
 };
 
 static void hisi_sysctl_class_init(ObjectClass *klass, const void *data)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -109,6 +109,17 @@ typedef struct HisiSoCConfig {
      */
     uint8_t         chip_variant;
 
+    /*
+     * V1-family chip identification at non-standard sysctl offsets.
+     * ipctool's get_chip_V1() reads SCSYSID0 (giving the family ID
+     * 0x35180100) and then disambiguates the four V1 variants via
+     * sysctl_base + 0x88 and sysctl_base + 0x8C — see hisi-sysctl.c
+     * and ipctool's hal_hisi.c get_chip_V1().  Both default to 0
+     * (= unmatched) for non-V1 SoCs.
+     */
+    uint32_t        v1_chip_id_88; /* 1=CV100, 2=18EV100, 3=18AV100 */
+    uint32_t        v1_chip_id_8c; /* bits[14:8]: 0x10=18CV100, 0x57=18EV100 */
+
     /* UARTs (PL011) */
     int             num_uarts;
     hwaddr          uart_bases[HISI_MAX_UARTS];


### PR DESCRIPTION
## Summary

Three more die-identical V1 siblings of Hi3516CV100 — same ARM926EJ-S, same \`0x20xxxxxx\` address map, same HISFC350 flash, same peripheral layout. Per ipctool's \`hal_hisi.c\` \`get_chip_V1()\`, they share the SCSYSID0 family ID \`0x35180100\` and are disambiguated by two non-standard sysctl registers:

| Reg                | Value      | Chip       |
|--------------------|------------|------------|
| \`sysctl + 0x88\`  | 1          | 3516CV100  |
| \`sysctl + 0x88\`  | 2          | 3518EV100  |
| \`sysctl + 0x88\`  | 3          | 3518AV100  |
| \`sysctl + 0x8C\` bits[14:8] | 0x10 | 3518CV100 |
| \`sysctl + 0x8C\` bits[14:8] | 0x57 | 3518EV100 |

\`0x88\` is a read-only chip-ID register (ipctool writes 3 first, but real silicon ignores it); \`0x8C\` takes priority over \`0x88\` when matched.

## Changes

- Extended \`hisi-sysctl\` with two new properties \`v1-chip-id-88\` / \`v1-chip-id-8c\`. Default 0 (= "unmatched") for non-V1 SoCs.
- Added \`HisiSoCConfig\` fields and wiring to plumb them into the device.
- Added three new SoC configs verbatim-cloned from \`hi3516cv100_soc\`:
  - \`hi3518av100_soc\`: \`v1_chip_id_88 = 3\`
  - \`hi3518cv100_soc\`: \`v1_chip_id_8c = 0x10 << 8\`
  - \`hi3518ev100_soc\`: both markers set (ipctool can identify EV100 via either path)
- \`hi3516cv100_soc\` now also sets \`v1_chip_id_88 = 1\` so ipctool running on \`-M hi3516cv100\` correctly identifies the chip too — previously the register read 0 and ipctool returned "unknown". No behavioural change for kernels: they only read SCSYSID0..3, not 0x88/0x8C.
- README totals bumped 37 → 40.

## Test plan

- [x] \`bash qemu/setup.sh\` clean.
- [x] \`-machine help | grep hi3518\` lists all three new entries.
- [x] \`-M hi3518av100\`, \`-M hi3518cv100\`, \`-M hi3518ev100\` each boot \`qemu-boot/uImage.hi3516cv100\` + \`rootfs.squashfs.hi3516cv100\` to the \`Welcome to OpenIPC\` / login prompt.
- [x] \`-M hi3516cv100\` still boots — no regression.

## Notes

The login banner reflects the *kernel*'s \`MACHINE_START\` name (\`openipc-hi3516cv100\`), not the QEMU machine type — same situation as #77 with the V2A/V4A siblings. The actual chip-id differentiation is what ipctool reads via SCSYSID0 + the new 0x88/0x8C registers.