### PR TITLE
hi3516cv300: drop mmz= from extra_cmdline so non-CMA kernel boots

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -812,12 +812,18 @@ static const HisiSoCConfig hi3516cv300_soc = {
     .hwrng_base         = 0x120C0000,      /* HISEC_TRNG_CTRL (V3) */
     .hwrng_data_offset  = 0x204,
     /* CV300 has no on-chip DDR (external DDR3/3L up to 512 MiB).
-     * Stock CV300 cameras ship 128 MiB.  Kernel gets 32 MiB, vendor
-     * mmz.ko claims the upper 96 MiB at 0x82000000. */
+     * Stock CV300 cameras ship 128 MiB; kernel gets 32 MiB and the
+     * vendor mmz.ko claims the upper 96 MiB at 0x82000000.
+     *
+     * Do NOT inject mmz= here.  Real V3 u-boot does not set it, and
+     * OpenIPC's load_hisilicon treats the presence of mmz= as the
+     * "use CMA allocator" flag — but the cv300_lite kernel shipped
+     * in openipc.hi3516cv300-nor-lite.tgz is built without
+     * CONFIG_CMA, so the CMA branch silently fails and
+     * S99lsmodprobe never runs.  See issue #101. */
     .ram_size_default   = 128 * MiB,
     .kernel_mem_mb      = 32,
-    .extra_cmdline      = "mmz_allocator=hisi "
-                          "mmz=anonymous,0,0x82000000,96M",
+    .extra_cmdline      = NULL,
 
     .ram_base           = 0x80000000,
     .sram_base          = 0x04010000,


### PR DESCRIPTION
## Summary

- `hi3516cv300_soc.extra_cmdline` no longer auto-injects `mmz=anonymous,0,0x82000000,96M`. The OpenIPC `nor-lite` cv300 kernel is built without `CONFIG_CMA`, and `load_hisilicon` uses `mmz=` as a "use CMA allocator" flag — keeping the injection forced the script down a non-functional path and boot hung before login.
- Matches real V3 u-boot bootargs (verified on a live IMX291 / Hi3516CV300 reference board: `/proc/cmdline` contains `mem=`, `console=`, `root=`, `mtdparts=` — no `mmz=`).
- `kernel_mem_mb = 32` still auto-injects `mem=32M`; only the `mmz=` token is dropped.

Closes #101

## Test plan

- [x] `bash qemu-boot/run-cv300.sh` reaches `Welcome to OpenIPC / openipc-hi3516cv300 login:`, `Loading vendor modules… Starting majestic: OK`. Kernel command line: `… mem=32M` (no `mmz=`, no `mmz_allocator=`).
- [x] Regression: `bash qemu-boot/run-ev300.sh` still gets `mem=32M mmz_allocator=hisi mmz=anonymous,0,0x42000000,96M` auto-injected — V4 / other SoC path unchanged.
- [ ] CI: matrix entry `hi3516cv300` (`ping_linux: true`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)