### PR TITLE
ci: add OpenIPC kernel boot test for hi3520dv200

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,14 +235,19 @@ jobs:
           # hi3516cv610 (V5) excluded: no OpenIPC firmware release yet
 
           # NVR/DVR family — OpenIPC ships nor-lite firmware for 3 SoCs:
-          #   hi3520dv200, hi3536cv100, hi3536dv100.
-          # The latter two boot cleanly with the same -kernel/-initrd path
-          # used for IPC.  hi3520dv200 ships a Linux 3.0.8 build that
-          # exhibits the PL011-disabled-UART silent-hang same as Hi3536
-          # flagship / Hi3535 vendor 3.x kernels — excluded from CI until
-          # OpenIPC's linux fork moves to a newer kernel for that SoC
-          # (locally unblocked via the Linux 4.9 backport in
-          # reference_phase4_7_hi3520dv200.md).
+          # hi3520dv200, hi3536cv100, hi3536dv100.  All three boot cleanly
+          # with the same -kernel/-initrd path used for IPC.  The earlier
+          # PL011-disabled-UART silent-hang on the Linux 3.0.8 build for
+          # hi3520dv200 is now handled by uart_pre_enable + the HIL2V200
+          # L2-cache and hieth-sf stubs (openhisilicon#66/#68/#70).  The
+          # U-Boot smoke gate parallel to hi3516av100 will follow once
+          # OpenIPC firmware/latest publishes u-boot-hi3520dv200-universal
+          # .bin (openhisilicon#89).
+          - name: hi3520dv200
+            soc: hi3520dv200
+            machine: hi3520dv200
+            append: "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs"
+
           - name: hi3536cv100
             soc: hi3536cv100
             machine: hi3536cv100


### PR DESCRIPTION
## Summary
- The PL011-disabled-UART silent hang that previously kept hi3520dv200 out of CI is fixed by `uart_pre_enable` + the HIL2V200 / hieth-sf stubs that already landed (#66 / #68 / #70).
- Published Linux 3.0.8 nor-lite firmware (`openipc.hi3520dv200-nor-lite.tgz`) now reaches the `openipc-hi3520dv200 login:` prompt in ~7 s with the default machine memory layout.
- This wires the kernel boot test into the matrix; the U-Boot smoke gate parallel to hi3516av100 will follow once OpenIPC publishes `u-boot-hi3520dv200-universal.bin` to firmware/latest (see #89).

## Test plan
- [x] Locally ran the CI matrix's exact `OpenIPC kernel + rootfs boot` step against the published `openipc.hi3520dv200-nor-lite.tgz` — login reached at iter 8 (~7 s), chip-id detection OK
- [x] Confirms no regression on the existing #65 NVR-family entries (hi3536cv100 / hi3536dv100 are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)