### PR TITLE
hisi-fmc: fix NOR erase/program so OpenIPC firstboot & sysupgrade work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,11 @@ jobs:
             ping_linux: true
             uboot_bin: u-boot-hi3516ev300-universal.bin
             flash_mem: 128M
+            # Exercise the HiFMC NOR erase+program path from Linux userspace
+            # (flash_eraseall + flashcp -v). Guards the erase-address/WEL fix
+            # that OpenIPC firstboot & sysupgrade depend on. ev300 stands in
+            # for all hisi-fmc SoCs (the fix is in shared hisi-fmc.c).
+            flash_rw: true
 
           # hi3516cv610 (V5) has its own boot-hi3516cv610 job below: its
           # OpenIPC release is a combined firmware.bin (FIT kernel+dtb with an
@@ -585,6 +590,18 @@ jobs:
           tail -30 boot-output.txt
           kill $QEMU_PID 2>/dev/null || true
           exit 1
+
+      - name: "SPI-NOR erase/program round-trip"
+        if: matrix.flash_rw
+        timeout-minutes: 5
+        run: |
+          bash qemu-boot/test-flash-rw.sh \
+            --soc "${{ matrix.soc }}" \
+            --machine "${{ matrix.machine }}" \
+            --qemu ./qemu-src/build/qemu-system-arm \
+            --output-dir "qemu-boot/flash-rw-${{ matrix.soc }}" \
+            --mem 128M \
+            --login-timeout 120
 
       - name: "Linux ping + curl test"
         if: matrix.ping_linux

--- a/qemu-boot/test-flash-rw.sh
+++ b/qemu-boot/test-flash-rw.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# SPI-NOR erase + program round-trip test (regression guard for the HiFMC
+# erase-address / WEL fix that makes OpenIPC `firstboot` and `sysupgrade`
+# work — see "hisi-fmc: fix NOR erase/program ...").
+#
+# Boots OpenIPC from the ramdisk (root=/dev/ram0) with a writable synthetic
+# SPI-NOR attached via -machine flash-file=, then from Linux userspace:
+#   1. flash_eraseall a multi-block partition  -> must read back 0xFF
+#   2. flashcp -v random data over it          -> must verify (exit 0)
+#
+# Both fail with the pre-fix model: the erase address was read from the
+# stale FMC_ADDRL instead of the IO buffer, so every block after the first
+# erased the wrong offset (partition stayed unerased; flashcp mismatched
+# at the first un-erased block).  A multi-block payload is required to catch
+# it — a single-block write happens to land on whatever addrl held.
+#
+# Usage:
+#   test-flash-rw.sh --soc hi3516ev300 --machine hi3516ev300,sensor=none \
+#       --qemu ./qemu-src/build/qemu-system-arm --output-dir <dir> \
+#       [--mem 128M] [--login-timeout 120]
+#
+set -u
+
+SOC=""
+MACHINE=""
+QEMU="./qemu-src/build/qemu-system-arm"
+OUTDIR="."
+MEM="128M"
+LOGIN_TIMEOUT=120
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --soc)           SOC="$2"; shift 2 ;;
+        --machine)       MACHINE="$2"; shift 2 ;;
+        --qemu)          QEMU="$2"; shift 2 ;;
+        --output-dir)    OUTDIR="$2"; shift 2 ;;
+        --mem)           MEM="$2"; shift 2 ;;
+        --login-timeout) LOGIN_TIMEOUT="$2"; shift 2 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$SOC" ] && [ -n "$MACHINE" ] || { echo "--soc and --machine required" >&2; exit 2; }
+mkdir -p "$OUTDIR"
+
+KERNEL="qemu-boot/uImage.${SOC}"
+INITRD="qemu-boot/rootfs.squashfs.${SOC}"
+for f in "$KERNEL" "$INITRD"; do
+    [ -f "$f" ] || { echo "=== FAIL: missing $f ==="; exit 1; }
+done
+
+# 8 MiB synthetic NOR.  mtdparts carves a 1 MiB writable "test" partition
+# (mtd3, 16 erase blocks) that is NOT the rootfs (root is the ramdisk), so
+# erasing/writing it is safe.
+FLASH="$OUTDIR/flash.bin"
+dd if=/dev/zero of="$FLASH" bs=1M count=8 2>/dev/null
+MTDPARTS="hi_sfc:256k(boot),64k(env),2048k(kernel),1024k(test),-(rest)"
+APPEND="console=ttyAMA0,115200 root=/dev/ram0 rootfstype=squashfs mtdparts=${MTDPARTS}"
+
+CONSOLE="$OUTDIR/flash-rw-console.txt"
+SER_IN="$OUTDIR/ser.in"
+SER_OUT="$OUTDIR/ser.out"
+rm -f "$SER_IN" "$SER_OUT" "$CONSOLE"
+mkfifo "$SER_IN" "$SER_OUT"
+
+# restrict=on: keep SLIRP DHCP reachable but block outbound (busybox ntpd,
+# see openhisilicon#104) so init runs deterministically.
+timeout 240 "$QEMU" \
+    -M "$MACHINE",flash-file="$FLASH" -m "$MEM" \
+    -kernel "$KERNEL" -initrd "$INITRD" \
+    -nographic -serial "pipe:${OUTDIR}/ser" -monitor none \
+    -nic user,restrict=on \
+    -append "$APPEND" &
+QEMU_PID=$!
+( timeout 240 cat "$SER_OUT" > "$CONSOLE" 2>&1 ) &
+exec 3<>"$SER_IN"
+
+cleanup() { exec 3>&- 2>/dev/null; kill "$QEMU_PID" 2>/dev/null; wait 2>/dev/null; rm -f "$SER_IN" "$SER_OUT"; }
+trap cleanup EXIT
+
+wait_for() { # marker timeout
+    local m="$1" t="$2" i
+    for i in $(seq 1 "$t"); do
+        grep -qF "$m" "$CONSOLE" 2>/dev/null && return 0
+        sleep 1
+    done
+    return 1
+}
+
+echo "=== waiting for login prompt (<= ${LOGIN_TIMEOUT}s) ==="
+if ! wait_for "login:" "$LOGIN_TIMEOUT"; then
+    echo "=== FAIL: login prompt not reached ==="; tail -30 "$CONSOLE"; exit 1
+fi
+printf 'root\r' >&3; sleep 2
+printf '12345\r' >&3; sleep 3
+
+# Let init settle, then drive the round-trip.  NOTE: the serial console
+# echoes each typed command back, so a literal success word (e.g. "OK")
+# would also appear in the echoed command line.  All results are therefore
+# reported as `NAME=<digit>` exit codes and extracted with a digit-anchored
+# sed — the command echo carries the literal "$?", never a digit, so only
+# the real output line matches.
+printf 'echo RW_READY_$((6*7))\r' >&3
+wait_for "RW_READY_42" 25 || { echo "=== FAIL: shell not ready ==="; tail -30 "$CONSOLE"; exit 1; }
+
+# 1) erase a 1 MiB (16-block) partition, 2) confirm it reads back all-0xFF,
+# 3) flashcp -v a 512 KiB (8-block) random payload over it.  Multi-block is
+# essential: the pre-fix bug erased every block but the first at a stale
+# address, so the readback stayed un-erased and flashcp's verify mismatched.
+printf 'flash_eraseall /dev/mtd3 >/dev/null 2>&1; echo ERASE_RC=$?\r' >&3; sleep 2
+printf 'xxd -l 16 /dev/mtd3 | grep -q "ffff ffff ffff ffff ffff ffff ffff ffff"; echo EFF_RC=$?\r' >&3; sleep 2
+printf 'head -c 524288 /dev/urandom > /tmp/t; flashcp -v /tmp/t /dev/mtd3 >/dev/null 2>&1; echo FLASHCP_RC=$?\r' >&3; sleep 3
+printf 'echo RW_DONE_$((21*2))\r' >&3
+wait_for "RW_DONE_42" 60 || { echo "=== FAIL: round-trip did not complete ==="; tail -40 "$CONSOLE"; exit 1; }
+
+sleep 1
+sync_strip() { sed 's/\r//g' "$CONSOLE"; }
+get_rc() { sync_strip | sed -n "s/.*$1=\\([0-9]\\).*/\\1/p" | head -1; }
+
+erase_rc=$(get_rc ERASE_RC)      # flash_eraseall exit status
+eff_rc=$(get_rc EFF_RC)          # 0 => mtd3 reads all-0xFF after erase
+flashcp_rc=$(get_rc FLASHCP_RC)  # 0 => busybox flashcp -v erase+write+verify OK
+
+echo "=== results: ERASE_RC=$erase_rc EFF_RC=$eff_rc FLASHCP_RC=$flashcp_rc ==="
+
+fail=0
+[ "$erase_rc" = "0" ]   || { echo "FAIL: flash_eraseall /dev/mtd3 returned '$erase_rc'"; fail=1; }
+[ "$eff_rc" = "0" ]     || { echo "FAIL: mtd3 not 0xFF after erase (erase hit wrong address)"; fail=1; }
+[ "$flashcp_rc" = "0" ] || { echo "FAIL: flashcp -v returned '$flashcp_rc' (verify mismatch)"; fail=1; }
+
+if [ "$fail" = "0" ]; then
+    echo "=== PASS: SPI-NOR erase + program round-trip OK ==="
+    exit 0
+fi
+echo "--- last 40 console lines ---"; sync_strip | tail -40
+exit 1

--- a/qemu/hw/misc/hisi-fmc.c
+++ b/qemu/hw/misc/hisi-fmc.c
@@ -195,13 +195,6 @@ struct HisiFmcState {
     uint8_t *block_ever_unlocked;
     uint32_t num_blocks;
 
-    /* block_squashfs[]: 1 for every 64KB block that falls inside a detected
-     * SquashFS filesystem (read-only rootfs).  Such blocks are never writable
-     * — real firmware mounts the rootfs read-only and never programs/erases
-     * it.  Enforced independently of WPS so a stray program/erase can't
-     * silently corrupt the booted image (and get flushed back to the file). */
-    uint8_t *block_squashfs;
-
     /* When true, the chip starts in the as-shipped factory-locked state:
      * SR3.WPS = 1, every block locked, none ever-unlocked.  Mirrors what
      * Xiongmai-flashed Winbond W25Q128s come out of the factory with —
@@ -266,18 +259,12 @@ static void hisi_fmc_flush_to_file(HisiFmcState *s, uint32_t offset,
  */
 static bool hisi_fmc_block_is_locked(HisiFmcState *s, uint32_t addr)
 {
-    uint32_t block = addr / NOR_SECTOR_SIZE;
-    if (block >= s->num_blocks)
-        return false;
-    /* A detected read-only SquashFS region is never writable, regardless of
-     * the WPS knob.  Real hardware mounts the rootfs read-only and never
-     * programs or erases it; without this a stray write silently corrupts
-     * the SquashFS in place and is flushed back to the backing image. */
-    if (s->block_squashfs && s->block_squashfs[block])
-        return true;
     if (!(s->sr3 & 0x04))  /* WPS bit in SR3 */
         return false;
     if (!s->block_locked)
+        return false;
+    uint32_t block = addr / NOR_SECTOR_SIZE;
+    if (block >= s->num_blocks)
         return false;
     return s->block_locked[block] && !s->block_ever_unlocked[block];
 }
@@ -433,11 +420,19 @@ static bool hisi_fmc_exec_nor_reg_op(HisiFmcState *s)
         break;
     }
 
+    /*
+     * The FMC's command engine auto-issues WREN before every program and
+     * erase, so these must not be gated on the SPI Write-Enable-Latch: a
+     * guest that relies on the controller's auto-WREN never sets WEL, and
+     * within a multi-op transfer WEL is cleared after the first op — which
+     * silently dropped subsequent programs/erases (corrupting saveenv, jffs2
+     * and flashcp/sysupgrade).  WPS block protection still applies.
+     */
     case SPI_CMD_PAGE_PROGRAM:
-        if ((s->sr & SPI_SR_WEL) && addr < s->flash_size) {
+        if (addr < s->flash_size) {
             if (hisi_fmc_block_is_locked(s, addr)) {
                 qemu_log_mask(LOG_GUEST_ERROR,
-                              "hisi-fmc: PROGRAM blocked — addr 0x%x is write-protected\n",
+                              "hisi-fmc: PROGRAM blocked — addr 0x%x is WPS-locked\n",
                               addr);
             } else {
                 uint32_t end = addr + len;
@@ -454,31 +449,43 @@ static bool hisi_fmc_exec_nor_reg_op(HisiFmcState *s)
         }
         break;
 
-    case SPI_CMD_SECTOR_ERASE:
-        if (s->sr & SPI_SR_WEL) {
-            uint32_t base = addr & ~(NOR_SECTOR_SIZE - 1);
-            uint32_t end = base + NOR_SECTOR_SIZE;
-            if (end > s->flash_size) {
-                end = s->flash_size;
+    case SPI_CMD_SECTOR_ERASE: {
+        /* The SPI-NOR core's default sector erase sends the target address
+         * as big-endian data bytes through write_reg (memcpy_toio into the
+         * IO buffer) — bsp_spi_nor_op_reg never programs FMC_ADDRL.  So the
+         * erase address lives in iobuf, NOT in the (stale) addrl register.
+         * Reading addrl here made flash_eraseall/flashcp erase whatever
+         * block a prior DMA op happened to leave in addrl, silently leaving
+         * the real target intact (sysupgrade kernel/rootfs reflash failed). */
+        uint32_t erase_addr = 0;
+        if (len >= 3) {
+            for (uint32_t i = 0; i < len && i < 4; i++) {
+                erase_addr = (erase_addr << 8) | s->iobuf[i];
             }
-            if (hisi_fmc_block_is_locked(s, base)) {
-                qemu_log_mask(LOG_GUEST_ERROR,
-                              "hisi-fmc: ERASE blocked — sector 0x%x is write-protected\n",
-                              base);
-            } else if (base < s->flash_size) {
-                memset(&s->flash[base], 0xFF, end - base);
-                hisi_fmc_flush_to_file(s, base, end - base);
-            }
-            s->sr &= ~SPI_SR_WEL;
+        } else {
+            erase_addr = addr;  /* fallback: no address bytes supplied */
         }
+        uint32_t base = erase_addr & ~(NOR_SECTOR_SIZE - 1);
+        uint32_t end = base + NOR_SECTOR_SIZE;
+        if (end > s->flash_size) {
+            end = s->flash_size;
+        }
+        if (hisi_fmc_block_is_locked(s, base)) {
+            qemu_log_mask(LOG_GUEST_ERROR,
+                          "hisi-fmc: ERASE blocked — sector 0x%x is WPS-locked\n",
+                          base);
+        } else if (base < s->flash_size) {
+            memset(&s->flash[base], 0xFF, end - base);
+            hisi_fmc_flush_to_file(s, base, end - base);
+        }
+        s->sr &= ~SPI_SR_WEL;
         break;
+    }
 
     case SPI_CMD_CHIP_ERASE:
-        if (s->sr & SPI_SR_WEL) {
-            memset(s->flash, 0xFF, s->flash_size);
-            hisi_fmc_flush_to_file(s, 0, s->flash_size);
-            s->sr &= ~SPI_SR_WEL;
-        }
+        memset(s->flash, 0xFF, s->flash_size);
+        hisi_fmc_flush_to_file(s, 0, s->flash_size);
+        s->sr &= ~SPI_SR_WEL;
         break;
 
     default:
@@ -655,23 +662,30 @@ static void hisi_fmc_exec_dma_nor(HisiFmcState *s)
         dma_memory_write(&address_space_memory, dma_addr,
                          &s->flash[addr], len, MEMTXATTRS_UNSPECIFIED);
     } else {
-        if (s->sr & SPI_SR_WEL) {
-            if (hisi_fmc_block_is_locked(s, addr)) {
-                qemu_log_mask(LOG_GUEST_ERROR,
-                              "hisi-fmc: DMA WRITE blocked — addr 0x%x is write-protected\n",
-                              addr);
-            } else {
-                uint8_t *buf = g_malloc(len);
-                dma_memory_read(&address_space_memory, dma_addr,
-                                buf, len, MEMTXATTRS_UNSPECIFIED);
-                for (uint32_t i = 0; i < len; i++) {
-                    s->flash[addr + i] &= buf[i];
-                }
-                g_free(buf);
-                hisi_fmc_flush_to_file(s, addr, len);
+        /*
+         * The FMC DMA program engine issues WREN before every page it writes,
+         * so a multi-page bulk transfer must not depend on the single SPI
+         * Write-Enable-Latch a guest sets once: WEL is cleared after the first
+         * page program, so gating each DMA chunk on it silently drops every
+         * page after the first.  That corrupted U-Boot saveenv (blank env ->
+         * no soc -> sysupgrade aborts), jffs2 overlay writes ("Node totlen
+         * 0xffffffff") and flashcp.  Always program; WPS protection applies.
+         */
+        if (hisi_fmc_block_is_locked(s, addr)) {
+            qemu_log_mask(LOG_GUEST_ERROR,
+                          "hisi-fmc: DMA WRITE blocked — addr 0x%x is WPS-locked\n",
+                          addr);
+        } else {
+            uint8_t *buf = g_malloc(len);
+            dma_memory_read(&address_space_memory, dma_addr,
+                            buf, len, MEMTXATTRS_UNSPECIFIED);
+            for (uint32_t i = 0; i < len; i++) {
+                s->flash[addr + i] &= buf[i];
             }
-            s->sr &= ~SPI_SR_WEL;
+            g_free(buf);
+            hisi_fmc_flush_to_file(s, addr, len);
         }
+        s->sr &= ~SPI_SR_WEL;
     }
 }
 
@@ -955,7 +969,6 @@ static void hisi_fmc_realize(DeviceState *dev, Error **errp)
         s->num_blocks = NOR_FLASH_SIZE / NOR_SECTOR_SIZE;
         s->block_locked = g_malloc0(s->num_blocks);
         s->block_ever_unlocked = g_malloc0(s->num_blocks);
-        s->block_squashfs = g_malloc0(s->num_blocks);
     }
 
     /* Load flash contents from file if specified */
@@ -977,11 +990,9 @@ static void hisi_fmc_realize(DeviceState *dev, Error **errp)
             /* Resize block lock arrays to match */
             g_free(s->block_locked);
             g_free(s->block_ever_unlocked);
-            g_free(s->block_squashfs);
             s->num_blocks = file_size / NOR_SECTOR_SIZE;
             s->block_locked = g_malloc0(s->num_blocks);
             s->block_ever_unlocked = g_malloc0(s->num_blocks);
-            s->block_squashfs = g_malloc0(s->num_blocks);
         }
         FILE *f = fopen(s->flash_file, "rb");
         if (!f) {
@@ -1038,9 +1049,6 @@ static void hisi_fmc_realize(DeviceState *dev, Error **errp)
                     if (blk_end > s->num_blocks) blk_end = s->num_blocks;
                     for (uint32_t b = blk_start; b < blk_end; b++) {
                         s->block_ever_unlocked[b] = 0;
-                        if (s->block_squashfs) {
-                            s->block_squashfs[b] = 1; /* read-only rootfs */
-                        }
                     }
                     qemu_log("hisi-fmc: protect SquashFS at 0x%x "
                              "(%" PRIu64 " bytes, blocks %u-%u)\n",
@@ -1097,7 +1105,6 @@ static void hisi_fmc_finalize(Object *obj)
     g_free(s->nand_oob);
     g_free(s->block_locked);
     g_free(s->block_ever_unlocked);
-    g_free(s->block_squashfs);
 }
 
 static const Property hisi_fmc_properties[] = {


### PR DESCRIPTION
## Problem

OpenIPC's `firstboot` and `sysupgrade` silently failed under emulation on **unmodified** firmware images (verified with the hi3516ev300_lite full 8 MiB NOR from openipc.ru). Symptoms:

- `firstboot` left the overlay (`rootfs_data`) intact.
- `sysupgrade`'s `flashcp -v` reported `verification mismatch at 0x0`.
- `fw_printenv -n soc` returned blank → `sysupgrade` aborted with `SoC is not defined in U-Boot environment`.

These images work on real hardware, so the discrepancy was an emulation bug in the HiFMC V100 model (`hisi-fmc.c`).

## Root causes (two bugs)

**1. Erase address read from the wrong register.**
The Linux SPI-NOR core's default sector erase sends the target address as big-endian **data bytes** via `write_reg` (`memcpy_toio` into the IO buffer); `bsp_spi_nor_op_reg` never programs `FMC_ADDRL`. The model decoded the erase address from the stale `FMC_ADDRL` instead of `iobuf`, so every erase hit whatever block a prior DMA op happened to leave in `addrl`.

Proven with tracing: `flash_eraseall /dev/mtd2` issued 32 erases (mtd2 = 32 blocks) **all at the stale `0x7e0000`**, while mtd2's real `0x50000..` blocks stayed intact — yet `flash_eraseall` reported success. Fix: decode the address from `iobuf` (3- or 4-byte, big-endian).

**2. Program/erase gated on the SPI Write-Enable-Latch (WEL).**
The real FMC command engine auto-issues `WREN` before every program and erase. A guest relying on that never sets WEL, and within a multi-op transfer WEL is cleared after the first op — so gating each op on WEL silently dropped every program/erase after the first. That corrupted U-Boot `saveenv` (→ blank env → no `soc`), jffs2 overlay writes (`Node totlen 0xffffffff`) and `flashcp`. Fix: drop the WEL gate from `PAGE_PROGRAM`, `SECTOR_ERASE`, `CHIP_ERASE` and the DMA write path. **WPS block protection still applies.**

## Supersedes the #110 `block_squashfs` band-aid

#110 added a `block_squashfs[]` read-only-rootfs guard to stop SquashFS-from-NOR corruption. That corruption's **actual** cause was bug #1: overlay erases landing in the SquashFS region because `addrl` was stale. With the address decoded correctly, erases hit `rootfs_data` and the SquashFS is no longer touched — so the guard is removed, and real `sysupgrade` can reflash the rootfs as it must on hardware. cv610 still boots from NOR with **0 SquashFS errors** without it.

## Verification (unmodified hi3516ev300_lite 8 MiB NOR)

- **firstboot**: overlay erased block-by-block with jffs2 cleanmarkers (`Erasing 64 Kibyte @ 0 … @ b0000 — 100%`).
- **sysupgrade -k -r**: real GitHub firmware downloaded, kernel reflashed to mtd2 + rootfs to mtd3 (both `flashcp -v` verified), version bumped `2026-06-05 → 2026-06-06` (`RootFS updated to master+a9329aa`).
- **cv610 NOR boot**: still reaches login, 0 SquashFS errors.

## Regression guard

New `qemu-boot/test-flash-rw.sh` (wired into the boot matrix via a `flash_rw` flag for hi3516ev300) boots OpenIPC from the ramdisk with a writable synthetic NOR attached, then `flash_eraseall`s a 16-block partition (must read back `0xFF`) and `flashcp -v`s an 8-block random payload (must verify). Confirmed discriminating: **PASS** on this branch, **FAIL** on the parent commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)