### PR TITLE
hi3519v101/av200: wire real hisi-gmac (fixes hi_gmac_v200 probe deferral)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,7 @@ jobs:
             soc: hi3519v101
             machine: hi3519v101
             append: "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)"
+            ping_linux: true
 
           - name: hi3516ev300
             soc: hi3516ev300

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -1246,7 +1246,7 @@ static const HisiSoCConfig hi3516dv300_soc = {
  *
  * V3A generation — big.LITTLE + GICv2, V3-era peripheral addresses
  * (0x121xxxxx UARTs/SPI/GPIO like CV300).
- * Uses GMAC (not FEMAC) for Ethernet; GMAC not yet emulated.
+ * Uses GMAC (HiGMAC V200, hi_gmac_v200 driver) for Ethernet.
  */
 static const HisiSoCConfig hi3519v101_soc = {
     .name               = "hi3519v101",
@@ -1298,7 +1298,12 @@ static const HisiSoCConfig hi3519v101_soc = {
     .gpio_stride        = 0x1000,
     .gpio_irq           = 43,               /* shared IRQ for all ports (GIC) */
 
-    /* No FEMAC — uses GMAC (higmac) which is not yet emulated */
+    /* Gigabit Ethernet — HiGMAC V200, DT compatible "hisilicon,higmac-v3".
+     * Vendor DTB: reg = <0x10050000 0x1000 0x120100ec 0x04>, the 2nd cell
+     * is the macif phy-mode select inside the CRG, which our hisi-regbank
+     * already covers.  IRQ confirmed from the embedded board.dtb. */
+    .gmac_base          = 0x10050000,
+    .gmac_irq           = 25,
 
     .num_himci          = 3,
     .himci_bases        = { 0x100c0000, 0x100d0000, 0x100e0000 },
@@ -1328,7 +1333,7 @@ static const HisiSoCConfig hi3519v101_soc = {
         { 0x04, (24 << 12) | 792 },
     },
 
-    .num_regbanks       = 11,
+    .num_regbanks       = 10,
     .regbanks           = {
         { "hisi-misc",       0x12030000, 0x10000 },
         { "hisi-ddr",        0x12060000, 0x10000 },
@@ -1336,7 +1341,6 @@ static const HisiSoCConfig hi3519v101_soc = {
         { "hisi-pwm",        0x12130000, 0x10000 },
         { "hisi-usb-ehci",   0x10120000, 0x10000 },
         { "hisi-usb-ohci",   0x10110000, 0x10000 },
-        { "hisi-gmac",       0x10050000, 0x10000 },
         { "hisi-vi-cap",     0x11380000, 0x100000 },
         { "hisi-vou",        0x11000000, 0x20000 },
         { "hisi-vpss",       0x11180000, 0x10000 },
@@ -1403,6 +1407,10 @@ static const HisiSoCConfig hi3516av200_soc = {
     .gpio_stride        = 0x1000,
     .gpio_irq           = 43,
 
+    /* GMAC: inherits the 3519V101 wiring (same die per vendor guide). */
+    .gmac_base          = 0x10050000,
+    .gmac_irq           = 25,
+
     .num_himci          = 3,
     .himci_bases        = { 0x100c0000, 0x100d0000, 0x100e0000 },
     .himci_irqs         = { 23, 24, 13 },
@@ -1430,7 +1438,7 @@ static const HisiSoCConfig hi3516av200_soc = {
         { 0x04, (24 << 12) | 792 },
     },
 
-    .num_regbanks       = 11,
+    .num_regbanks       = 10,
     .regbanks           = {
         { "hisi-misc",       0x12030000, 0x10000 },
         { "hisi-ddr",        0x12060000, 0x10000 },
@@ -1438,7 +1446,6 @@ static const HisiSoCConfig hi3516av200_soc = {
         { "hisi-pwm",        0x12130000, 0x10000 },
         { "hisi-usb-ehci",   0x10120000, 0x10000 },
         { "hisi-usb-ohci",   0x10110000, 0x10000 },
-        { "hisi-gmac",       0x10050000, 0x10000 },
         { "hisi-vi-cap",     0x11380000, 0x100000 },
         { "hisi-vou",        0x11000000, 0x20000 },
         { "hisi-vpss",       0x11180000, 0x10000 },


### PR DESCRIPTION
## Summary
- `hi3519v101_soc` and `hi3516av200_soc` left `.gmac_base`/`.gmac_irq` unset and carried an inert `hisi-regbank` stub at `0x10050000`, so the vendor `hi_gmac_v200` driver saw zero-filled MMIO and deferred probe forever (`eth0` never appeared, `ip: SIOCGIFINDEX: No such device`).
- `hisi-gmac.c` already advertises support for HiGMAC V200 on these SoCs (see file header). The fix is purely SoC-config wiring: set `.gmac_base = 0x10050000`, `.gmac_irq = 25`, and remove the regbank stub (it would overlap the device's `0x1000` MMIO window).
- IRQ confirmed from the FDT embedded in `uImage.hi3519v101`: `ethernet@10050000` with `interrupts = <0 0x19 4>`, `compatible = "hisilicon,higmac-v3"`. The DTB's 2nd reg cell at `0x120100ec` (macif phy-mode select) falls inside the existing CRG `hisi-regbank` at `0x12010000`, so no additional wiring is needed.
- CI: enable `ping_linux` on the `hi3519v101` matrix entry to gate this regression. AV200 shares the wiring path through `hisilicon_common_init()` (same die per the in-code vendor guide), so a separate matrix entry adds no real coverage.

## Test plan
- [x] `timeout 90 bash qemu-boot/run-3519v101.sh -nic user` — `udhcpc` obtains `10.0.2.15` lease over `eth0`.
- [x] `bash qemu-boot/test-linux-network.sh --soc hi3519v101 ... --setup-network` (same path CI runs) — `PASS Linux ping`, `PASS Linux curl (TCP)`. Login 33 s, ping done 39 s, curl done 40 s.
- [x] `bash qemu-boot/run-av100.sh` regression — `hi_gmac_v200 10090000.ethernet` still gets DHCP lease.
- [x] `qemu-system-arm -M hi3516av200 -nic user -S` — machine creates cleanly (no MMIO overlap, no asserts).
- [ ] CI green on the new `ping_linux` matrix step for `hi3519v101`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)