### PR TITLE
ci: enable ping_linux for hi3536dv100

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,7 @@ jobs:
             soc: hi3536dv100
             machine: hi3536dv100
             append: "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs"
+            ping_linux: true
             uboot_bin: u-boot-hi3536dv100-universal.bin
 
     continue-on-error: ${{ matrix.allow_failure == true }}


### PR DESCRIPTION
## Summary

Last DVR/NVR coverage gap. hi3536dv100 uses `hisi-femac` at `0x10010000` — the same QEMU controller model the other femac SoCs (hi3516cv100/cv200/av100/cv300/ev300) and, since #94, the hieth-sf subclass on hi3520dv200 run `test-linux-network.sh` against successfully. The U-Boot ping gate is already on the full ping path for hi3536dv100 (no `uboot_smoke_only`), so we know its TX/RX/PHY model works end-to-end.

Flip `ping_linux: true` so the Linux boot job runs the existing post-login busybox ping + curl checks over the TAP+dnsmasq bridge.

## Coverage after this PR

| SoC | controller | U-Boot ping | Linux ping/curl |
|---|---|---|---|
| hi3520dv200 | hieth-sf (femac subclass) | ✓ #95 | ✓ #95 |
| hi3536cv100 | hisi-gmac (16-byte desc) | ✓ #96 | (not in this PR; gmac TX/RX vs Linux higmacv300 path needs a separate look) |
| hi3536dv100 | hisi-femac | ✓ existing | ✓ **this PR** |

## Test plan

- [x] hi3536dv100 already passes the U-Boot ping gate, which exercises the same femac TX/RX/PHY path post-login.
- [ ] CI verifies the post-login busybox ping + curl in `test-linux-network.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)