### PR TITLE
ci: add -nic user,restrict=on to boot step (fixes #104)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,12 +521,23 @@ jobs:
           # layout from HisiSoCConfig (measured: CV100 ~20 s, CV200
           # ~18 s, AV100 ~15 s, CV300/CV500/3519V101 <30 s, EV300 ~7 s).
           # 120 s gives us a 4× margin over the measured worst case.
+          #
+          # `-nic user,restrict=on` keeps SLIRP's internal DHCP server
+          # reachable (udhcpc still gets 10.0.2.15) but blocks all
+          # outbound traffic.  Required because busybox ntpd in OpenIPC
+          # uses a strict 0.5 ms STEP_PEER_MAX delay threshold; on
+          # GitHub-hosted runners the NAT path adds >5 ms latency,
+          # ntpd rejects every reply and loops past the 120 s deadline.
+          # See openhisilicon#104.  With restrict=on the NTP pool DNS
+          # lookups fail fast, ntpd exits, S49ntp returns "OK", and
+          # the rest of init runs deterministically.
           QEMU=./qemu-src/build/qemu-system-arm
           timeout 120 $QEMU \
             -M ${{ matrix.machine }} \
             -kernel "qemu-boot/uImage.${{ matrix.soc }}" \
             -initrd "qemu-boot/rootfs.squashfs.${{ matrix.soc }}" \
             -nographic -serial mon:stdio \
+            -nic user,restrict=on \
             -append '${{ matrix.append }}' \
             -d unimp,guest_errors -D qemu-boot/qemu.log \
             2>&1 | tee boot-output.txt &


### PR DESCRIPTION
## Summary
- Root cause of the sporadic `Boot hi3516cv500` timeout in #104 is busybox `ntpd` in the OpenIPC rootfs: it uses a strict 0.5 ms STEP_PEER_MAX delay threshold. GitHub-hosted runners' SLIRP NAT adds >5 ms latency, so every NTP reply is rejected (`delay 0.005919 is too high, ignoring`) and ntpd loops on the next pool server, blocking S49ntp.
- The flake presents as bistable (passes on rerun) because the local NAT happens to be sub-millisecond, so the first reply is accepted and ntpd exits in ~100 ms — the path that produces the issue is data-dependent on the runner's network latency at boot time.
- Fix: `-nic user,restrict=on` keeps SLIRP's internal DHCP server reachable (udhcpc still gets `10.0.2.15`) but blocks outbound traffic. NTP pool DNS lookups fail immediately with `bad address`, ntpd exits with error, S49ntp reports `OK`, boot proceeds deterministically.
- The boot step only checks for the `login:` marker and the `Wrong chip-id`/`hiunknown` regression — neither depends on external network access. The follow-up `Linux ping + curl test` and `U-Boot ping test` steps use separate qemu invocations with TAP networking and are unaffected.

## Investigation
1. Locally cv500 boots to login in 27-29 s consistently — couldn't reproduce the flake. Suggested it was CI-network-specific.
2. Captured the failing-run log: last visible line is `ntpd: reply from 5.254.77.191: delay 0.005919 is too high, ignoring`, with `Starting ntpd: OK` missing. ntpd is the blocker.
3. Tested `-nic user,restrict=on` locally: 5 consecutive runs all reach login in 55-57 s, with `ntpd: bad address '0.pool.ntp.org'` followed promptly by `Starting ntpd: OK` then the rest of init.
4. Also tested `-net none`: faster (~40 s) but produces a `qemu-system-arm: warning: nic hisi-gmac.0 has no peer` and breaks 3519v101's boot detection in some configurations. `restrict=on` is the right middle ground — networking still exists, DHCP still works, only outbound is blocked.

## Test plan
- [x] Local cv500: 5× consecutive runs with restrict=on → all reach login in 55-57 s.
- [x] Local hi3519v101 / hi3516av100 / hi3516ev300 with restrict=on → all reach login (41 s / 59 s / 68 s).
- [ ] CI green across the full matrix on this branch and rerun once or twice to spot-check that cv500 no longer flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)