### PR TITLE
hisilicon: machine-level flash-file property (fixes #80)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,6 @@ jobs:
             append: "console=ttyAMA0,115200 root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),2048k(kernel),5120k(rootfs),-(rootfs_data)"
             ping_linux: true
             uboot_bin: u-boot-hi3516cv100-universal.bin
-            flash_type: hisi-sfc350
 
           - name: hi3516cv200
             soc: hi3516cv200
@@ -203,10 +202,6 @@ jobs:
             append: "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)"
             ping_linux: true
             uboot_bin: u-boot-hi3516av100-universal.bin
-            # AV100 (V2A) shares CV100's HISFC350 flash controller — must
-            # set the flash-file global on hisi-sfc350, NOT hisi-fmc.
-            # See openhisilicon#59.
-            flash_type: hisi-sfc350
 
           - name: hi3516cv300
             soc: hi3516cv300
@@ -387,7 +382,6 @@ jobs:
           dd if=qemu-boot/rootfs.squashfs.${{ matrix.soc }} of=$FLASH bs=1 seek=$((0x350000)) conv=notrunc 2>/dev/null
 
           mkfifo /tmp/ub.in /tmp/ub.out
-          FLASH_TYPE="${{ matrix.flash_type || 'hisi-fmc' }}"
           # flash_mem overrides the machine-default ram size for
           # U-Boot flash-boot (some SoCs need more RAM than the
           # kernel-default to fit U-Boot + decompressed kernel).
@@ -395,9 +389,11 @@ jobs:
           if [ -n "${{ matrix.flash_mem }}" ]; then
             MEM_ARG="-m ${{ matrix.flash_mem }}"
           fi
+          # `-M $machine,flash-file=$f` works regardless of which
+          # underlying flash controller (hisi-fmc / hisi-sfc350) the
+          # machine instantiates.  See openhisilicon#80.
           $QEMU \
-            -M ${{ matrix.machine }} $MEM_ARG \
-            -global ${FLASH_TYPE}.flash-file=$FLASH \
+            -M ${{ matrix.machine }},flash-file=$FLASH $MEM_ARG \
             -nographic -serial pipe:/tmp/ub -nic tap,ifname=tap0,script=no,downscript=no \
             -monitor none &
           QEMU_PID=$!

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -3426,12 +3426,13 @@ static const HisiSoCConfig hi3536_soc = {
     },
 };
 
-/* ── Machine state with sensor property ────────────────────────────── */
+/* ── Machine state with sensor + flash-file properties ─────────────── */
 
-/* Extra state appended to MachineState for the sensor property */
+/* Extra state appended to MachineState for machine-level properties */
 typedef struct {
     MachineState parent_obj;
     char *sensor;
+    char *flash_file;
 } HisiMachineState;
 
 /* ── Appended DTB fixup ────────────────────────────────────────────── */
@@ -3923,11 +3924,31 @@ static void hisilicon_common_init(MachineState *machine,
         const char *fmc_type = c->fmc_type ? c->fmc_type : "hisi-fmc";
         DeviceState *fmc = qdev_new(fmc_type);
         SysBusDevice *fmcbus = SYS_BUS_DEVICE(fmc);
+
+        /*
+         * Forward the machine-level "flash-file" property to whichever
+         * flash controller the SoC instantiates (hisi-fmc or hisi-sfc350).
+         * Lets consumers say `-machine $M,flash-file=...` (or `-global
+         * hisi-arm.flash-file=...`) without knowing which controller the
+         * machine uses.  See openhisilicon#80.
+         *
+         * The device-level globals `-global hisi-fmc.flash-file=...` and
+         * `-global hisi-sfc350.flash-file=...` still work too — they're
+         * applied by the qdev realize machinery and only match when the
+         * SoC actually instantiates the named device, so they don't
+         * conflict with this forwarding.
+         */
+        HisiMachineState *hms = (HisiMachineState *)machine;
+        if (hms->flash_file && hms->flash_file[0]) {
+            qdev_prop_set_string(fmc, "flash-file", hms->flash_file);
+        }
+
         sysbus_realize_and_unref(fmcbus, &error_fatal);
         sysbus_mmio_map(fmcbus, 0, c->fmc_ctrl_base);
         sysbus_mmio_map(fmcbus, 1, c->fmc_mem_base);
 
-        /* Check if flash-file was set (via -global hisi-fmc.flash-file=...) */
+        /* Check if flash-file was set (via either the machine-level
+         * property or a device-level -global). */
         if (!machine->kernel_filename) {
             char *ff = object_property_get_str(OBJECT(fmc), "flash-file", NULL);
             if (ff && ff[0]) {
@@ -4678,7 +4699,7 @@ static void hisilicon_common_init(MachineState *machine,
     }
 }
 
-/* ── Sensor property accessors ─────────────────────────────────────── */
+/* ── Machine-level property accessors ──────────────────────────────── */
 
 static char *hisi_machine_get_sensor(Object *obj, Error **errp)
 {
@@ -4692,6 +4713,20 @@ static void hisi_machine_set_sensor(Object *obj, const char *value,
     HisiMachineState *s = (HisiMachineState *)obj;
     g_free(s->sensor);
     s->sensor = g_strdup(value);
+}
+
+static char *hisi_machine_get_flash_file(Object *obj, Error **errp)
+{
+    HisiMachineState *s = (HisiMachineState *)obj;
+    return g_strdup(s->flash_file);
+}
+
+static void hisi_machine_set_flash_file(Object *obj, const char *value,
+                                        Error **errp)
+{
+    HisiMachineState *s = (HisiMachineState *)obj;
+    g_free(s->flash_file);
+    s->flash_file = g_strdup(value);
 }
 
 /* ── Per-machine wrappers ──────────────────────────────────────────── */
@@ -4719,6 +4754,13 @@ static void hisi_machine_set_sensor(Object *obj, const char *value,
             hisi_machine_get_sensor, hisi_machine_set_sensor);       \
         object_class_property_set_description(oc, "sensor",          \
             "Image sensor to attach (e.g. imx335)");                 \
+        object_class_property_add_str(oc, "flash-file",              \
+            hisi_machine_get_flash_file,                             \
+            hisi_machine_set_flash_file);                            \
+        object_class_property_set_description(oc, "flash-file",      \
+            "SPI NOR flash image to attach to the SoC's flash "      \
+            "controller (forwards to whichever device the machine "  \
+            "instantiates: hisi-fmc or hisi-sfc350).");              \
         if (config.max_cpus > 0) {                                   \
             mc->max_cpus = config.max_cpus;                          \
         }                                                            \


### PR DESCRIPTION
## Summary

Resolves the abstraction leak where every downstream U-Boot CI must know which flash controller (\`hisi-fmc\` vs \`hisi-sfc350\`) each SoC uses.

The new machine-level \`flash-file\` property lets consumers attach the flash image without that knowledge:

\`\`\`bash
# Same line works for every SoC, regardless of underlying flash controller
qemu-system-arm -M \$machine,flash-file=\$flash ...
\`\`\`

The machine init forwards the property to whichever device the SoC config wires up (\`hisi-fmc\` or \`hisi-sfc350\`) just before \`sysbus_realize_and_unref\`.

## Implementation (Option 1 from the issue)

- New \`flash_file\` field on \`HisiMachineState\`.
- \`hisi_machine_get_flash_file\` / \`hisi_machine_set_flash_file\` accessors.
- \`DEFINE_HISI_MACHINE\` registers the property on every machine class with a description.
- In \`hisilicon_common_init\`, when the SoC has \`fmc_ctrl_base\`, the machine's \`flash_file\` is forwarded to the device via \`qdev_prop_set_string(fmc, "flash-file", ...)\` before realize.

## Backward compat

The existing per-device globals continue to work:

\`\`\`bash
-global hisi-fmc.flash-file=\$f       # works on V4 / Goke / V3+
-global hisi-sfc350.flash-file=\$f    # works on V1 / V2A
\`\`\`

QEMU's qdev-realize machinery applies these only when the matching device type is instantiated, so they don't conflict with the machine-level forwarding.

## CI cleanup (self-test that downstream gets simpler too)

- Drops the \`flash_type: hisi-sfc350\` matrix variable on \`hi3516cv100\` and \`hi3516av100\`.
- Drops the \`FLASH_TYPE=...\` selector in the U-Boot ping step.
- Single \`-M \$machine,flash-file=\$flash\` line now drives every SoC family.

The OpenIPC u-boot fleet (8 repos) can mirror this cleanup — drop the \`flash_type\` matrix entries everywhere they exist.

## Test plan

- [x] \`-M hi3516av100,flash-file=…\` (sfc350) reaches U-Boot banner.
- [x] \`-M hi3516ev200,flash-file=…\` / \`-M hi3516ev300,flash-file=…\` / \`-M hi3518ev300,flash-file=…\` (fmc) reach \`System startup\`.
- [x] \`-M gk7205v200,flash-file=…\` / \`-M gk7605v100,flash-file=…\` (fmc, large U-Boot) reach U-Boot banner.
- [x] Old \`-global hisi-sfc350.flash-file=…\` still works on AV100 (backward compat).
- [x] CI matrix simplified — no per-row \`flash_type\` overrides remain.

## Future cleanup

\`-machine prop=val\` is the canonical syntax. Deprecating the device-level globals is possible but not done here; downstream can migrate at their own pace.