### PR TITLE
hi3516cv610: fix SquashFS-from-NOR corruption + add boot CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,10 @@ jobs:
             uboot_bin: u-boot-hi3516ev300-universal.bin
             flash_mem: 128M
 
-          # hi3516cv610 (V5) excluded: no OpenIPC firmware release yet
+          # hi3516cv610 (V5) has its own boot-hi3516cv610 job below: its
+          # OpenIPC release is a combined firmware.bin (FIT kernel+dtb with an
+          # appended SquashFS) under the SoC-family name, so it needs an
+          # extraction step and doesn't fit this download/boot matrix.
 
           # NVR/DVR family — OpenIPC ships nor-lite firmware (kernel +
           # rootfs) and u-boot-${soc}-universal.bin for 3 SoCs:
@@ -723,4 +726,99 @@ jobs:
             qemu-boot/linux-network-${{ matrix.soc }}
             /tmp/*-ping.txt
             /tmp/linux-network-summary.txt
+          retention-days: 7
+
+  # hi3516cv610 (V5).  Unlike the SoCs in the matrix above, OpenIPC ships
+  # cv610 as a single firmware.bin (a FIT holding the kernel + dtb, with the
+  # SquashFS rootfs appended) under the SoC-family name "hi3516cv6xx",
+  # "ultimate" variant.  Split it into kernel/dtb/rootfs and boot like
+  # qemu-boot/run-cv610.sh.
+  boot-hi3516cv610:
+    name: Boot hi3516cv610
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libfdt1 libglib2.0-0 libpixman-1-0 libslirp0 u-boot-tools
+
+      - name: Download QEMU binary
+        uses: actions/download-artifact@v4
+        with:
+          name: qemu-arm
+          path: qemu-src/build/
+
+      - name: Make QEMU executable
+        run: chmod +x qemu-src/build/qemu-system-arm
+
+      - name: Download and split OpenIPC firmware
+        run: |
+          cd qemu-boot
+          curl -sL "https://github.com/OpenIPC/firmware/releases/download/latest/openipc.hi3516cv6xx-nor-ultimate.tgz" \
+              -o openipc.hi3516cv6xx-nor-ultimate.tgz
+          tar xzf openipc.hi3516cv6xx-nor-ultimate.tgz
+          FW=firmware.bin.hi3516cv6xx
+          # FIT: image 1 = linux_kernel (zImage), image 0 = fdt-1 (dtb).
+          dumpimage -T flat_dt -p 1 -o uImage.hi3516cv610 "$FW"
+          dumpimage -T flat_dt -p 0 -o cv610.dtb          "$FW"
+          # SquashFS rootfs is appended right after the FIT.
+          sqoff=$(grep -aboP 'hsqs' "$FW" | head -1 | cut -d: -f1)
+          dd if="$FW" of=rootfs.squashfs.hi3516cv610 bs=64k iflag=skip_bytes \
+              skip="$sqoff" status=none
+          ls -la uImage.hi3516cv610 cv610.dtb rootfs.squashfs.hi3516cv610
+
+      - name: "OpenIPC kernel + rootfs boot"
+        timeout-minutes: 4
+        run: |
+          # cv610's kernel is capped to 32 MiB by default (mmz claims the
+          # rest); the "ultimate" rootfs ramdisk needs more, so pass mem=128M.
+          QEMU=./qemu-src/build/qemu-system-arm
+          timeout 150 $QEMU -M hi3516cv610 -m 256M \
+            -kernel qemu-boot/uImage.hi3516cv610 \
+            -dtb qemu-boot/cv610.dtb \
+            -initrd qemu-boot/rootfs.squashfs.hi3516cv610 \
+            -nographic -serial mon:stdio -nic user,restrict=on \
+            -append 'mem=128M console=ttyAMA0,115200 earlyprintk root=/dev/ram0 rootfstype=squashfs' \
+            -d unimp,guest_errors -D qemu-boot/qemu.log 2>&1 | tee boot-output.txt &
+          QEMU_PID=$!
+
+          # Wait for the login prompt.
+          for i in $(seq 1 150); do
+            if grep -qE "login:" boot-output.txt 2>/dev/null; then
+              echo ""
+              echo "=== Boot successful: login prompt reached ==="
+              kill $QEMU_PID 2>/dev/null || true
+              if grep -qE "SQUASHFS error|Kernel panic|deadlocked" boot-output.txt; then
+                echo "=== FAIL: squashfs corruption / kernel panic ==="
+                grep -nE "SQUASHFS error|Kernel panic|deadlocked" boot-output.txt | head
+                exit 1
+              fi
+              echo "=== Boot clean ==="
+              exit 0
+            fi
+            if ! kill -0 $QEMU_PID 2>/dev/null; then
+              echo "=== FAIL: QEMU exited before login ==="
+              tail -30 boot-output.txt
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "=== TIMEOUT: login prompt not reached ==="
+          tail -30 boot-output.txt
+          kill $QEMU_PID 2>/dev/null || true
+          exit 1
+
+      - name: Upload boot log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: boot-log-hi3516cv610
+          path: |
+            boot-output.txt
+            qemu-boot/qemu.log
           retention-days: 7

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2179,8 +2179,18 @@ static const HisiSoCConfig hi3516cv610_soc = {
     .uart_bases         = { 0x11040000, 0x11041000, 0x11042000 },
     .uart_irqs          = { 10, 11, 12 },
 
-    /* No SP804 timers — ARM arch timer only (24 MHz) */
-    .num_timers         = 0,
+    /* Linux uses the Cortex-A7 generic timer (24 MHz, via DTB).  But the
+     * cv610 U-Boot's udelay() polls an SP804-style countdown timer at
+     * 0x11000000 (vendor platform.h: CFG_TIMERBASE, VALUE@0x4,
+     * CFG_TIMER_CLK = 3 MHz).  Without it udelay() spins forever and U-Boot
+     * hangs in the SPI-NOR probe during a flash boot (`-machine
+     * hi3516cv610,flash-file=...` with no -kernel).  Wire one SP804 so the
+     * flash-boot path works; the IRQ is unused (U-Boot polls, Linux uses the
+     * arch timer and has no DT node here), so any free SPI suffices. */
+    .num_timers         = 1,
+    .timer_bases        = { 0x11000000 },
+    .timer_irqs         = { 4 },
+    .timer_freq         = 3000000,
 
     .num_spis           = 2,
     .spi_bases          = { 0x11070000, 0x11071000 },

--- a/qemu/hw/misc/hisi-fmc.c
+++ b/qemu/hw/misc/hisi-fmc.c
@@ -195,6 +195,13 @@ struct HisiFmcState {
     uint8_t *block_ever_unlocked;
     uint32_t num_blocks;
 
+    /* block_squashfs[]: 1 for every 64KB block that falls inside a detected
+     * SquashFS filesystem (read-only rootfs).  Such blocks are never writable
+     * — real firmware mounts the rootfs read-only and never programs/erases
+     * it.  Enforced independently of WPS so a stray program/erase can't
+     * silently corrupt the booted image (and get flushed back to the file). */
+    uint8_t *block_squashfs;
+
     /* When true, the chip starts in the as-shipped factory-locked state:
      * SR3.WPS = 1, every block locked, none ever-unlocked.  Mirrors what
      * Xiongmai-flashed Winbond W25Q128s come out of the factory with —
@@ -259,12 +266,18 @@ static void hisi_fmc_flush_to_file(HisiFmcState *s, uint32_t offset,
  */
 static bool hisi_fmc_block_is_locked(HisiFmcState *s, uint32_t addr)
 {
+    uint32_t block = addr / NOR_SECTOR_SIZE;
+    if (block >= s->num_blocks)
+        return false;
+    /* A detected read-only SquashFS region is never writable, regardless of
+     * the WPS knob.  Real hardware mounts the rootfs read-only and never
+     * programs or erases it; without this a stray write silently corrupts
+     * the SquashFS in place and is flushed back to the backing image. */
+    if (s->block_squashfs && s->block_squashfs[block])
+        return true;
     if (!(s->sr3 & 0x04))  /* WPS bit in SR3 */
         return false;
     if (!s->block_locked)
-        return false;
-    uint32_t block = addr / NOR_SECTOR_SIZE;
-    if (block >= s->num_blocks)
         return false;
     return s->block_locked[block] && !s->block_ever_unlocked[block];
 }
@@ -424,7 +437,7 @@ static bool hisi_fmc_exec_nor_reg_op(HisiFmcState *s)
         if ((s->sr & SPI_SR_WEL) && addr < s->flash_size) {
             if (hisi_fmc_block_is_locked(s, addr)) {
                 qemu_log_mask(LOG_GUEST_ERROR,
-                              "hisi-fmc: PROGRAM blocked — addr 0x%x is WPS-locked\n",
+                              "hisi-fmc: PROGRAM blocked — addr 0x%x is write-protected\n",
                               addr);
             } else {
                 uint32_t end = addr + len;
@@ -450,7 +463,7 @@ static bool hisi_fmc_exec_nor_reg_op(HisiFmcState *s)
             }
             if (hisi_fmc_block_is_locked(s, base)) {
                 qemu_log_mask(LOG_GUEST_ERROR,
-                              "hisi-fmc: ERASE blocked — sector 0x%x is WPS-locked\n",
+                              "hisi-fmc: ERASE blocked — sector 0x%x is write-protected\n",
                               base);
             } else if (base < s->flash_size) {
                 memset(&s->flash[base], 0xFF, end - base);
@@ -645,7 +658,7 @@ static void hisi_fmc_exec_dma_nor(HisiFmcState *s)
         if (s->sr & SPI_SR_WEL) {
             if (hisi_fmc_block_is_locked(s, addr)) {
                 qemu_log_mask(LOG_GUEST_ERROR,
-                              "hisi-fmc: DMA WRITE blocked — addr 0x%x is WPS-locked\n",
+                              "hisi-fmc: DMA WRITE blocked — addr 0x%x is write-protected\n",
                               addr);
             } else {
                 uint8_t *buf = g_malloc(len);
@@ -942,6 +955,7 @@ static void hisi_fmc_realize(DeviceState *dev, Error **errp)
         s->num_blocks = NOR_FLASH_SIZE / NOR_SECTOR_SIZE;
         s->block_locked = g_malloc0(s->num_blocks);
         s->block_ever_unlocked = g_malloc0(s->num_blocks);
+        s->block_squashfs = g_malloc0(s->num_blocks);
     }
 
     /* Load flash contents from file if specified */
@@ -963,9 +977,11 @@ static void hisi_fmc_realize(DeviceState *dev, Error **errp)
             /* Resize block lock arrays to match */
             g_free(s->block_locked);
             g_free(s->block_ever_unlocked);
+            g_free(s->block_squashfs);
             s->num_blocks = file_size / NOR_SECTOR_SIZE;
             s->block_locked = g_malloc0(s->num_blocks);
             s->block_ever_unlocked = g_malloc0(s->num_blocks);
+            s->block_squashfs = g_malloc0(s->num_blocks);
         }
         FILE *f = fopen(s->flash_file, "rb");
         if (!f) {
@@ -1022,6 +1038,9 @@ static void hisi_fmc_realize(DeviceState *dev, Error **errp)
                     if (blk_end > s->num_blocks) blk_end = s->num_blocks;
                     for (uint32_t b = blk_start; b < blk_end; b++) {
                         s->block_ever_unlocked[b] = 0;
+                        if (s->block_squashfs) {
+                            s->block_squashfs[b] = 1; /* read-only rootfs */
+                        }
                     }
                     qemu_log("hisi-fmc: protect SquashFS at 0x%x "
                              "(%" PRIu64 " bytes, blocks %u-%u)\n",
@@ -1078,6 +1097,7 @@ static void hisi_fmc_finalize(Object *obj)
     g_free(s->nand_oob);
     g_free(s->block_locked);
     g_free(s->block_ever_unlocked);
+    g_free(s->block_squashfs);
 }
 
 static const Property hisi_fmc_properties[] = {


### PR DESCRIPTION
Brings up the Hi3516CV610 (V5) for CI and fixes a flash-emulation bug that
corrupted the rootfs when booting with the SquashFS mounted from NOR.

## What's here

**`hisi-fmc`: keep detected SquashFS regions read-only.**
Booting with `root=/dev/mtdblock3` makes Linux issue stray sector erases into
the read-only SquashFS during init. `hisi-fmc` applied them to the in-memory
flash *and* flushed them back to the backing image (`hisi_fmc_flush_to_file`),
silently corrupting the rootfs in place — later reads then failed xz
decompression and init died. The existing SquashFS guard was gated behind
`SR3.WPS`, which `nor_wps_locked=false` leaves off, so it never fired.
Fix: mark every block inside a detected SquashFS (the existing `hsqs` scan)
and reject program/erase to it unconditionally — real hardware never writes a
read-only rootfs partition. The WPS factory-lock path (#83) is untouched.

**`hi3516cv610`: wire the SP804 timer at `0x11000000`.**
Linux uses the A7 generic timer, but cv610 U-Boot's `udelay()` polls an
SP804-style countdown timer there; with `num_timers=0` nothing was mapped, so
`udelay()` span forever during a flash boot. (IRQ unused — U-Boot polls,
Linux has no DT node here.)

**`ci`: add a `Boot hi3516cv610` job.**
OpenIPC ships cv610 as a single `firmware.bin` (a FIT with kernel+dtb plus an
appended SquashFS) under the family name `hi3516cv6xx`, `ultimate` variant —
so it needs an extraction step and doesn't fit the existing download matrix.
The job downloads the release, splits it (`dumpimage` + `dd`), and boots it to
the login prompt.

## Verification
- Boots the official `openipc.hi3516cv6xx-nor-ultimate.tgz` to
  `openipc-hi3516cv6xx login:`, 0 errors.
- MTD-root regression (`root=/dev/mtdblock3`): **32 stray erases into the
  SquashFS are now blocked**, the rootfs md5 is unchanged across the boot
  (not corrupted), `VFS: Mounted root (squashfs filesystem) readonly`, login
  reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)