### PR TITLE
ci: promote hi3520dv200 U-Boot smoke gate to full ping + Linux network

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,17 +238,16 @@ jobs:
           # rootfs) and u-boot-${soc}-universal.bin for 3 SoCs:
           # hi3520dv200, hi3536cv100, hi3536dv100.  Linux boot test runs
           # for all three.  U-Boot smoke gate is wired up parallel to
-          # hi3516av100 (openhisilicon#59 / #74).  hi3536dv100 (femac)
-          # runs the full ping path; the other two fall back to smoke
-          # (autoboot reached) — hi3520dv200's hieth-sf is a regbank stub
-          # without a real PHY model, and hi3536cv100's vendor U-Boot
-          # probes a 2-PHY GMAC config that can't link in our model.
+          # hi3516av100 (openhisilicon#59 / #74).  hi3520dv200 and
+          # hi3536dv100 (both femac/hieth-sf) run the full ping path;
+          # hi3536cv100 stays smoke-only — its vendor U-Boot probes a
+          # 2-PHY GMAC config that can't link in our single-PHY model.
           - name: hi3520dv200
             soc: hi3520dv200
             machine: hi3520dv200
             append: "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs"
+            ping_linux: true
             uboot_bin: u-boot-hi3520dv200-universal.bin
-            uboot_smoke_only: true
 
           - name: hi3536cv100
             soc: hi3536cv100
@@ -423,11 +422,10 @@ jobs:
 
           # Smoke-only mode: stop after the autoboot prompt, skip the network
           # half.  Used for SoCs whose U-Boot networking path doesn't complete
-          # in QEMU even though U-Boot itself runs — e.g. hi3520dv200's
-          # hieth-sf is a regbank stub (no real PHY model), and hi3536cv100's
-          # vendor U-Boot probes a 2-PHY GMAC config that can't link in our
-          # single-PHY model.  Same gate shape OpenIPC/u-boot-{cv200,cv300}
-          # use downstream ("gets past System startup").
+          # in QEMU even though U-Boot itself runs — currently only
+          # hi3536cv100, whose vendor U-Boot probes a 2-PHY GMAC config that
+          # can't link in our single-PHY model.  Same gate shape OpenIPC/
+          # u-boot-{cv200,cv300} use downstream ("gets past System startup").
           SMOKE_ONLY="${{ matrix.uboot_smoke_only || 'false' }}"
           if [ "$SMOKE_ONLY" = "true" ]; then
             exec 3>&-


### PR DESCRIPTION
## Summary

Follow-up to #94 (full hieth-sf MAC+PHY emulation): now that hi3520dv200 has a working PHY + TX/RX DMA path, promote the existing CI U-Boot smoke gate to the full `ping 10.0.10.1 → is alive` path other femac SoCs use, and add `ping_linux: true` so the Linux boot job runs the busybox ping + curl gate (`test-linux-network.sh`) over the same TAP bridge.

## Verification

Built #94's branch locally and ran the **same** invocation the CI gate uses for the U-Boot test, just with SLIRP (`-nic user,net=10.0.10.0/24,host=10.0.10.1`) in place of TAP, since the SLIRP host answers ICMP echo identically to dnsmasq on the qbr0 bridge:

```
OpenIPC # setenv ipaddr 10.0.10.15
OpenIPC # setenv serverip 10.0.10.1
OpenIPC # setenv gatewayip 10.0.10.1
OpenIPC # setenv netmask 255.255.255.0
OpenIPC # ping 10.0.10.1
Hisilicon ETH net controler
MAC:   00-00-23-34-45-66
UP_PORT : phy status change : LINK=UP : DUPLEX=FULL : SPEED=100M
host 10.0.10.1 is alive
```

That's the exact "is alive" string the gate greps for.

For the Linux side, the same flash image's kernel boot reaches `openipc-hi3520dv200 login:` with eth0 holding a DHCP lease (`udhcpc: lease of 10.0.2.15 obtained from 10.0.2.2`). Under TAP+dnsmasq the lease will come from `10.0.10.50..99` instead, and the existing `test-linux-network.sh` runs `ping -c1 10.0.10.1` and `curl http://10.0.10.1:8080` post-login.

## Dependency

This depends on #94 landing first — without the full hieth-sf MAC+PHY emulation the CI gate's `ping 10.0.10.1` will hit `ARP Retry` (real-HW network init never completes against a regbank stub). Don't merge this PR before #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)