### PR TITLE
hisi-gmac: auto-detect 4-word descriptors so U-Boot ping works on 3519v101

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,7 @@ jobs:
             machine: hi3519v101
             append: "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)"
             ping_linux: true
+            uboot_bin: u-boot-hi3519v101-universal.bin
 
           - name: hi3516ev300
             soc: hi3516ev300

--- a/qemu/hw/net/hisi-gmac.c
+++ b/qemu/hw/net/hisi-gmac.c
@@ -288,9 +288,31 @@ static void hisi_gmac_update_irq(HisiGmacState *s)
  * later words are reserved padding, so the read/write path doesn't
  * change — only the stride between descriptors does.  Exposed as the
  * `desc-size` property (default 32, set to 16 for hi3536cv100).
+ *
+ * Auto-detect: the same SoC can run two firmwares built with different
+ * `CONFIG_HIGMAC_DESC_4_WORD` — e.g. the OpenIPC Hi3519V101 ships a
+ * U-Boot built with 4-word descriptors but a kernel built with 8-word.
+ * When SW writes a *_WR_ADDR pointer for the first time after the ring
+ * is empty, that value IS one descriptor stride, so we latch it.  This
+ * keeps both firmwares working without per-SoC config changes.
  */
 #define DESC_SIZE_BYTES_MAX     32
 #define DESC_SIZE_BYTES_DEFAULT 32
+
+/* Latch a smaller descriptor stride when SW reveals it via the first
+ * non-zero wr-ptr write to an empty ring.  No-op if the ring isn't
+ * empty (SW queued multiple descriptors at once, which we can't safely
+ * disambiguate) or if the value isn't a smaller power-of-two stride. */
+static inline void hisi_gmac_maybe_detect_stride(HisiGmacState *s,
+                                                  uint32_t wr, uint32_t rd)
+{
+    if (wr == 0 || rd != 0 || wr >= s->desc_size_bytes) {
+        return;
+    }
+    if (wr == 16) {
+        s->desc_size_bytes = 16;
+    }
+}
 
 /* Queue size in bytes from the depth register value (queue size in
  * words, so * 4).  0 if the driver hasn't programmed depth yet. */
@@ -558,6 +580,7 @@ static void hisi_gmac_write(void *opaque, hwaddr offset, uint64_t val,
     case RX_FQ_START_ADDR:   s->rx_fq_start = val; break;
     case RX_FQ_DEPTH:        s->rx_fq_depth = val; break;
     case RX_FQ_WR_ADDR:
+        hisi_gmac_maybe_detect_stride(s, val, s->rx_fq_rd);
         s->rx_fq_wr = val;
         /* New free buffers available — check if we can receive now */
         qemu_flush_queued_packets(qemu_get_queue(s->nic));
@@ -576,6 +599,7 @@ static void hisi_gmac_write(void *opaque, hwaddr offset, uint64_t val,
     case TX_BQ_START_ADDR:   s->tx_bq_start = val; break;
     case TX_BQ_DEPTH:        s->tx_bq_depth = val; break;
     case TX_BQ_WR_ADDR:
+        hisi_gmac_maybe_detect_stride(s, val, s->tx_bq_rd);
         s->tx_bq_wr = val;
         /* New TX packets queued — process them */
         hisi_gmac_tx(s);


### PR DESCRIPTION
## Summary
- The OpenIPC Hi3519V101 firmware ships a U-Boot built with `CONFIG_HIGMAC_DESC_4_WORD` (16-byte descriptors) and a kernel built without it (32-byte descriptors). `hisi-gmac.c` hard-coded the stride via the `desc-size` property, so the U-Boot driver hung after PHY link-up — it wrote `TX_BQ_WR_ADDR = 0x10` (one 16-byte descriptor), but the device's 32-byte stride caused `hisi_gmac_tx()` to mis-advance `rd_ptr` and write the completion at the wrong offset. U-Boot polled forever.
- Fix: latch a smaller descriptor stride when SW reveals it via the first non-zero wr-ptr write to an empty ring. Detection runs in the `RX_FQ_WR_ADDR` and `TX_BQ_WR_ADDR` handlers. Kernel writes `wr=0x20` first and stays at 32; U-Boot writes `wr=0x10` first and drops to 16. No per-SoC config changes.
- CI: enable `uboot_bin` for the `hi3519v101` matrix entry (added to `ping_linux` in #105 a few minutes ago).

## Diagnosis trail
Instrumented `hisi-gmac.c` with a tracing fprintf, ran both av100 (working) and 3519v101 (hanging) U-Boot ping under QEMU, diffed the register access logs. The divergence was unambiguous:

| | `TX_BQ_DEPTH` (0x584) | first `TX_BQ_WR_ADDR` (0x588) | descriptor stride |
|---|---|---|---|
| av100 U-Boot         | `0x10` (64-byte ring) | `0x20` | 32 |
| 3519v101 U-Boot      | `0x8`  (32-byte ring) | `0x10` | 16 |
| 3519v101 kernel (works) | (default) | (32-byte increments) | 32 |

## Test plan
- [x] `bash /tmp/uboot-ping-trace.sh hi3519v101 u-boot-hi3519v101-universal.bin` — `host 10.0.2.2 is alive` (was: hang after `MAC: 00-00-23-34-45-66`).
- [x] `bash qemu-boot/test-linux-network.sh --soc hi3519v101 ... --setup-network` — `PASS Linux ping`, `PASS Linux curl (TCP)`. login 26s, ping 30s, curl 31s.
- [x] `bash /tmp/uboot-ping-trace.sh hi3516av100 u-boot-hi3516av100-universal.bin` — `host 10.0.2.2 is alive` (regression check: no change).
- [x] `bash qemu-boot/run-3519v101.sh -nic user` — `udhcpc: lease of 10.0.2.15 obtained` (Linux kernel regression check).
- [ ] CI green on the new `uboot_bin` matrix step for `hi3519v101`, and no regressions on the other GMAC SoCs (`hi3516av100`, `hi3536cv100`, `hi3536dv100`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)