### PR TITLE
hi3516av300 mask-ROM emulation: SP804 + mask-ROM alias + hisi-himci PIO

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -3946,6 +3946,27 @@ static void hisilicon_load_maskrom(MemoryRegion *sysmem,
                            HISI_MASKROM_SIZE, &error_fatal);
     memory_region_add_subregion(sysmem, HISI_MASKROM_BASE, rom);
 
+    /*
+     * Real silicon aliases the mask-ROM at low address 0 on reset.
+     * The bootrom relies on this: media_program_a stores
+     * `0x00004680` as the SD-read function pointer and later calls it
+     * via `bx`, expecting to hit the bootrom's read-block routine.
+     * Without the alias, qemu jumps to whatever is mapped at 0x4680
+     * (the trapnull stub or unmapped memory) and the bootrom crashes
+     * before ever issuing CMD17.
+     *
+     * The alias overrides the `hisilicon.trapnull` ROM that the
+     * non-bios paths install at 0 (which we still install for
+     * compatibility, then this alias takes precedence in the
+     * memory region priority).
+     */
+    {
+        MemoryRegion *alias = g_new(MemoryRegion, 1);
+        memory_region_init_alias(alias, NULL, "hisilicon.maskrom-alias-0",
+                                 rom, 0, HISI_MASKROM_SIZE);
+        memory_region_add_subregion_overlap(sysmem, 0, alias, 1);
+    }
+
     loaded = load_elf(machine->firmware, NULL, NULL, NULL,
                       &entry, &low, &high, NULL,
                       0 /* little-endian */, EM_ARM,

--- a/qemu/hw/misc/hisi-himci.c
+++ b/qemu/hw/misc/hisi-himci.c
@@ -78,6 +78,14 @@ OBJECT_DECLARE_SIMPLE_TYPE(HisiHimciState, HISI_HIMCI)
 #define MCI_UHS_REG_EXT   0x108
 #define MCI_TUNING_CTRL   0x118
 
+/* FIFO data window: DW MMC exposes its FIFO at a fixed offset.  On
+ * HiSilicon V4-family silicon the av300 mask-ROM reads via
+ * SDIO0+0x200 (verified by disasm of the PIO read at bootrom
+ * 0x0400457c).  We expose 0x200..0x3FF as the data window. */
+#define MCI_FIFO_DATA_BASE  0x200
+#define MCI_FIFO_DATA_END   0x3FF
+#define MCI_FIFO_SIZE       4096   /* enough for a 512-byte block ×8 */
+
 /* ── Bit definitions ───────────────────────────────────────────────── */
 
 /* CTRL */
@@ -152,6 +160,15 @@ struct HisiHimciState {
     uint32_t adma_q_rdptr, adma_q_wrptr;
 
     uint32_t cardthrctl, uhs_reg_ext, tuning_ctrl;
+
+    /* PIO FIFO state — populated when a DATA_EXPECTED command runs
+     * without DMA (BMOD_DE=0 and CTRL_USE_IDMAC=0).  The guest reads
+     * via MCI_FIFO_DATA_BASE; STATUS bits 17..29 expose FIFO_COUNT
+     * in 32-bit words, which the av300 mask-ROM polls before each
+     * 4-byte FIFO read. */
+    uint8_t  fifo_buf[MCI_FIFO_SIZE];
+    uint32_t fifo_len;       /* bytes currently in FIFO */
+    uint32_t fifo_rd_off;    /* read cursor (bytes) */
 };
 
 /* ── IRQ ───────────────────────────────────────────────────────────── */
@@ -261,6 +278,28 @@ static void hisi_himci_do_data(HisiHimciState *s, uint32_t idmac_addr,
  * Execute a command with optional data transfer via IDMAC at dbaddr.
  * Used by the direct CMD register path (U-Boot) and clock-update bypass.
  */
+/*
+ * PIO data-transfer fallback used when neither BMOD_DE nor
+ * CTRL_USE_IDMAC is set — the av300 mask-ROM reads SD blocks this way.
+ * Drain bytcnt bytes from the SD bus into the FIFO buffer; the guest
+ * then reads from MCI_FIFO_DATA_BASE 4 bytes at a time.  Writes are
+ * symmetric but the mask-ROM never exercises them.
+ */
+static void hisi_himci_do_pio(HisiHimciState *s, bool is_write)
+{
+    uint32_t want = s->bytcnt;
+    if (want > sizeof(s->fifo_buf)) {
+        want = sizeof(s->fifo_buf);
+    }
+    if (is_write) {
+        sdbus_write_data(&s->sdbus, s->fifo_buf, want);
+    } else {
+        sdbus_read_data(&s->sdbus, s->fifo_buf, want);
+    }
+    s->fifo_len = want;
+    s->fifo_rd_off = 0;
+}
+
 static void hisi_himci_exec_cmd(HisiHimciState *s, uint32_t cmd_val,
                                 uint32_t arg)
 {
@@ -271,6 +310,9 @@ static void hisi_himci_exec_cmd(HisiHimciState *s, uint32_t cmd_val,
         bool is_write = (cmd_val & CMD_RW_WRITE) != 0;
         if ((s->bmod & BMOD_DE) || (s->ctrl & CTRL_USE_IDMAC)) {
             hisi_himci_do_data(s, s->dbaddr, is_write);
+        } else {
+            /* PIO fallback — drain the bus into the internal FIFO. */
+            hisi_himci_do_pio(s, is_write);
         }
         s->rintsts |= INT_DTO;
     }
@@ -391,7 +433,15 @@ static uint64_t hisi_himci_read(void *opaque, hwaddr offset, unsigned size)
     case MCI_RESP3:         return s->resp[3];
     case MCI_MINTSTS:       return s->rintsts & s->intmask;
     case MCI_RINTSTS:       return s->rintsts;
-    case MCI_STATUS:        return 0;
+    case MCI_STATUS: {
+        /* Expose FIFO_COUNT (in 32-bit words) in bits 17..29 so the
+         * mask-ROM's PIO read loop can poll for available data. */
+        uint32_t avail_bytes = (s->fifo_rd_off < s->fifo_len)
+                             ? (s->fifo_len - s->fifo_rd_off) : 0;
+        uint32_t words = avail_bytes / 4;
+        if (words > 0x1FFF) words = 0x1FFF;
+        return words << 17;
+    }
     case MCI_FIFOTH:        return s->fifoth;
     case MCI_CDETECT:       return s->cdetect;
     case MCI_WRTPRT:        return s->wrtprt;
@@ -418,6 +468,18 @@ static uint64_t hisi_himci_read(void *opaque, hwaddr offset, unsigned size)
     case MCI_UHS_REG_EXT:   return s->uhs_reg_ext;
     case MCI_TUNING_CTRL:   return s->tuning_ctrl;
     default:
+        /* FIFO_DATA window — return next 4 bytes from the staged PIO
+         * read buffer, advance the read cursor.  Any offset in the
+         * window does this; DW MMC FIFO is "memory-mapped" but uses
+         * an internal pointer, not the offset. */
+        if (offset >= MCI_FIFO_DATA_BASE && offset <= MCI_FIFO_DATA_END) {
+            if (s->fifo_rd_off + 4 <= s->fifo_len) {
+                uint32_t v = ldl_le_p(s->fifo_buf + s->fifo_rd_off);
+                s->fifo_rd_off += 4;
+                return v;
+            }
+            return 0;
+        }
         return 0;
     }
 }
@@ -573,6 +635,9 @@ static void hisi_himci_reset(DeviceState *dev)
     s->cardthrctl = 0;
     s->uhs_reg_ext = 0;
     s->tuning_ctrl = 0;
+
+    s->fifo_len = 0;
+    s->fifo_rd_off = 0;
 
     qemu_set_irq(s->irq, 0);
 }

--- a/qemu/patches/0001-arm-sp804-continuous-trigger.patch
+++ b/qemu/patches/0001-arm-sp804-continuous-trigger.patch
@@ -1,0 +1,52 @@
+arm_timer: switch SP804 to CONTINUOUS_TRIGGER ptimer policy
+
+Real SP804 silicon (TRM DDI0271 §2.3) doesn't disable when the timer
+count reaches zero — in periodic mode with LOAD = 0 it just keeps
+reloading at the configured tick rate, firing the IRQ every tick (a
+harmless IRQ storm when interrupts are disabled, expected behaviour
+when they are).
+
+qemu's default PTIMER_POLICY_LEGACY guard treats "delta == 0 with
+enabled timer" as a bug and disables the underlying ptimer with
+"Timer with delta zero, disabling" on stderr.  Once disabled, the
+timer never re-arms on subsequent LOAD writes — the device freezes.
+
+That breaks guest code that programs TimerControl with the enable
+bit set BEFORE writing TimerLoad — for example the hi3516av300
+mask-ROM's main() at 0x04002704 calls timer_start (writes
+CONTROL = 0xc2, enable+periodic+32-bit) before timer_reset_counter
+(writes LOAD = 0xFFFFFFFF).  On real silicon this is fine; on qemu
+the SP804 ptimer dies between the two writes and the bootrom hangs
+forever in wait_timer_0 polling VALUE.
+
+PTIMER_POLICY_CONTINUOUS_TRIGGER is exactly the policy bit for "stay
+running with limit=0".  ptimer.c's rate-limit (10 µs minimum period)
+keeps the IRQ storm bounded.
+
+Verified: with this fix the hi3516av300 mask-ROM's timer waits
+complete normally inside qemu; the existing maskrom-av300 CI
+handshake assertion (PR widgetii/qemu-hisilicon#98) still passes
+byte-for-byte.
+
+--- a/hw/timer/arm_timer.c	2026-05-21 15:48:16.389379931 +0300
++++ b/hw/timer/arm_timer.c	2026-05-21 15:28:15.322413709 +0300
+@@ -180,7 +180,18 @@
+     s->freq = freq;
+     s->control = TIMER_CTRL_IE;
+ 
+-    s->timer = ptimer_init(arm_timer_tick, s, PTIMER_POLICY_LEGACY);
++    /*
++     * Match real SP804 silicon behaviour: when periodic mode is enabled
++     * with LOAD = 0 (count == limit == 0), the timer doesn't disable —
++     * it keeps reloading at the configured tick rate (an IRQ storm if
++     * interrupts are enabled, harmless otherwise).  Without the
++     * CONTINUOUS_TRIGGER policy, the ptimer legacy guard fires
++     * "Timer with delta zero, disabling" and freezes the device, which
++     * hangs guest code that programs CONTROL before LOAD (e.g. the
++     * hi3516av300 mask-ROM's timer_start → timer_reset_counter sequence
++     * — main() at 0x04002704 in the reverse-engineered bootrom).
++     */
++    s->timer = ptimer_init(arm_timer_tick, s, PTIMER_POLICY_CONTINUOUS_TRIGGER);
+     vmstate_register_any(NULL, &vmstate_arm_timer, s);
+     return s;
+ }


### PR DESCRIPTION
## Summary

Three model-correctness fixes that together let the reverse-engineered hi3516av300 mask-ROM actually issue SD-card reads inside qemu. Each commit stands alone; they're stacked because the second only matters once the first works, and so on.

## Commits

### 1. `qemu/patches: arm_timer SP804 — CONTINUOUS_TRIGGER ptimer policy`

QEMU's default `PTIMER_POLICY_LEGACY` prints \`Timer with delta zero, disabling\` and freezes the underlying ptimer when count=limit=0. Real SP804 silicon (TRM DDI0271 §2.3) doesn't — periodic mode with LOAD=0 just keeps reloading. Switch to `PTIMER_POLICY_CONTINUOUS_TRIGGER` to match silicon. Avoids a freeze when the mask-ROM programs CONTROL before LOAD.

### 2. `hi3516av300: alias mask-ROM at 0x0 + hisi-himci PIO FIFO`

**Mask-ROM alias at 0x0**: real silicon aliases the on-chip ROM to both `0x04000000` and `0x00000000`. The av300 bootrom stores `0x00004680` as the SD read-block function pointer (literally `movw r2,#0x4680; movt r2,#0` at bootrom 0x04004700) and later jumps to it. Without the alias the CPU lands in the trapnull stub. Install a `memory_region_init_alias` at 0x0 with overlap priority 1.

**Hisi-himci PIO FIFO**: bootrom reads SD data in PIO mode (no DMA). Polls `STATUS` bits 17..29 (FIFO_COUNT words), then reads 32-bit words from `SDIO0+0x200` (verified by disasm `ldr ip, [r1, #512]` at bootrom 0x0400457c). Add a 4 KiB internal FIFO drained synchronously from \`sdbus_read_data\` when DATA_EXPECTED runs without DMA, exposed at `0x200..0x3FF`.

## Verified

* maskrom-av300 CI assertion from #98 still green byte-for-byte.
* With these three fixes plus wait-loop patches to the bootrom ELF, the av300 vendor mask-ROM now drives qemu through `CMD0 → CMD8 → CMD55 → ACMD41 → CMD2 → CMD3 → CMD7 → CMD55 → CMD6 → CMD16(SET_BLOCKLEN=512) → CMD17(READ LBA 0)`, exchanging the expected 512-byte payload. Next blocker is bootrom DDR plumbing (out of scope here).

Companion docs: \`openhisilicon/bootrom/hi3516av300/SD-RECOVERY.txt\`.

## Test plan

- [x] Patch applies cleanly to QEMU v10.2.0 \`hw/timer/arm_timer.c\`.
- [x] qemu-system-arm builds.
- [x] maskrom-av300 CI assertion passes locally.
- [ ] Full SoC matrix passes in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)