### PR TITLE
hi3520dv200: wire up HISFC350 so flash-file boots U-Boot (fixes #89)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2765,7 +2765,15 @@ static const HisiSoCConfig hi3520dv200_soc = {
     .timer_freq         = 99000000,
 
     .num_spis           = 0,
-    .fmc_ctrl_base      = 0,
+
+    /* HISFC350 SPI flash controller — vendor U-Boot platform.h hardcodes
+     * SFC_REG_BASE = 0x10010000 and SFC_MEM_BASE = 0x58000000 (same V1-era
+     * layout as Hi3516CV100 / Hi3518EV100).  Lets `-machine hi3520dv200,
+     * flash-file=...` boot vendor / OpenIPC U-Boot directly from the
+     * NOR image (openhisilicon#89). */
+    .fmc_ctrl_base      = 0x10010000,
+    .fmc_mem_base       = 0x58000000,
+    .fmc_type           = "hisi-sfc350",
 
     .num_i2c            = 1,
     .i2c_bases          = { 0x200d0000 },


### PR DESCRIPTION
## Summary
- `-M hi3520dv200,flash-file=...` previously fell through to fastboot mode (no FMC controller wired up), so the boot ROM emitted only 0x20 handshake probes and U-Boot never started.
- Vendor U-Boot's `platform.h` pins `SFC_REG_BASE = 0x10010000` and `SFC_MEM_BASE = 0x58000000` — the same V1-era layout already used by Hi3516CV100 / Hi3518EV100, so reusing `hisi-sfc350` is enough.
- Both the vendor SDK prebuilt (`Hi3520D_SDK_V2.0.5.1`, 228,344 B) and the `OpenIPC/u-boot-hi3520dv200` build (104,911 B) now reach the `hisilicon #` prompt within ~1 s.
- Linux `-kernel` boot is unaffected (still reaches OpenIPC login prompt).

## Test plan
- [x] Repro from #89: vendor `u-boot_hi3520d.bin` flash boot — banner + `hisilicon #` prompt visible
- [x] OpenIPC `u-boot-hi3520dv200-universal.bin` flash boot — same
- [x] Existing Linux boot via `qemu-boot/run-hi3520dv200.sh` — still reaches `openipc-hi3520dv200 login:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)