### PR TITLE
hi3536cv100: fix gmac base address + add 16-byte descriptor support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,11 +237,10 @@ jobs:
           # NVR/DVR family — OpenIPC ships nor-lite firmware (kernel +
           # rootfs) and u-boot-${soc}-universal.bin for 3 SoCs:
           # hi3520dv200, hi3536cv100, hi3536dv100.  Linux boot test runs
-          # for all three.  U-Boot smoke gate is wired up parallel to
-          # hi3516av100 (openhisilicon#59 / #74).  hi3520dv200 and
-          # hi3536dv100 (both femac/hieth-sf) run the full ping path;
-          # hi3536cv100 stays smoke-only — its vendor U-Boot probes a
-          # 2-PHY GMAC config that can't link in our single-PHY model.
+          # for all three; all three also run the full U-Boot ping path
+          # (parallel to hi3516av100, openhisilicon#59 / #74).  See the
+          # per-SoC notes in qemu/hw/arm/hisilicon.c for which Ethernet
+          # controller each instantiates (hieth-sf, femac, gmac).
           - name: hi3520dv200
             soc: hi3520dv200
             machine: hi3520dv200
@@ -254,7 +253,6 @@ jobs:
             machine: hi3536cv100
             append: "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs"
             uboot_bin: u-boot-hi3536cv100-universal.bin
-            uboot_smoke_only: true
 
           - name: hi3536dv100
             soc: hi3536dv100
@@ -421,11 +419,10 @@ jobs:
           done
 
           # Smoke-only mode: stop after the autoboot prompt, skip the network
-          # half.  Used for SoCs whose U-Boot networking path doesn't complete
-          # in QEMU even though U-Boot itself runs — currently only
-          # hi3536cv100, whose vendor U-Boot probes a 2-PHY GMAC config that
-          # can't link in our single-PHY model.  Same gate shape OpenIPC/
-          # u-boot-{cv200,cv300} use downstream ("gets past System startup").
+          # half.  Reserved for SoCs whose U-Boot networking path doesn't
+          # complete in QEMU even though U-Boot itself runs.  No DVR/NVR SoC
+          # uses this currently; it's kept available for new bring-ups that
+          # need to land the Linux gate before the network model is finished.
           SMOKE_ONLY="${{ matrix.uboot_smoke_only || 'false' }}"
           if [ "$SMOKE_ONLY" = "true" ]; then
             exec 3>&-

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -3202,8 +3202,18 @@ static const HisiSoCConfig hi3536cv100_soc = {
     .dma_base           = 0x11020000,
     .dma_type           = "hisi-regbank",
 
-    .gmac_base          = 0x10010000,       /* same as Hi3536DV100 FE-MAC */
-    .gmac_irq           = 11,
+    /* Vendor higmacv300 — DT `ethernet@100a0000` in OpenIPC kernel
+     * arch/arm/boot/dts/hi3536c.dtsi, second port `ethernet@100a1000`.
+     * U-Boot `arch/arm/include/asm/arch-hi3536c/platform.h` defines
+     * GSF_REG_BASE = 0x100a0000, HIGMAC1_IOBASE = +0x1000.  Shared GIC
+     * SPI 16 between both ports.  Earlier 0x10010000/IRQ 11 was a stale
+     * copy from hi3536dv100's femac slot (different controller).
+     *
+     * Vendor `drivers/net/higmacv300/higmac.h` sets
+     * CONFIG_HIGMAC_DESC_4_WORD on hi3536cv100 — 16-byte descriptors. */
+    .gmac_base          = 0x100a0000,
+    .gmac_irq           = 16,
+    .gmac_desc_size     = 16,
 
     .num_i2c            = 1,
     .i2c_bases          = { 0x120c0000 },
@@ -3225,7 +3235,14 @@ static const HisiSoCConfig hi3536cv100_soc = {
     .regbanks           = {
         { "hisi-dmac",       0x11020000, 0x1000  },
         { "hisi-cipher",     0x11030000, 0x10000 },
-        { "hisi-gmac1",      0x10020000, 0x1000  },  /* 2nd GbE stub */
+        { "hisi-gmac1",      0x100a1000, 0x1000  },  /* HIGMAC1 stub
+                                                       — DT ethernet@100a1000,
+                                                       responds 0 so the
+                                                       vendor U-Boot probe
+                                                       loop falls through
+                                                       to HIGMAC0 (where our
+                                                       PHY at addr 1 links
+                                                       UP). */
         { "hisi-ir",         0x12140000, 0x10000 },
         { "hisi-misc",       0x12120000, 0x10000 },
     },
@@ -4257,10 +4274,13 @@ static void hisilicon_common_init(MachineState *machine,
         sysbus_connect_irq(busdev, 0, pic[c->femac_irq]);
     }
 
-    /* GMAC (Gigabit Ethernet MAC) — for AV100, 3519V101 */
+    /* GMAC (Gigabit Ethernet MAC) — for AV100, 3519V101, hi3536cv100… */
     if (c->gmac_base) {
         DeviceState *gmac = qdev_new("hisi-gmac");
         qemu_configure_nic_device(gmac, true, NULL);
+        if (c->gmac_desc_size) {
+            qdev_prop_set_uint32(gmac, "desc-size", c->gmac_desc_size);
+        }
         SysBusDevice *busdev = SYS_BUS_DEVICE(gmac);
         sysbus_realize_and_unref(busdev, &error_fatal);
         sysbus_mmio_map(busdev, 0, c->gmac_base);

--- a/qemu/hw/net/hisi-gmac.c
+++ b/qemu/hw/net/hisi-gmac.c
@@ -198,6 +198,9 @@ struct HisiGmacState {
     /* PHY registers */
     uint16_t phy_regs[32];
 
+    /* Descriptor size in bytes (16 or 32; CONFIG_HIGMAC_DESC_4_WORD). */
+    uint32_t desc_size_bytes;
+
     /* Backing register array for misc registers */
     uint32_t regs[MMIO_SIZE / 4];
 };
@@ -277,13 +280,17 @@ static void hisi_gmac_update_irq(HisiGmacState *s)
  * are BYTE offsets into the queue and advance by DESC_SIZE per
  * descriptor, wrapping at queue_size_bytes.
  *
- * Both U-Boot (HIGMAC_HWQ_TX_BQ_DEPTH=2) and the vendor kernel
- * (HIGMAC_HWQ_TX_BQ_DEPTH=1024) use 32-byte descriptors on AV100 and
- * 3519V101's higmac IP — DESC_SIZE is hardcoded 32 in the kernel's
- * higmac.h.  We hardcode 32 here too.  (4-word/16-byte descriptors are
- * a CONFIG_HIGMAC_DESC_4_WORD opt-in not used by default.)
+ * Descriptor size is 8 words (32 bytes) on AV100 / 3519V101 / hi3536dv100
+ * (vendor `drivers/net/.../higmac.h` `DESC_WORD_SHIFT=3`).  It's 4 words
+ * (16 bytes) when `CONFIG_HIGMAC_DESC_4_WORD` is set — e.g. hi3536cv100
+ * (`drivers/net/higmacv300/higmac.h` with `DESC_WORD_SHIFT=2`).  Word 0
+ * is the buffer DMA address and word 1 is the length/flags bitfield;
+ * later words are reserved padding, so the read/write path doesn't
+ * change — only the stride between descriptors does.  Exposed as the
+ * `desc-size` property (default 32, set to 16 for hi3536cv100).
  */
-#define DESC_SIZE_BYTES         32
+#define DESC_SIZE_BYTES_MAX     32
+#define DESC_SIZE_BYTES_DEFAULT 32
 
 /* Queue size in bytes from the depth register value (queue size in
  * words, so * 4).  0 if the driver hasn't programmed depth yet. */
@@ -294,13 +301,14 @@ static inline uint32_t queue_size_bytes(uint32_t depth_reg)
 
 /* Advance a byte-offset ring pointer by one descriptor, wrapping at
  * queue_size_bytes.  Returns 0 if the queue is unsized. */
-static inline uint32_t ring_next_ptr(uint32_t ptr, uint32_t depth_reg)
+static inline uint32_t ring_next_ptr(HisiGmacState *s, uint32_t ptr,
+                                     uint32_t depth_reg)
 {
     uint32_t qsz = queue_size_bytes(depth_reg);
     if (!qsz) {
         return 0;
     }
-    ptr += DESC_SIZE_BYTES;
+    ptr += s->desc_size_bytes;
     if (ptr >= qsz) {
         ptr = 0;
     }
@@ -323,10 +331,10 @@ static void hisi_gmac_tx(HisiGmacState *s)
 
     while (rd_ptr != wr_ptr) {
         uint32_t desc_addr = s->tx_bq_start + rd_ptr;
-        uint32_t desc[DESC_SIZE_BYTES / 4];
+        uint32_t desc[DESC_SIZE_BYTES_MAX / 4];
 
         dma_memory_read(&address_space_memory, desc_addr,
-                        desc, DESC_SIZE_BYTES, MEMTXATTRS_UNSPECIFIED);
+                        desc, s->desc_size_bytes, MEMTXATTRS_UNSPECIFIED);
 
         uint32_t data_addr = desc[0];
         uint32_t w1 = desc[1];
@@ -350,12 +358,12 @@ static void hisi_gmac_tx(HisiGmacState *s)
 
             desc[1] = (w1 & ~(1u << 31));
             dma_memory_write(&address_space_memory, rq_addr,
-                             desc, DESC_SIZE_BYTES, MEMTXATTRS_UNSPECIFIED);
+                             desc, s->desc_size_bytes, MEMTXATTRS_UNSPECIFIED);
 
-            s->tx_rq_wr = ring_next_ptr(s->tx_rq_wr, s->tx_rq_depth);
+            s->tx_rq_wr = ring_next_ptr(s, s->tx_rq_wr, s->tx_rq_depth);
         }
 
-        rd_ptr = ring_next_ptr(rd_ptr, s->tx_bq_depth);
+        rd_ptr = ring_next_ptr(s, rd_ptr, s->tx_bq_depth);
     }
 
     s->tx_bq_rd = rd_ptr;
@@ -397,9 +405,9 @@ static ssize_t hisi_gmac_receive(NetClientState *nc, const uint8_t *buf,
 
     /* Pop a descriptor from RX_FQ */
     uint32_t fq_addr = s->rx_fq_start + s->rx_fq_rd;
-    uint32_t desc[DESC_SIZE_BYTES / 4];
+    uint32_t desc[DESC_SIZE_BYTES_MAX / 4];
     dma_memory_read(&address_space_memory, fq_addr,
-                    desc, DESC_SIZE_BYTES, MEMTXATTRS_UNSPECIFIED);
+                    desc, s->desc_size_bytes, MEMTXATTRS_UNSPECIFIED);
 
     uint32_t data_addr = desc[0];
     uint32_t w1 = desc[1];
@@ -414,7 +422,7 @@ static ssize_t hisi_gmac_receive(NetClientState *nc, const uint8_t *buf,
                      buf, size, MEMTXATTRS_UNSPECIFIED);
 
     /* Advance RX_FQ read pointer */
-    s->rx_fq_rd = ring_next_ptr(s->rx_fq_rd, s->rx_fq_depth);
+    s->rx_fq_rd = ring_next_ptr(s, s->rx_fq_rd, s->rx_fq_depth);
 
     /* Push descriptor to RX_BQ with received length */
     uint32_t bq_addr = s->rx_bq_start + s->rx_bq_wr;
@@ -426,9 +434,9 @@ static ssize_t hisi_gmac_receive(NetClientState *nc, const uint8_t *buf,
     desc[1] = w1;
 
     dma_memory_write(&address_space_memory, bq_addr,
-                     desc, DESC_SIZE_BYTES, MEMTXATTRS_UNSPECIFIED);
+                     desc, s->desc_size_bytes, MEMTXATTRS_UNSPECIFIED);
 
-    s->rx_bq_wr = ring_next_ptr(s->rx_bq_wr, s->rx_bq_depth);
+    s->rx_bq_wr = ring_next_ptr(s, s->rx_bq_wr, s->rx_bq_depth);
 
     /* Raise RX interrupt */
     s->raw_pmu_int |= RX_BQ_IN_INT;
@@ -668,6 +676,13 @@ static void hisi_gmac_realize(DeviceState *dev, Error **errp)
 
 static const Property hisi_gmac_properties[] = {
     DEFINE_NIC_PROPERTIES(HisiGmacState, conf),
+    /* Descriptor stride: 32 bytes by default (8-word descriptor), 16 for
+     * SoCs whose vendor higmacv300 sets CONFIG_HIGMAC_DESC_4_WORD — e.g.
+     * hi3536cv100.  Word 0 (buffer DMA addr) and word 1 (length/flags)
+     * sit at the same offsets in both layouts, only the per-descriptor
+     * stride differs. */
+    DEFINE_PROP_UINT32("desc-size", HisiGmacState, desc_size_bytes,
+                       DESC_SIZE_BYTES_DEFAULT),
 };
 
 static void hisi_gmac_class_init(ObjectClass *klass, const void *data)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -170,6 +170,10 @@ typedef struct HisiSoCConfig {
     /* GMAC (Gigabit Ethernet MAC) — for AV100, 3519V101 */
     hwaddr          gmac_base;      /* 0 = no GMAC */
     int             gmac_irq;
+    /* Descriptor stride in bytes (0 = device default of 32).  Set to 16
+     * for SoCs whose vendor higmacv300 driver defines
+     * CONFIG_HIGMAC_DESC_4_WORD — currently hi3536cv100. */
+    uint32_t        gmac_desc_size;
 
     /* SD/MMC — himciv200 (older SoCs) */
     int             num_himci;


### PR DESCRIPTION
## Summary

Two unrelated bugs in the hi3536cv100 SoC config / gmac model that together prevented vendor U-Boot from completing the GMAC bring-up. Fixing both lets the existing CI U-Boot ping gate run end-to-end (`host 10.0.10.1 is alive`); the smoke-only escape hatch can come off.

### 1. gmac base / IRQ were wrong

`gmac_base = 0x10010000, gmac_irq = 11` — a stale copy from hi3536dv100's *femac* slot (a different controller entirely). Vendor higmacv300 lives at the GSF register block `0x100a0000` per `arch/arm/include/asm/arch-hi3536c/platform.h` (`GSF_REG_BASE = 0x100a0000`) and shares GIC SPI 16 between both ports, per the OpenIPC kernel DT (`arch/arm/boot/dts/hi3536c.dtsi` `ethernet@100a0000` + `ethernet@100a1000`).

With the wrong base, none of vendor U-Boot's MDIO accesses reached our gmac model at all — they went into unmapped MMIO, the PHY probe returned all-zero, and both ETH0 and ETH1 reported `"PHY(phyaddr=N, rgmii) not link!"`. Move the gmac MMIO + IRQ to the correct values; relocate the `hisi-gmac1` regbank stub from `0x10020000` to `0x100a1000` so ETH1's MDIO probe falls through gracefully (its PHY at address 2 doesn't respond, the vendor probe loop moves on to ETH0).

### 2. Descriptor stride hardcoded to 32 bytes

The gmac model assumed 8-word descriptors (`DESC_SIZE_BYTES = 32`), which matches hi3516av100 / hi3519v101 / hi3536dv100 (vendors leave `CONFIG_HIGMAC_DESC_4_WORD` undefined). hi3536cv100 *does* define it (`drivers/net/higmacv300/higmac.h` `DESC_WORD_SHIFT = 2`), so descriptors are 4 words / 16 bytes. Word 0 (buffer DMA address) and word 1 (length/flags) live at the same offsets in both layouts — only the per-descriptor stride changes — so reading/writing the useful fields is unchanged.

Add an `uint32_t desc_size_bytes` state field with a `desc-size` UINT32 device property (default 32) and a matching `gmac_desc_size` knob on `HisiSoCConfig`. Set it to 16 for hi3536cv100. All other gmac SoCs keep the 32-byte default unchanged.

## Verification

```
OpenIPC # setenv ipaddr 10.0.10.15
OpenIPC # setenv serverip 10.0.10.1
OpenIPC # setenv gatewayip 10.0.10.1
OpenIPC # setenv netmask 255.255.255.0
OpenIPC # ping 10.0.10.1
PHY IDR2 read failed
ETH0: PHY(phyaddr=1, rgmii) link UP: DUPLEX=FULL : SPEED=100M
MAC:   00-00-23-34-45-66
host 10.0.10.1 is alive
```

The `PHY IDR2 read failed` line above the link-UP is a benign vendor probe of ETH1 — HIGMAC1 is still a regbank stub. The vendor probe loop falls through to ETH0 and the ping completes.

## CI change

Drop `uboot_smoke_only: true` from the hi3536cv100 matrix entry so the gate runs the same full ping path the other femac/hieth-sf SoCs use. No DVR/NVR SoC needs smoke-only mode any more; the flag stays in the workflow for future bring-ups.

## Files changed

- `qemu/hw/net/hisi-gmac.c` — `desc_size_bytes` state + `desc-size` property; replace the `DESC_SIZE_BYTES` constant in TX/RX descriptor I/O and ring-advance helper.
- `qemu/hw/arm/hisilicon.c` — pass `c->gmac_desc_size` to the gmac on instantiation; fix hi3536cv100 SoC config (gmac_base, gmac_irq, gmac_desc_size, regbank stub address).
- `qemu/include/hw/arm/hisilicon.h` — add `gmac_desc_size` field to `HisiSoCConfig`.
- `.github/workflows/ci.yml` — drop `uboot_smoke_only: true` for hi3536cv100; refresh the matrix comment.

## Test plan

- [x] `bash qemu-boot/run-...-flash.sh` style invocation locally with `-nic user,net=10.0.10.0/24,host=10.0.10.1` reproduces `host 10.0.10.1 is alive` from vendor U-Boot on hi3536cv100.
- [x] Existing "Boot hi3536cv100" Linux job still passes (kernel boot, not network).
- [ ] "Boot hi3536cv100 / U-Boot ping" job (new shape per this PR) — CI will verify on push.
- [ ] Other gmac SoCs (hi3516av100, hi3516dv100, hi3536dv100, hi3519v101, hi3520dv200…) still boot unchanged with the default 32-byte descriptor stride.

## Out of scope

- Full second-MAC emulation for HIGMAC1 (ETH1). Vendor U-Boot already proceeds with ETH0 once its link is up, so a working ETH1 isn't needed to pass the existing gates. Plumbing a second gmac instance (with its own SLIRP backend) is a separate bring-up.
- Hardening the descriptor stride against guests that probe-and-resize — kept as a static property here. Could become a `desc_size` register-derived value later if any future SoC needs runtime selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)