### PR TITLE
hi3520dv200: full hieth-sf MAC+PHY emulation (Linux DHCP works)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2800,8 +2800,11 @@ static const HisiSoCConfig hi3520dv200_soc = {
 
     /* HiSilicon SF Ethernet (drivers/net/hieth-sf/) — vendor 3.0.x
      * kernel hangs in hieth_init (sys-hi3520d.c set_phy_valtage busy
-     * waits on MDIO_RWCTRL bit 15) without this (openhisilicon#68). */
+     * waits on MDIO_RWCTRL bit 15) without this (openhisilicon#68).
+     * Vendor `drivers/net/hieth-sf/Kconfig` sets HIETH_IRQNUM = 56 for
+     * ARCH_HI3520D (Linux IRQ); GIC SPI = 56 - HI3520D_IRQ_START(32). */
     .hieth_sf_base      = 0x10090000,
+    .hieth_sf_irq       = 24,
 
     /* CRG default register state — vendor get_bus_clk() reads CRG0 + CRG1
      * + A9_AXI_SCALE_REG to compute busclk = (24 MHz / refdiv * fbdiv) / 2.
@@ -4457,16 +4460,17 @@ static void hisilicon_common_init(MachineState *machine,
     }
 
     /* HiSilicon SF (single-FIFO) Ethernet controller — Hi3520D family.
-     * Vendor 3.0.x drivers/net/hieth-sf/sys-hi3520d.c set_phy_valtage()
-     * busy-loops with no timeout on MDIO_RWCTRL bit 15.  This stub
-     * latches that bit on writes and returns 0xFFFF on PHY-data reads
-     * so autoscan finds nothing and the probe exits with -ENODEV.  See
-     * openhisilicon#68. */
+     * Subclass of `hisi-femac` (same register layout) with the integrated
+     * PHY responding at MDIO address 3 instead of 1 (vendor drivers/net/
+     * hieth-sf/mdio.c scans the himii bus and binds at himii:03).  Full
+     * TX/RX/IRQ inherited from FEMAC. */
     if (c->hieth_sf_base) {
         DeviceState *eth = qdev_new("hisi-hieth-sf");
+        qemu_configure_nic_device(eth, true, NULL);
         SysBusDevice *busdev = SYS_BUS_DEVICE(eth);
         sysbus_realize_and_unref(busdev, &error_fatal);
         sysbus_mmio_map(busdev, 0, c->hieth_sf_base);
+        sysbus_connect_irq(busdev, 0, pic[c->hieth_sf_irq]);
     }
 
     /* Generic register banks (pin mux, DDR PHY, PWM, etc.) */

--- a/qemu/hw/net/hisi-femac.c
+++ b/qemu/hw/net/hisi-femac.c
@@ -175,6 +175,7 @@ struct HisiFemacState {
     uint16_t phy_bmsr;
     uint16_t phy_anar;
     uint16_t phy_anlpar;
+    uint8_t  phy_addr;  /* MDIO address the integrated PHY responds at */
 
     /* GLB */
     uint32_t hostmac_l32;
@@ -277,11 +278,12 @@ static void hisi_femac_mdio_access(HisiFemacState *s, uint32_t val)
     s->mdio_rwctrl = val | MDIO_RW_FINISH;
 
     /*
-     * Respond to PHY address 0 (U-Boot default) and 1 (Linux DTB default).
+     * Respond to PHY address 0 (U-Boot default) and the configured PHY
+     * address (Linux DTB / driver default — 1 for femac, 3 for hieth-sf).
      * Real hardware has one internal PHY; the address depends on the
      * driver configuration.
      */
-    if (phy_addr != FEMAC_PHY_ADDR && phy_addr != 0) {
+    if (phy_addr != s->phy_addr && phy_addr != 0) {
         s->mdio_ro_data = 0xffff;
         return;
     }
@@ -757,6 +759,7 @@ static void hisi_femac_reset(DeviceState *dev)
 
 static const Property hisi_femac_properties[] = {
     DEFINE_NIC_PROPERTIES(HisiFemacState, conf),
+    DEFINE_PROP_UINT8("phy-addr", HisiFemacState, phy_addr, FEMAC_PHY_ADDR),
 };
 
 static void hisi_femac_class_init(ObjectClass *klass, const void *data)

--- a/qemu/hw/net/hisi-hieth-sf.c
+++ b/qemu/hw/net/hisi-hieth-sf.c
@@ -1,140 +1,55 @@
 /*
- * HiSilicon SF (single-FIFO) Ethernet controller — minimal QEMU stub.
+ * HiSilicon SF (single-FIFO) Ethernet controller — QOM subclass of
+ * hisi-femac.
  *
- * Found on Hi3520D / Hi3536C / Hi3536DV100 family (per
- * openipc/linux:hisilicon-hi3520dv200's `drivers/net/hieth-sf/`,
- * selected via CONFIG_HIETH=y).  Vendor MMIO at 0x10090000 size 0x10000.
+ * The Hi3520Dv200 DVR/NVR SoC ships the V1-era "hieth-sf" controller
+ * at 0x10090000.  Its register layout (port @ 0x0000, MDIO @ 0x1100,
+ * GLB @ 0x1300, TX EQ_ADDR+EQFRM_LEN at 0x0360/0x0364, RX IQ_ADDR @
+ * 0x0358 / RO_IQFRM_DES @ 0x0354, IRQ_ENA/RAW/STAT @ 0x1334/1338/1330)
+ * is byte-identical to the FEMAC controller modelled in hisi-femac.c:
+ * compare the offsets in the vendor `drivers/net/hieth-sf/{glb,frag,
+ * port}.h` headers with `drivers/net/ethernet/hisilicon/hisi_femac.c`.
  *
- * The driver hang we satisfy here is in arch/arm/.../sys-hi3520d.c
- * `set_phy_valtage()` and `revise_led_shine()`, both of which do:
- *
- *     do {
- *         writel(reg_value, IO_MDIO_RWCTRL);
- *         udelay(10);
- *     } while (!(readl(IO_MDIO_RWCTRL) & (0x1 << 15)));
- *
- * with no timeout — a regbank stub returning 0 spins forever.  Hardware
- * sets bit 15 of MDIO_RWCTRL when the MDIO operation completes, so this
- * model latches bit 15 of MDIO_RWCTRL on every write, making the busy
- * wait exit on the next read.
- *
- * Other operations (PHY ID reads via hieth_mdio_read, register settings,
- * GLB_SOFT_RESET writes) follow store-then-poll-or-just-store patterns
- * that a flat regbank handles correctly.  We return 0xFFFF for
- * MDIO_RO_DATA so PHY autoscan sees "no PHY" and the driver exits the
- * probe with -ENODEV instead of touching DMA descriptors.  The kernel
- * prints "no dev probed" and continues booting; that's enough for shell.
- *
- * No TX/RX path is modeled — `-nic user` does not attach to this device.
+ * The only behavioural difference exposed to the guest is the MDIO
+ * address of the integrated PHY: vendor `drivers/net/hieth-sf/mdio.c`
+ * scans the himii bus and binds at address 3 ("himii:03"), whereas
+ * upstream hisi_femac binds at address 1.  We model that by inheriting
+ * everything from hisi-femac and only overriding the `phy-addr`
+ * property default from 1 to 3.
  *
  * Copyright (c) 2026 OpenIPC.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include "qemu/osdep.h"
+#include "qapi/error.h"
+#include "hw/qdev-properties.h"
 #include "hw/sysbus.h"
-#include "qemu/log.h"
-#include "qemu/module.h"
+#include "qom/object.h"
 
-#define TYPE_HISI_HIETH_SF "hisi-hieth-sf"
-OBJECT_DECLARE_SIMPLE_TYPE(HisiHiethSfState, HISI_HIETH_SF)
+#define TYPE_HISI_FEMAC      "hisi-femac"
+#define TYPE_HISI_HIETH_SF   "hisi-hieth-sf"
 
-#define HISI_HIETH_SF_MMIO_SIZE   0x10000
+/* PHY address the vendor Linux hieth driver scans on the himii bus. */
+#define HIETH_SF_PHY_ADDR    3
 
-/* Register offsets (drivers/net/hieth-sf/{mdio,glb}.h) */
-#define R_MDIO_RWCTRL            0x1100
-#define R_MDIO_RO_DATA           0x1104
-
-#define B_MDIO_READY             15
-
-struct HisiHiethSfState {
-    SysBusDevice parent_obj;
-    MemoryRegion iomem;
-    uint32_t regs[HISI_HIETH_SF_MMIO_SIZE / 4];
-};
-
-static uint64_t hisi_hieth_sf_read(void *opaque, hwaddr offset, unsigned size)
+static void hisi_hieth_sf_instance_init(Object *obj)
 {
-    HisiHiethSfState *s = HISI_HIETH_SF(opaque);
-
-    if (offset >= HISI_HIETH_SF_MMIO_SIZE) {
-        return 0;
-    }
-
-    switch (offset) {
-    case R_MDIO_RO_DATA:
-        /*
-         * 0xFFFF on every read register (e.g. PHY ID 1 / 2) makes the
-         * Linux PHY framework treat each PHY address as absent, so
-         * mdiobus_scan finds nothing and phy_connect returns -ENODEV.
-         */
-        return 0xFFFF;
-
-    default:
-        return s->regs[offset / 4];
-    }
-}
-
-static void hisi_hieth_sf_write(void *opaque, hwaddr offset,
-                                uint64_t val, unsigned size)
-{
-    HisiHiethSfState *s = HISI_HIETH_SF(opaque);
-
-    if (offset >= HISI_HIETH_SF_MMIO_SIZE) {
-        return;
-    }
-
-    switch (offset) {
-    case R_MDIO_RWCTRL:
-        /*
-         * Latch the "operation done" bit so the no-timeout busy waits in
-         * sys-hi3520d.c (set_phy_valtage / revise_led_shine) and the
-         * timed waits in mdio.c wait_mdio_ready() exit on first read.
-         */
-        s->regs[offset / 4] = (uint32_t)val | (1u << B_MDIO_READY);
-        break;
-
-    default:
-        s->regs[offset / 4] = (uint32_t)val;
-        break;
-    }
-}
-
-static const MemoryRegionOps hisi_hieth_sf_ops = {
-    .read = hisi_hieth_sf_read,
-    .write = hisi_hieth_sf_write,
-    .endianness = DEVICE_LITTLE_ENDIAN,
-    .valid.min_access_size = 4,
-    .valid.max_access_size = 4,
-};
-
-static void hisi_hieth_sf_init(Object *obj)
-{
-    HisiHiethSfState *s = HISI_HIETH_SF(obj);
-
-    memory_region_init_io(&s->iomem, obj, &hisi_hieth_sf_ops, s,
-                          TYPE_HISI_HIETH_SF, HISI_HIETH_SF_MMIO_SIZE);
-    sysbus_init_mmio(SYS_BUS_DEVICE(obj), &s->iomem);
-}
-
-static void hisi_hieth_sf_reset(DeviceState *dev)
-{
-    HisiHiethSfState *s = HISI_HIETH_SF(dev);
-    memset(s->regs, 0, sizeof(s->regs));
-}
-
-static void hisi_hieth_sf_class_init(ObjectClass *klass, const void *data)
-{
-    DeviceClass *dc = DEVICE_CLASS(klass);
-    device_class_set_legacy_reset(dc, hisi_hieth_sf_reset);
+    /*
+     * Override the parent `phy-addr` property default (1, for femac)
+     * with 3 so the vendor 3.0.x hieth driver finds the PHY at
+     * himii:03.  SoC init code may still override this via
+     * qdev_prop_set_uint8() before realize().
+     */
+    object_property_set_uint(obj, "phy-addr", HIETH_SF_PHY_ADDR,
+                             &error_abort);
 }
 
 static const TypeInfo hisi_hieth_sf_info = {
     .name          = TYPE_HISI_HIETH_SF,
-    .parent        = TYPE_SYS_BUS_DEVICE,
-    .instance_size = sizeof(HisiHiethSfState),
-    .instance_init = hisi_hieth_sf_init,
-    .class_init    = hisi_hieth_sf_class_init,
+    .parent        = TYPE_HISI_FEMAC,
+    .instance_init = hisi_hieth_sf_instance_init,
+    /* No fields beyond parent: instance_size + class_init inherited. */
 };
 
 static void hisi_hieth_sf_register_types(void)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -262,13 +262,13 @@ typedef struct HisiSoCConfig {
 
     /* HiSilicon SF (single-FIFO) Ethernet controller — used by Hi3520D
      * family and other vendor 3.0/3.4 kernels via drivers/net/hieth-sf/.
-     * The vendor sys-hi3520d.c set_phy_valtage() / revise_led_shine()
-     * busy-wait on MDIO_RWCTRL bit 15 with no timeout; a regbank stub
-     * spins forever.  The `hisi-hieth-sf` model latches that bit on
-     * MDIO_RWCTRL writes so the polling loop exits, and returns 0xFFFF
-     * for MDIO_RO_DATA so PHY autoscan finds nothing and the probe
-     * fails gracefully (no DMA-ring init).  No NIC packet path. */
+     * Register layout matches FEMAC byte-for-byte; the `hisi-hieth-sf`
+     * model subclasses `hisi-femac` and only overrides the PHY MDIO
+     * address (3 instead of 1, where vendor `drivers/net/hieth-sf/
+     * mdio.c` scans the himii bus).  Full TX/RX rings and IRQ path
+     * are inherited from the FEMAC model. */
     hwaddr          hieth_sf_base; /* 0 = no HiSilicon SF Ethernet */
+    int             hieth_sf_irq;  /* GIC SPI for the hieth-sf controller */
 
     /* Hardware True Random Number Generator
      * (HISEC_TRNG_CTRL on V3+, RNG_GEN on V2) */


### PR DESCRIPTION
## Summary

Replace the `hisi-hieth-sf` MDIO regbank stub with a **QOM subclass of `hisi-femac`**, gaining the full FEMAC TX engine, RX ring, IRQ path, and PHY model. The only behavioural difference exposed to the guest is the PHY MDIO address: **3** (vendor `drivers/net/hieth-sf/mdio.c` scans the himii bus and binds at "himii:03") instead of femac's 1. This is implemented via a new `phy-addr` UINT8 property on `hisi-femac` (default 1), with the subclass overriding the default to 3.

hi3520dv200 wires the NIC backend (`qemu_configure_nic_device`) and connects GIC SPI 24 — derived from vendor `drivers/net/hieth-sf/Kconfig` (`HIETH_IRQNUM = 56` for `ARCH_HI3520D`, minus `HI3520D_IRQ_START = 32`).

## Why

The hieth-sf register layout matches FEMAC byte-for-byte:

| Block | Offset | hieth-sf source | femac source |
|---|---|---|---|
| TX queue | EQ_ADDR=0x0360 / EQFRM_LEN=0x0364 | `drivers/net/hieth-sf/port.h` | `drivers/net/ethernet/hisilicon/hisi_femac.c` |
| RX FIFO | IQ_ADDR=0x0358 / RO_IQFRM_DES=0x0354 | same | same |
| Queue status | RO_QUEUE_STAT=0x036C | same | same |
| GLB | IRQ_RAW=0x1338 / IRQ_ENA=0x1334 / IRQ_STAT=0x1330 / HOSTMAC=0x1300 | same | same |

Rather than duplicate ~700 lines of TX/RX/IRQ logic, this PR makes `hisi-hieth-sf` a thin QOM subclass that only changes the PHY MDIO default.

## End-to-end demo

**Before** (PHY-not-found, eth0 never registered):

```
Fixed MDIO Bus: probed
himii: probed
PHY himii:03 not found
hieth: connect to phy_device himii:03 failed!
…
Starting network...
ip: SIOCGIFINDEX: No such device
…
openipc-hi3520dv200 login:
```

**After** (DHCP completes via SLIRP):

```
himii: probed
Invalid HW-MAC Address: 00:00:00:00:00:00
Set Random MAC address: 4A:97:3A:4D:28:0F
…
Starting network...
udhcpc: started, v1.36.1
udhcpc: broadcasting discover
udhcpc: broadcasting select for 10.0.2.15, server 10.0.2.2
udhcpc: lease of 10.0.2.15 obtained from 10.0.2.2, lease time 86400
…
openipc-hi3520dv200 login:
```

This closes the [openipc/firmware#2089](https://github.com/OpenIPC/firmware/issues/2089) follow-up: the boot path the user reported on real silicon (PHY link up, udhcpc DISCOVER never answered) is now end-to-end reproducible in QEMU, and DHCP succeeds when the SLIRP backend is attached.

## Files changed

- `qemu/hw/net/hisi-femac.c` — add `DEFINE_PROP_UINT8("phy-addr", …, FEMAC_PHY_ADDR)` and replace the hardcoded `FEMAC_PHY_ADDR` constant in `mdio_access` with `s->phy_addr`. No behaviour change for existing femac SoCs.
- `qemu/hw/net/hisi-hieth-sf.c` — rewrite as a QOM subclass of `hisi-femac` that sets `phy-addr = 3` in its instance_init.
- `qemu/hw/arm/hisilicon.c` — wire `qemu_configure_nic_device(eth, true, NULL)` and `sysbus_connect_irq(busdev, 0, pic[c->hieth_sf_irq])` for the hieth-sf path; set `.hieth_sf_irq = 24` on hi3520dv200.
- `qemu/include/hw/arm/hisilicon.h` — add `int hieth_sf_irq` to `HisiSoCConfig`.

## Test plan

- [x] `bash qemu-boot/run-hi3520dv200-flash.sh <fresh-image>` (with `-nic user`) reaches `openipc-hi3520dv200 login:` with eth0 holding a DHCP lease from SLIRP (`10.0.2.15`).
- [x] No `LOG_GUEST_ERROR` or unimplemented-MMIO entries in the QEMU `-d unimp,guest_errors` log.
- [x] Existing "Boot hi3520dv200" Linux CI job still passes (uses `-kernel/-initrd`, doesn't exercise network).
- [ ] U-Boot smoke gate (`uboot_smoke_only: true` for hi3520dv200) can likely be promoted to the full ping path now that PHY+MAC both work — left as a separate follow-up to keep this PR focused.
- [ ] FEMAC SoCs (hi3516cv100/cv200/cv300/ev300) still boot with PHY at address 1 (unchanged property default). Existing "Boot hi*" Linux/U-Boot CI jobs will verify on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)