### PR TITLE
hisilicon: boot xm720/Goke-V500 u-boot via deadbeef loader descriptor

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -3781,6 +3781,62 @@ static void hisilicon_write_bootrom(MemoryRegion *sysmem,
     }
 
     /*
+     * xm720 / Goke-V500 (gk7205v500/v510/v530) multi-section vendor images
+     * carry no vector table at flash offset 0 — the first 64 bytes are zero
+     * and the first-stage loader sits deeper in the image, prefixed by its
+     * own ARM vector table and a run of 8 0xdeadbeef marker words that is
+     * immediately followed by the loader's absolute load address (e.g.
+     * 0x40707000).  Real silicon's boot ROM parses this layout; mirror it
+     * here.  When flash offset 0 is not a reset branch (so the naive
+     * copy-to-ram_base / jump-to-0 path would just execute zeros), scan for
+     * the marker run, take the load address that follows it, and copy/jump
+     * from the loader's vector table 8 words (32 bytes) before the markers.
+     *
+     * Read the flash image from the file directly: at machine-init time the
+     * FMC memory window is not yet readable through the address space (the
+     * copy loop only reads the real flash at guest runtime), so we inspect the
+     * backing file to learn the layout.
+     */
+    HisiMachineState *hms = (HisiMachineState *)machine;
+    if (hms->flash_file && hms->flash_file[0]) {
+        char *data = NULL;
+        gsize len = 0;
+        if (g_file_get_contents(hms->flash_file, &data, &len, NULL)) {
+            const uint32_t *w = (const uint32_t *)data;
+            size_t nwords = len / 4;
+            uint32_t vec0 = nwords ? le32_to_cpu(w[0]) : 0;
+            bool vec0_branch = (vec0 & 0xFF000000) == 0xEA000000;  /* b <imm24>   */
+            bool vec0_ldrpc  = (vec0 & 0xFFFFF000) == 0xE59FF000;  /* ldr pc,[pc] */
+            const int MARK_RUN = 8;                     /* 8x 0xdeadbeef */
+            size_t scan = MIN(nwords, (size_t)(0x40000 / 4));  /* first 256 KiB */
+            if (!vec0_branch && !vec0_ldrpc) {
+                for (size_t i = 0; i + MARK_RUN + 1 <= scan; i++) {
+                    if (le32_to_cpu(w[i]) != 0xdeadbeef) {
+                        continue;
+                    }
+                    int run = 0;
+                    while (run < MARK_RUN &&
+                           le32_to_cpu(w[i + run]) == 0xdeadbeef) {
+                        run++;
+                    }
+                    if (run < MARK_RUN || i < (size_t)MARK_RUN) {
+                        continue;
+                    }
+                    /* Load address immediately follows the marker run; the
+                     * loader's vector table is the 8 words before the run. */
+                    uint32_t load_addr = le32_to_cpu(w[i + MARK_RUN]);
+                    if ((load_addr & ~0xFFFFu) >= c->ram_base) {
+                        flash_src += (i - MARK_RUN) * 4;
+                        ram_dst = load_addr;
+                    }
+                    break;
+                }
+            }
+            g_free(data);
+        }
+    }
+
+    /*
      * Build a small boot ROM that copies U-Boot from the SPI NOR flash
      * memory window to DDR and jumps to it.
      *


### PR DESCRIPTION
## Problem
The synthetic bootrom (`hisilicon_write_bootrom`) copies 1 MiB from NOR to `ram_base` and jumps to offset 0. That works for V4 vendor images (valid reset branch at offset 0) but the **xm720 / Goke-V500** images (`gk7205v500/v510/v530`) have a **zero** 64-byte header, so the CPU executed zeros → no UART output. On real silicon the boot ROM parses the image's loader descriptor; the stub didn't.

## Fix
When flash offset 0 is not a reset branch, scan the flash image for the loader self-descriptor — a run of 8 `0xdeadbeef` words immediately followed by the loader's absolute load address (e.g. `0x40707000`). Copy/jump from the loader's vector table (the 8 words preceding the markers) to that load address. The image is read from the backing file because the FMC window isn't readable through the address space at machine-init time.

V4 images and cv6xx raw u-boot keep their existing path (valid offset-0 vector → scan skipped).

## Verified (boots to U-Boot banner)
- ✅ `gk7205v500`, `gk7205v510`, `gk7205v530` (was: empty serial)
- ✅ no regression: `gk7205v200` (V4), `hi3516cv610` (raw u-boot)

Tested against the published `u-boot-gk7205v5xx-nor.bin` images from OpenIPC/firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)