### PR TITLE
hisi-fmc: add nor-wps-locked init knob for factory-locked NOR recovery testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,39 @@ device-level globals (`-global hisi-fmc.flash-file=…` /
 
 Default login: `root` / `12345`
 
+#### Factory-locked NOR (recovery testing)
+
+XM-flashed Winbond W25Q128s ship from the factory with `SR3.WPS = 1`
+and every individual block-lock bit set. WPS is non-volatile, so it
+survives power-cycle and even a fresh-U-Boot via the boot ROM —
+every `sf erase` / `sf write` from a recovery agent silently no-ops
+until firmware issues Winbond Global Block Unlock (`0x98`) and
+clears `SR3.WPS`. The runtime kernel/U-Boot/agent has to do this
+unlock dance to make the chip writable
+([OpenIPC kernel workaround](https://github.com/OpenIPC/linux/commit/3961fada5)).
+
+To exercise that recovery-unlock path under QEMU, use
+`hisi-fmc.nor-wps-locked=on` (default `off`):
+
+```bash
+qemu-system-arm -M hi3516ev200 -kernel u-boot.bin \
+    -global hisi-fmc.nor-wps-locked=on \
+    -global hisi-fmc.flash-file=blank-flash.img
+```
+
+When on, the emulator starts the chip in the as-shipped state
+(SR3.WPS=1, all blocks locked, none ever-unlocked) and logs:
+
+```
+hisi-fmc: factory-locked NOR (SR3.WPS=1, all 128 blocks locked);
+firmware must Global-Unlock 0x98 + clear SR3.WPS before erase/program
+will succeed
+```
+
+A test passes only if the firmware actually issues the unlock
+sequence — without the knob, the same firmware silently "works"
+against an emulator that never had the lock to begin with.
+
 ### Method 2: Boot with separate kernel and rootfs
 
 Useful for development when you build kernel and rootfs independently and

--- a/qemu/hw/misc/hisi-fmc.c
+++ b/qemu/hw/misc/hisi-fmc.c
@@ -195,6 +195,15 @@ struct HisiFmcState {
     uint8_t *block_ever_unlocked;
     uint32_t num_blocks;
 
+    /* When true, the chip starts in the as-shipped factory-locked state:
+     * SR3.WPS = 1, every block locked, none ever-unlocked.  Mirrors what
+     * Xiongmai-flashed Winbond W25Q128s come out of the factory with —
+     * lets CI exercise the kernel/U-Boot/agent recovery-unlock path
+     * (Winbond Global Block Unlock 0x98 + clear SR3.WPS) instead of the
+     * default already-unlocked-by-runtime-firmware behaviour.  See
+     * openhisilicon#83. */
+    bool     nor_wps_locked;
+
     /* Register-mode I/O buffer (shared via memory window) */
     bool     iobuf_valid;         /* true after reg-mode op, cleared on next read */
     uint8_t  iobuf[IOBUF_SIZE];
@@ -1021,6 +1030,31 @@ static void hisi_fmc_realize(DeviceState *dev, Error **errp)
             }
         }
     }
+
+    /* Factory-locked NOR override (openhisilicon#83).
+     *
+     * Applied AFTER the SquashFS scan so it overrides whatever the scan
+     * computed.  Real Xiongmai-flashed Winbond W25Q128s come out of the
+     * factory with SR3.WPS = 1 and every block individually locked; the
+     * runtime kernel/U-Boot/agent has to issue Global Block Unlock
+     * (0x98) + clear SR3.WPS to make the chip writable.  Without this
+     * knob, qemu-side flash starts already-unlocked because vendor
+     * firmware (when actually run) would have done that work — but a
+     * recovery boot ROM / fresh-U-Boot / bare-metal agent doesn't see
+     * the locked state at all, so its global-unlock code path goes
+     * untested.
+     *
+     * Default off preserves current behaviour. */
+    if (s->nor_wps_locked && s->flash_type == FLASH_TYPE_SPI_NOR &&
+        s->block_locked && s->block_ever_unlocked) {
+        s->sr3 |= 0x04;                         /* WPS = 1 */
+        memset(s->block_locked, 1, s->num_blocks);
+        memset(s->block_ever_unlocked, 0, s->num_blocks);
+        qemu_log("hisi-fmc: factory-locked NOR (SR3.WPS=1, all "
+                 "%u blocks locked); firmware must Global-Unlock 0x98 "
+                 "+ clear SR3.WPS before erase/program will succeed\n",
+                 s->num_blocks);
+    }
 }
 
 static void hisi_fmc_init(Object *obj)
@@ -1051,6 +1085,14 @@ static const Property hisi_fmc_properties[] = {
                        FLASH_TYPE_SPI_NOR),
     DEFINE_PROP_STRING("flash-file", HisiFmcState, flash_file),
     DEFINE_PROP_UINT32("flash-jedec", HisiFmcState, flash_jedec, 0),
+    /* Start the chip in the as-shipped factory-locked state for SPI NOR.
+     * When on: SR3.WPS = 1, every block individually locked, no block
+     * ever-unlocked.  Lets CI exercise the recovery-unlock path
+     * (Winbond Global Block Unlock 0x98 + clear SR3.WPS) that runtime
+     * vendor firmware would have already executed.  Default off
+     * preserves the existing already-unlocked behaviour.  See
+     * openhisilicon#83. */
+    DEFINE_PROP_BOOL("nor-wps-locked", HisiFmcState, nor_wps_locked, false),
 };
 
 static void hisi_fmc_class_init(ObjectClass *klass, const void *data)


### PR DESCRIPTION
Closes #83.

## Summary

Adds an init-time knob that lets \`-global hisi-fmc.nor-wps-locked=on\` start the emulated SPI NOR in the as-shipped factory-locked state (SR3.WPS=1 + every block individually locked + none ever-unlocked).  This is what XM-flashed Winbond W25Q128s actually look like out of the factory — and what the kernel/U-Boot/agent recovery code path has to handle (issue Winbond Global Block Unlock \`0x98\` + clear SR3.WPS).

Without this knob, the qemu side starts already-unlocked because vendor runtime firmware would have done that work — but a recovery boot ROM / fresh U-Boot / bare-metal agent never sees the locked state, so its global-unlock code path goes untested.

## Implementation

- New \`bool nor_wps_locked\` field on \`HisiFmcState\`.
- New property \`nor-wps-locked\` (default \`false\`) — preserves existing behaviour.
- Override applied at the end of \`hisi_fmc_realize\` (after the SquashFS scan that would otherwise set \`block_ever_unlocked\` for non-SquashFS blocks).  When on:
  - \`s->sr3 |= 0x04\`           — WPS = 1
  - \`block_locked[] = 1\`       — every block locked
  - \`block_ever_unlocked[] = 0\` — none ever individually unlocked
- Logs \`hisi-fmc: factory-locked NOR (SR3.WPS=1, all N blocks locked); firmware must Global-Unlock 0x98 + clear SR3.WPS before erase/program will succeed\` so the test author can grep for it.

The existing \`hisi_fmc_block_is_locked()\` plus the \`0x98\` and \`WRITE_STATUS3\` handlers consume the lock state — no other code changes needed.  After the agent issues \`0x98\` (clears \`block_locked[]\`, sets \`block_ever_unlocked[]\` to 1) and writes SR3 with bit 2 cleared, \`hisi_fmc_block_is_locked()\` returns false and erase/program proceed.

## Verification

- Default (off): no log message, no behaviour change.  Existing flows boot normally.
- On: emulator logs the factory-locked banner at boot; firmware that doesn't issue \`0x98\` + clear SR3.WPS sees blocked erase/program (existing \`PROGRAM blocked\` / \`ERASE blocked\` log lines fire).

## Future work (issue's bonus suggestion)

Once the knob lands, a CI test that:
1. Boots an emulated machine with \`nor-wps-locked=on\` and a known image.
2. Runs the defib boot-ROM upload + agent flash flow against the emulator's UART.
3. Asserts the post-flash CRC matches expected.

— would catch the silent-no-op regression on the host side without anyone needing access to a real factory-locked camera.  Out of scope for this PR (knob first, smoke-test infra separately).

## Usage

\`\`\`bash
qemu-system-arm -M hi3516ev200 -kernel u-boot.bin \\
    -drive file=blank-flash.img,if=mtd,format=raw \\
    -global hisi-fmc.nor-wps-locked=on
\`\`\`