### PR TITLE
hisi-gzip: chunk inflate loop so the windowBits cap actually fires

### DIFF
--- a/qemu/hw/misc/hisi-gzip.c
+++ b/qemu/hw/misc/hisi-gzip.c
@@ -166,7 +166,7 @@ static void hisi_gzip_do_decompress(HisiGzipState *s, uint32_t src_len_reg)
     strm.next_in = src_buf;
     strm.avail_in = src_len;
     strm.next_out = dst_buf;
-    strm.avail_out = dst_max;
+    strm.avail_out = 0;
 
     int ret = inflateInit2(&strm, windowBits);
     if (ret != Z_OK) {
@@ -181,9 +181,61 @@ static void hisi_gzip_do_decompress(HisiGzipState *s, uint32_t src_len_reg)
         return;
     }
 
-    ret = inflate(&strm, Z_FINISH);
-    uint32_t out_len = strm.total_out;
-    const char *zmsg = strm.msg;
+    /*
+     * Chunk the inflate loop with Z_NO_FLUSH and a small avail_out.
+     *
+     * Calling inflate(Z_FINISH) with the entire output buffer
+     * pre-allocated takes zlib's inflate_fast path, where the
+     * back-distance check `if (op > whave)` is guarded by `if (dist >
+     * op)` — and `op` is the current output-buffer position.  With a
+     * full-size output buffer, every back-reference resolves with
+     * `dist <= op` (intra-buffer copy) and the whave check never
+     * fires.  Result: a stream encoded with a 32 KiB window
+     * decompresses fine even though we asked for a 13-bit window cap.
+     *
+     * Forcing avail_out <= chunk_size makes zlib call updatewindow()
+     * between chunks; the slow path then uses `whave` (capped at
+     * `wsize = 1<<wbits`) for the back-distance check, matching
+     * real-silicon behaviour where back-references beyond the
+     * 8 KiB-of-window-memory boundary cannot be resolved.
+     *
+     * chunk_size = 1024 keeps the over-permissiveness slop (the
+     * effective max valid distance is `whave + position_in_buffer
+     * = wsize + chunk_size`) at 1 KiB above the cap — small enough
+     * that streams with > 8 KiB back-distances reliably trip it,
+     * while not blocking edge-case streams whose distances are
+     * exactly at 8 KiB.  See openhisilicon#85.
+     */
+    const uint32_t chunk_size = 1024;
+    size_t total_out = 0;
+    const char *zmsg = NULL;
+    do {
+        uint32_t want = dst_max - total_out;
+        if (want > chunk_size) want = chunk_size;
+        if (want == 0) {
+            /* output buffer full */
+            break;
+        }
+        strm.next_out = dst_buf + total_out;
+        strm.avail_out = want;
+
+        ret = inflate(&strm, Z_NO_FLUSH);
+        total_out += (want - strm.avail_out);
+
+        if (ret == Z_STREAM_END) break;
+        if (ret != Z_OK) {
+            zmsg = strm.msg;
+            break;
+        }
+        if (strm.avail_in == 0 && strm.avail_out > 0) {
+            /* zlib wants more input but we have none — treat as error
+             * the same way Z_FINISH would have surfaced it. */
+            ret = Z_DATA_ERROR;
+            zmsg = strm.msg ? strm.msg : "unexpected end of input";
+            break;
+        }
+    } while (1);
+    uint32_t out_len = (uint32_t)total_out;
     inflateEnd(&strm);
 
     if (ret != Z_STREAM_END && ret != Z_OK) {


### PR DESCRIPTION
Closes #85.

## Diagnosis

You were right — PR #86 / commit b7b3bb1 didn't actually enforce the cap.

\`inflate(strm, Z_FINISH)\` with the full output buffer pre-allocated takes zlib's \`inflate_fast\` path.  The back-distance check there is:

\`\`\`c
op = out - beg;          // position in CURRENT output buffer
if (dist <= op) {
    /* intra-buffer copy — no whave check */
} else {
    op = dist - op;
    if (op > whave) FAIL;  // <-- only fires when reaching here
}
\`\`\`

With one big output buffer holding the whole decompressed stream, every back-reference resolves with \`dist <= op\` and the \`whave\` check is never reached.  windowBits ends up cosmetic.

## Empirical proof

Stand-alone C test against system zlib (raw deflate stream, 33 KiB payload encoded with windowBits=-15, decoded with progressively smaller windowBits):

| windowBits | window  | Z_FINISH+full | Z_NO_FLUSH+chunked(1024) |
|-----------:|:--------|:--------------|:-------------------------|
| -15        | 32768 B | Z_STREAM_END  | Z_STREAM_END             |
| -13        |  8192 B | Z_STREAM_END  | **Z_DATA_ERROR** "invalid distance too far back" |
| -12        |  4096 B | Z_STREAM_END  | **Z_DATA_ERROR**         |
| -10        |  1024 B | Z_STREAM_END  | **Z_DATA_ERROR**         |
| -8         |   256 B | Z_STREAM_END  | **Z_DATA_ERROR**         |

Same library, same input, same windowBits — only the inflate-call shape differs.

## Fix

Switch to the chunked path: \`Z_NO_FLUSH\` in a loop with \`avail_out\` capped at 1 KiB per call.  zlib calls \`updatewindow()\` between chunks, \`whave\` correctly tops out at \`wsize = 1<<wbits = 8 KiB\`, and back-distances beyond it fail with \`Z_DATA_ERROR\` — the same path the user-facing log already surfaces.

The 1 KiB chunk leaves a ~12% slop (effective max valid distance = \`wsize + chunk = 9 KiB\` instead of strictly 8 KiB) — small enough to reject the broken \`u-boot-z.bin\` shape from #85 (which has multi-KiB excess), permissive enough not to flag streams whose distances sit exactly at 8 KiB.

## Test plan

- [x] All 7 legitimate V4/Goke u-boot artifacts (hi3516ev200/ev300, hi3518ev300, gk7205v200/v300, gk7202v300, gk7605v100) still decompress and reach the U-Boot banner.
- [x] Stand-alone C test (above) confirms chunked path rejects streams with back-distances exceeding the cap, while Z_FINISH+full accepts them.
- [x] CI green.

## Out of scope

A canned "broken stream" CI asset (e.g. the actual May 8 \`u-boot-gk7205v200-universal.bin\` with md5 \`ad398a8c…\`) would let CI assert the rejection path.  As you noted in the reopen comment, downstream u-boot CI is unaffected by the prior false-pass — gk now ships hi_gzip-encoded artifacts (PR #14, hardware-verified), so all real artifacts already use ≤8 KiB back-distances.  The gate just needs to not silently pass the next regression of the same shape, which after this PR it won't.