### PR TITLE
hisilicon: bump boot-ROM copy size 256 KiB → 1 MiB (fixes Goke V4 silent UART)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -3676,7 +3676,18 @@ static void hisilicon_write_bootrom(MemoryRegion *sysmem,
 {
     hwaddr flash_src = c->fmc_mem_base;         /* e.g. 0x14000000 */
     hwaddr ram_dst   = c->ram_base;             /* e.g. 0x40000000 */
-    uint32_t copy_sz = 0x40000;                 /* 256 KB boot partition */
+    /*
+     * Boot partition copy size.  Vendor U-Boot binaries vary widely:
+     * Hi3516CV100 ≈ 130 KB, Hi3516EV200 ≈ 230 KB, Goke V4 ≈ 515 KB.
+     * Real silicon's boot ROM parses a header to learn the exact size;
+     * we don't model that — copy 1 MiB which is enough to cover every
+     * vendor image we've seen, padded with whatever the surrounding
+     * flash holds.  Goke V4 silently failed when this was 256 KiB:
+     * relocation tables sit past 256 KiB in the 515 KiB binary, so
+     * post-relocation U-Boot jumped into garbage and produced no
+     * UART output.
+     */
+    uint32_t copy_sz = 0x100000;                /* 1 MiB boot partition */
     bool armv7 = c->use_gic;  /* ARM926 SoCs use VIC, Cortex-A7+ use GIC */
 
     /*


### PR DESCRIPTION
## Summary

Fixes the silent-UART entries on the gap list for \`gk7205v300\` and \`gk7605v100\` (and as a bonus, \`gk7205v200\` / \`gk7202v300\` which had the same root cause).

### The bug

Our boot-ROM stub copies the U-Boot image from SPI NOR flash to DDR before jumping into it.  Hardcoded \`copy_sz = 0x40000\` (256 KiB) was sized for the original lineup of vendor U-Boots:

| SoC          | u-boot.bin size |
|--------------|-----------------|
| Hi3516CV100  | ~130 KiB        |
| Hi3516EV200  | ~230 KiB        |
| Hi3516EV300  | ~230 KiB        |
| Hi3518EV300  | ~230 KiB        |
| **Goke V4**  | **~515 KiB** ❌ |

Goke V4 U-Boots are ~2× fatter.  The first 256 KiB has the text + early init, but the relocation tables sit in the upper half.  Real silicon's boot ROM parses a Sub-Image-Manifest header to learn the exact size and copies the whole thing; we don't model that, so on \`-M gk7205v*\` U-Boot jumped into a relocated section whose target memory was never copied, executed zeros, and emitted nothing on the UART (silent hang).

### Fix

\`copy_sz\` → 1 MiB.  Big enough to cover every vendor U-Boot image we've seen with margin, anything beyond the actual U-Boot end is just zero-padded flash data and harmless to copy.

### Verification

After the fix:

\`\`\`
=== gk7205v200 ===
U-Boot 2016.11-gcb34ca5-dirty (May 07 2026 - 17:00:02 +0000)gk7205v200
RAM:   64MB
Relocation Offset is: 0372e000
SPI Nor:  Check Flash Memory Controller v100 ... Found

=== gk7205v300 ===
U-Boot 2016.11-gcb34ca5-dirty (May 07 2026 - 17:00:06 +0000)gk7205v300
Relocation Offset is: 0772c000
SPI Nor:  Check Flash Memory Controller v100 ... Found

=== gk7202v300 ===
U-Boot 2016.11-gcb34ca5-dirty (May 07 2026 - 17:00:09 +0000)gk7202v300

=== gk7605v100 ===
U-Boot 2016.11-gcb34ca5-dirty (May 07 2026 - 17:00:14 +0000)gk7605v100
\`\`\`

(Previously: 0 bytes on UART for all four.)

\`hi3516ev200\` / \`hi3516ev300\` / \`hi3518ev300\` still print \`System startup\` — no regression on existing flash-boot SoCs.

## Test plan

- [x] \`bash qemu/setup.sh\` clean.
- [x] All four Goke V4 SoCs reach U-Boot banner from flash.
- [x] Existing V4 IPC SoCs (ev200/ev300/18ev300) still reach \`System startup\` (the last line they printed before the U-Boot banner anyway).
- [x] CI green.