### PR TITLE
ci: enable ping_linux for hi3516cv500 (covers av300 family)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,10 +415,15 @@ jobs:
             uboot_bin: u-boot-hi3516cv300-universal.bin
             flash_mem: 256M
 
+          # cv500 family covers av300 (same die, av300 is variant id 5);
+          # one Linux ping gate exercises both. uboot_bin skipped: the
+          # OpenIPC cv500 U-Boot resets in a loop on our QEMU model
+          # (separate bug, not blocking Linux gate).
           - name: hi3516cv500
             soc: hi3516cv500
             machine: hi3516cv500
             append: "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)"
+            ping_linux: true
 
           - name: hi3519v101
             soc: hi3519v101


### PR DESCRIPTION
## Summary
- cv500 is the V5-era flagship (Cortex-A7 dual-core) with HiGMAC at \`0x100a0000\` IRQ 16 — wired in \`qemu/hw/arm/hisilicon.c\` for a while but never had an end-to-end Ethernet gate.
- av300 is the same die (chip variant id 5), so a single gate covers both — same pattern as #105 for 3519v101/av200.
- \`uboot_bin\` intentionally omitted: the OpenIPC \`u-boot-hi3516cv500-universal.bin\` resets in a loop on our QEMU model (prints \`System startup / U-Boot 2016.11 / Relocation Offset\` repeatedly, never reaches autoboot). Separate bug, not in scope here.

## Test plan
- [x] Local: \`bash qemu-boot/test-linux-network.sh --soc hi3516cv500 ...\` → \`PASS Linux ping\`, \`PASS Linux curl (TCP)\`. login 71 s, ping 82 s, curl 83 s (well within the 240/45/100 s gate budget).
- [ ] CI green on \`Boot hi3516cv500\` + new \`Linux ping + curl test\` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)