### PR TITLE
hisilicon: wire hisi-ive at 0x11230000 in cv500/av300 socs

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -972,7 +972,7 @@ static const HisiSoCConfig hi3516cv500_soc = {
 
     .cpu_srst_offset    = 0x78,         /* REG_CPU_SRST_CRG for SMP bringup */
 
-    .num_regbanks       = 10,
+    .num_regbanks       = 11,
     .regbanks           = {
         { "hisi-misc",       0x12030000, 0x8000  },
         { "hisi-ddr",        0x12060000, 0x10000 },
@@ -984,6 +984,7 @@ static const HisiSoCConfig hi3516cv500_soc = {
         { "hisi-vi-proc",    0x11000000, 0x40000 },
         { "hisi-vpss",       0x11040000, 0x10000 },
         { "hisi-aiao",       0x113B0000, 0x20000 },
+        { "hisi-ive",        0x11230000, 0x10000 },   /* CV500 IVE: DT @0x11230000, SPI 37 */
     },
 };
 
@@ -1086,7 +1087,7 @@ static const HisiSoCConfig hi3516av300_soc = {
 
     .cpu_srst_offset    = 0x78,
 
-    .num_regbanks       = 11,
+    .num_regbanks       = 12,
     .regbanks           = {
         { "hisi-misc",       0x12030000, 0x8000  },
         { "hisi-ddr",        0x12060000, 0x10000 },
@@ -1099,6 +1100,7 @@ static const HisiSoCConfig hi3516av300_soc = {
         { "hisi-vpss",       0x11040000, 0x10000 },
         { "hisi-aiao",       0x113B0000, 0x20000 },
         { "hisi-npu",        0x11700000, 0x100000 },  /* 1.0 TOPS NPU */
+        { "hisi-ive",        0x11230000, 0x10000 },   /* AV300 IVE: DT @0x11230000, SPI 37 */
     },
 };
 


### PR DESCRIPTION
## Summary

The \`hi3516cv500\` and \`hi3516av300\` SoC machines have an IVE block at phys \`0x11230000\` (per cv500 DTS, distinct from the V4 family's \`0x11320000\`). Without this regbank entry, \`/dev/mem\` mmap to the IVE region from a guest kernel maps to bare RAM (silently returns zeros); guest IVE drivers see no HW.

Adds an entry to \`cv500_soc.regbanks\` and \`av300_soc.regbanks\` pointing the existing \`"hisi-ive"\` device at \`0x11230000\`. The device already handles all V4 IVE ops (sub/add/and/or/xor/thresh/hist/sobel/dilate/erode/integ + 16-bit variants); cv500 inherits these unchanged.

Note: IRQ wiring is intentionally left at the regbank-stub state for now — cv500/av300 IVE IRQ is SPI 37 per DT, distinct from V4's SPI 51. Guest drivers that poll IVE completion (rather than IRQ) work today.

## Test plan

- [x] Booted \`hi3516cv500\` machine with \`openipc.hi3516cv500-nor-lite\` kernel + a register-level IVE test cpio that mmaps \`/dev/mem\` at \`0x11230000\`. The device is reachable at the cv500 base.
- [x] V4 socs (ev200/ev300/etc.) unchanged.

## Downstream consumer

OpenIPC/openhisilicon will bump the pinned SHA + add a new \`QEMU IVE ops regression (cv500)\` CI job using \`-M hi3516cv500\` with \`--ive-base=0x11230000\` once this merges.