### PR TITLE
hi3520dv200: widen SFC350 mem window to 32 MiB + add flash run script

### DIFF
--- a/qemu-boot/run-hi3520dv200-flash.sh
+++ b/qemu-boot/run-hi3520dv200-flash.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Boot Hi3520Dv200 from a SPI NOR flash dump.
+#
+# Usage:
+#   bash qemu-boot/run-hi3520dv200-flash.sh [flash_dump.bin]
+#
+# Defaults to the 32 MiB MX25L25635E image staged in /tmp.  The image is
+# loaded into the emulated SFC350 controller; the built-in boot ROM at
+# address 0 copies U-Boot from the flash memory window (0x58000000) to
+# DDR and jumps to it.  The hi3520dv200 machine wires the SFC350
+# registers at 0x10010000 (see qemu/hw/arm/hisilicon.c:2722).
+#
+# MEM_WINDOW_SIZE in hisi-sfc350.c was widened to 32 MiB to accommodate
+# this layout (openipc/firmware#2089 reproduction).
+#
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+QEMU="$REPO_ROOT/qemu-src/build/qemu-system-arm"
+
+FLASH_FILE="${1:-/tmp/hi3520dv200-mx25l25635e-cs1-32mib-openipc-noboot-20260513-150731.bin}"
+
+if [ ! -f "$FLASH_FILE" ]; then
+    echo "Error: flash dump not found: $FLASH_FILE" >&2
+    echo "Usage: $0 <flash_dump.bin>" >&2
+    exit 1
+fi
+
+shift 2>/dev/null  # consume $1 so "$@" passes only extra args
+
+NIC_ARGS="-nic user"
+
+exec "$QEMU" -M hi3520dv200 \
+    -global hisi-sfc350.flash-file="$FLASH_FILE" \
+    -nographic -serial mon:stdio \
+    $NIC_ARGS \
+    -d unimp,guest_errors \
+    -D "$SCRIPT_DIR/qemu-hi3520dv200-flash.log" \
+    "$@"

--- a/qemu/hw/misc/hisi-sfc350.c
+++ b/qemu/hw/misc/hisi-sfc350.c
@@ -98,7 +98,10 @@
 #define SFC350_VERSION_ID       0x350
 
 #define CTRL_REG_SIZE           0x500
-#define MEM_WINDOW_SIZE         (16 * 1024 * 1024)
+/* Window sized for the largest SPI NOR we boot in QEMU (MX25L25635E = 32 MiB
+ * on hi3520dv200, openipc/firmware#2089).  mem_read returns 0xFF for offsets
+ * past s->flash_size so smaller flash images stay correct. */
+#define MEM_WINDOW_SIZE         (32 * 1024 * 1024)
 #define DATABUF_REGS            16
 #define DATABUF_BYTES           (DATABUF_REGS * 4)
 


### PR DESCRIPTION
## Summary

- Bump `MEM_WINDOW_SIZE` in `hisi-sfc350.c` from 16 MiB to 32 MiB so a real Macronix MX25L25635E dump (the chip on hi3520dv200 reference boards) is fully addressable via the AHB read window at `0x58000000`. `mem_read` already clamps offsets past `s->flash_size` to `0xFF`, so 8/16 MiB flash images stay byte-identical to before.
- Add `qemu-boot/run-hi3520dv200-flash.sh` modelled on the existing `run-cv100-flash.sh` (CV100 and 3520Dv200 share the `hisi-sfc350` controller) so flash-image boot is one-shot reproducible.

## Motivation: openipc/firmware#2089

Used to investigate [openipc/firmware#2089](https://github.com/OpenIPC/firmware/issues/2089) ("rootfs squashfs mount fails on real hardware despite CI/QEMU success"). With this PR applied:

- Running the supplied 32 MiB `hi3520dv200-mx25l25635e-cs1-…-noboot-…bin` flash dump under `bash qemu-boot/run-hi3520dv200-flash.sh <file>` reproduces the issue's failure mode **1:1**:
    ```
    SQUASHFS error: unable to read id index table
    Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(31,3)
    ```
- Swapping the rootfs+kernel partitions in the same dump with the currently-published `openipc.hi3520dv200-nor-lite` artifacts and re-booting reaches the `openipc-hi3520dv200 login:` prompt cleanly.

So QEMU is **not** masking an SFC350 emulation gap — the supplied flash dump's rootfs partition is structurally truncated (3.75 MiB FF gap in the middle of the partition, exactly where `id_table_start = 0x3BB443` lives). The "verified in QEMU" claim from openipc/firmware#2077 / #2082 holds against the actually-published rootfs file. The remaining work belongs upstream in the flashing tool, not in QEMU emulation or OpenIPC's squashfs build.

## Test plan

- [x] `qemu-system-arm -machine help | grep hi3520dv200` still lists the machine.
- [x] `bash qemu-boot/run-hi3520dv200-flash.sh <broken-32mib-dump>` reproduces the SQUASHFS panic (matches openipc/firmware#2089).
- [x] `bash qemu-boot/run-hi3520dv200-flash.sh <flash-with-published-rootfs>` boots to userspace login prompt.
- [x] QEMU `-d unimp,guest_errors` log is clean — no flash-controller fault during either run.
- [ ] CI smoke-gate (`U-Boot smoke / hi3520dv200`) still green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)