### PR TITLE
ci: enable U-Boot ping for hi3516cv500 (flash_mem=1G)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,14 +416,18 @@ jobs:
             flash_mem: 256M
 
           # cv500 family covers av300 (same die, av300 is variant id 5);
-          # one Linux ping gate exercises both. uboot_bin skipped: the
-          # OpenIPC cv500 U-Boot resets in a loop on our QEMU model
-          # (separate bug, not blocking Linux gate).
+          # one Linux + U-Boot gate exercises both.  flash_mem=1G because
+          # the OpenIPC cv500 U-Boot is built assuming the platform-max
+          # 1 GiB DDR and relocates itself to top-of-RAM (~0xBFEE2000).
+          # The default 128 MiB ram_size leaves that target unmapped,
+          # the relocation jump faults, and the CPU resets in a loop.
           - name: hi3516cv500
             soc: hi3516cv500
             machine: hi3516cv500
             append: "console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs mtdparts=hi_sfc:256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)"
             ping_linux: true
+            uboot_bin: u-boot-hi3516cv500-universal.bin
+            flash_mem: 1G
 
           - name: hi3519v101
             soc: hi3519v101


### PR DESCRIPTION
## Summary
The cv500 U-Boot reset loop noted in PR #108 wasn't a U-Boot/QEMU emulation bug — just a RAM-size mismatch.

The OpenIPC \`u-boot-hi3516cv500-universal.bin\` (U-Boot 2016.11) is built assuming the platform-max 1 GiB DDR. On boot it computes its relocation target as top-of-RAM, which lands at ~\`0xBFEE2000\`. Our QEMU machine's default \`ram_size_default = 128 MiB\` leaves that address unmapped, so the post-relocation jump faults and the CPU resets back to the boot ROM — producing the familiar \`System startup / U-Boot 2016.11 / Relocation Offset / <reset>\` loop.

Fix: pass \`flash_mem: 1G\` for the cv500 matrix entry, which the U-Boot step uses as \`-m 1G\`. With 1 GiB mapped, the relocation target is reachable and U-Boot completes init normally.

\`flash_mem\` only affects the U-Boot ping step. The Linux ping step and boot smoke continue with the 128 MiB default, matching typical real cv500 camera hardware.

## Test plan
- [x] Local: cv500 U-Boot with \`-m 1G\` reaches \`hisilicon #\` autoboot, PHY link UP, \`ping 10.0.10.1\` → \`host 10.0.10.1 is alive\`.
- [x] Local: cv500 Linux ping (the gate added in #108) still passes with default 128 MiB.
- [ ] CI green on the new \`U-Boot ping test\` step for cv500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)