### PR TITLE
hisilicon: implement Goke V500 xmsp804 timer so Linux full-boots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,6 +452,19 @@ jobs:
             # for all hisi-fmc SoCs (the fix is in shared hisi-fmc.c).
             flash_rw: true
 
+          # gk7205v500 (Goke V500) full-Linux boot regression gate.
+          # The goke V500 OpenIPC kernel uses an "xmsp804" timer
+          # (4 single-timer blocks at 0x100 stride, hisi-xmsp804.c);
+          # before the fix Linux hung at "Calibrating delay loop" because
+          # the periodic timer IRQ at block1 (0x12000100, GIC SPI 27) was
+          # never delivered.  Plain console=ttyAMA0 (no earlycon) suffices
+          # once the timer IRQ works.  Stands in for the whole V500 family
+          # (gk7205v510/v530, gk7202v330 share the xmsp804 wiring).
+          - name: gk7205v500
+            soc: gk7205v500
+            machine: gk7205v500,sensor=none
+            append: "console=ttyAMA0,115200 root=/dev/ram0 rootfstype=squashfs"
+
           # hi3516cv610 (V5) has its own boot-hi3516cv610 job below: its
           # OpenIPC release is a combined firmware.bin (FIT kernel+dtb with an
           # appended SquashFS) under the SoC-family name, so it needs an

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2013,6 +2013,7 @@ static const HisiSoCConfig gk7205v500_soc = {
     .gpio_count         = 8,
     HISI_V4_DDR_64M,                /* 512Mb DDR2 MCP */
     HISI_V4_COMMON_PERIPH,
+    .xmsp804_timer      = true,     /* goke V500 kernel uses xmedia,sp804 */
 };
 
 static const HisiSoCConfig gk7205v510_soc = {
@@ -2022,6 +2023,7 @@ static const HisiSoCConfig gk7205v510_soc = {
     .gpio_count         = 8,
     HISI_V4_DDR_128M,               /* 1Gb DDR3 MCP */
     HISI_V4_COMMON_PERIPH,
+    .xmsp804_timer      = true,     /* goke V500 kernel uses xmedia,sp804 */
 };
 
 static const HisiSoCConfig gk7205v530_soc = {
@@ -2031,6 +2033,7 @@ static const HisiSoCConfig gk7205v530_soc = {
     .gpio_count         = 8,
     HISI_V4_DDR_128M,               /* external DDR, 128 MiB typical */
     HISI_V4_COMMON_PERIPH,
+    .xmsp804_timer      = true,     /* goke V500 kernel uses xmedia,sp804 */
 };
 
 static const HisiSoCConfig gk7202v330_soc = {
@@ -2040,6 +2043,7 @@ static const HisiSoCConfig gk7202v330_soc = {
     .gpio_count         = 8,
     HISI_V4_DDR_64M,                /* 512Mb DDR2 MCP */
     HISI_V4_COMMON_PERIPH,
+    .xmsp804_timer      = true,     /* same GK7205V500 register family / goke V500 kernel */
 };
 
 /*
@@ -4441,18 +4445,34 @@ static void hisilicon_common_init(MachineState *machine,
         hisi_register_uart_pre_enable_reset(c);
     }
 
-    /* Timers (SP804) */
-    for (n = 0; n < c->num_timers; n++) {
-        if (c->timer_freq) {
-            DeviceState *t = qdev_new("sp804");
-            qdev_prop_set_uint32(t, "freq0", c->timer_freq);
-            qdev_prop_set_uint32(t, "freq1", c->timer_freq);
-            sysbus_realize_and_unref(SYS_BUS_DEVICE(t), &error_fatal);
-            sysbus_mmio_map(SYS_BUS_DEVICE(t), 0, c->timer_bases[n]);
-            sysbus_connect_irq(SYS_BUS_DEVICE(t), 0, pic[c->timer_irqs[n]]);
-        } else {
-            sysbus_create_simple("sp804", c->timer_bases[n],
-                                 pic[c->timer_irqs[n]]);
+    /* Timers */
+    if (c->xmsp804_timer) {
+        /*
+         * Goke V500 (gk7205v500/v510/v530, gk7202v330) xmsp804: four
+         * single-timer blocks at 0x100 stride at timer_bases[0] (0x12000000).
+         * Per xm720xxx.dtsi the per-block IRQs are GIC SPI 27, 6, 28 for
+         * blocks 1/2/3 (block0 is the free-running clocksource, no IRQ).
+         */
+        DeviceState *t = qdev_new("hisi-xmsp804");
+        qdev_prop_set_uint32(t, "freq", 24000000);
+        sysbus_realize_and_unref(SYS_BUS_DEVICE(t), &error_fatal);
+        sysbus_mmio_map(SYS_BUS_DEVICE(t), 0, c->timer_bases[0]);
+        sysbus_connect_irq(SYS_BUS_DEVICE(t), 1, pic[27]);
+        sysbus_connect_irq(SYS_BUS_DEVICE(t), 2, pic[6]);
+        sysbus_connect_irq(SYS_BUS_DEVICE(t), 3, pic[28]);
+    } else {
+        for (n = 0; n < c->num_timers; n++) {
+            if (c->timer_freq) {
+                DeviceState *t = qdev_new("sp804");
+                qdev_prop_set_uint32(t, "freq0", c->timer_freq);
+                qdev_prop_set_uint32(t, "freq1", c->timer_freq);
+                sysbus_realize_and_unref(SYS_BUS_DEVICE(t), &error_fatal);
+                sysbus_mmio_map(SYS_BUS_DEVICE(t), 0, c->timer_bases[n]);
+                sysbus_connect_irq(SYS_BUS_DEVICE(t), 0, pic[c->timer_irqs[n]]);
+            } else {
+                sysbus_create_simple("sp804", c->timer_bases[n],
+                                     pic[c->timer_irqs[n]]);
+            }
         }
     }
 

--- a/qemu/hw/misc/hisi-xmsp804.c
+++ b/qemu/hw/misc/hisi-xmsp804.c
@@ -1,0 +1,301 @@
+/*
+ * XMedia/Goke "xmsp804" timer — QEMU emulation.
+ *
+ * The Goke V500 family (gk7205v500/v510/v530, gk7202v330) ships an OpenIPC
+ * Linux 4.9.37 kernel whose timer driver
+ * (drivers/xmedia/timer/xmedia_sp804_timer.c, compatible "xmedia,sp804")
+ * differs from a stock ARM SP804: instead of two timers packed at offsets
+ * 0x00/0x20 in one 0x20-stride block, it exposes FOUR independent
+ * single-timer blocks at a 0x100 stride:
+ *
+ *   reg = <base+0x000 0x30>,  timer0: free-running clocksource
+ *         <base+0x100 0x30>,  timer1: per-CPU periodic clockevent
+ *         <base+0x200 0x30>,  timer2
+ *         <base+0x300 0x30>;  timer3
+ *   interrupts = <0 27 4>, <0 6 4>, <0 28 4>;  // timer1/2/3 (timer0 has none)
+ *
+ * Each block uses the *normal* SP804 register map (LOAD 0x00, VALUE 0x04,
+ * CTRL 0x08, INTCLR 0x0C, RIS 0x10, MIS 0x14, BGLOAD 0x18).  On a single-core
+ * A7 the kernel runs block0 as the clocksource and block1 as the periodic
+ * clockevent (GIC SPI 27); the stock QEMU "sp804" model only decodes
+ * 0x00-0x3F, so the kernel's writes to block1 (0x100/0x108) hit "Bad offset"
+ * and the periodic IRQ is never delivered — Linux hangs at
+ * "Calibrating delay loop".
+ *
+ * This device decodes the block from offset bits [9:8] (n = offset >> 8) and
+ * applies the per-timer register semantics to one ptimer per block, exposing
+ * one sysbus IRQ per block so each can be wired to its own GIC SPI.
+ *
+ * Copyright (c) 2026 OpenIPC.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/sysbus.h"
+#include "hw/irq.h"
+#include "hw/ptimer.h"
+#include "hw/qdev-properties.h"
+#include "migration/vmstate.h"
+#include "qemu/log.h"
+#include "qemu/module.h"
+#include "qom/object.h"
+
+/* Per-timer control bits (identical to ARM SP804). */
+#define TIMER_CTRL_ONESHOT      (1 << 0)
+#define TIMER_CTRL_32BIT        (1 << 1)
+#define TIMER_CTRL_DIV1         (0 << 2)
+#define TIMER_CTRL_DIV16        (1 << 2)
+#define TIMER_CTRL_DIV256       (2 << 2)
+#define TIMER_CTRL_IE           (1 << 5)
+#define TIMER_CTRL_PERIODIC     (1 << 6)
+#define TIMER_CTRL_ENABLE       (1 << 7)
+
+#define HISI_XMSP804_NUM_TIMERS  4
+#define HISI_XMSP804_STRIDE      0x100
+#define HISI_XMSP804_MMIO_SIZE   (HISI_XMSP804_NUM_TIMERS * HISI_XMSP804_STRIDE)
+
+#define TYPE_HISI_XMSP804 "hisi-xmsp804"
+OBJECT_DECLARE_SIMPLE_TYPE(HisiXmsp804State, HISI_XMSP804)
+
+typedef struct HisiXmsp804Timer {
+    ptimer_state *ptimer;
+    uint32_t control;
+    uint32_t limit;
+    int int_level;
+    qemu_irq irq;
+    int freq;
+} HisiXmsp804Timer;
+
+struct HisiXmsp804State {
+    SysBusDevice parent_obj;
+
+    MemoryRegion iomem;
+    HisiXmsp804Timer timer[HISI_XMSP804_NUM_TIMERS];
+    uint32_t freq;
+};
+
+/* Raise/lower the block IRQ from the latched interrupt + mask. */
+static void xmsp804_timer_update(HisiXmsp804Timer *t)
+{
+    if (t->int_level && (t->control & TIMER_CTRL_IE)) {
+        qemu_irq_raise(t->irq);
+    } else {
+        qemu_irq_lower(t->irq);
+    }
+}
+
+/*
+ * Recompute the ptimer limit after a settings change.
+ * Must be called inside a ptimer transaction.
+ */
+static void xmsp804_timer_recalibrate(HisiXmsp804Timer *t, int reload)
+{
+    uint32_t limit;
+
+    if ((t->control & (TIMER_CTRL_PERIODIC | TIMER_CTRL_ONESHOT)) == 0) {
+        /* Free running. */
+        limit = (t->control & TIMER_CTRL_32BIT) ? 0xffffffff : 0xffff;
+    } else {
+        /* Periodic / one-shot. */
+        limit = t->limit;
+    }
+    ptimer_set_limit(t->ptimer, limit, reload);
+}
+
+static uint32_t xmsp804_timer_read(HisiXmsp804Timer *t, hwaddr offset)
+{
+    switch (offset >> 2) {
+    case 0: /* TimerLoad */
+    case 6: /* TimerBGLoad */
+        return t->limit;
+    case 1: /* TimerValue */
+        return ptimer_get_count(t->ptimer);
+    case 2: /* TimerControl */
+        return t->control;
+    case 4: /* TimerRIS */
+        return t->int_level;
+    case 5: /* TimerMIS */
+        if ((t->control & TIMER_CTRL_IE) == 0) {
+            return 0;
+        }
+        return t->int_level;
+    default:
+        qemu_log_mask(LOG_GUEST_ERROR,
+                      "%s: Bad offset %x\n", __func__, (int)offset);
+        return 0;
+    }
+}
+
+static void xmsp804_timer_write(HisiXmsp804Timer *t, hwaddr offset,
+                                uint32_t value)
+{
+    int freq;
+
+    switch (offset >> 2) {
+    case 0: /* TimerLoad */
+        t->limit = value;
+        ptimer_transaction_begin(t->ptimer);
+        xmsp804_timer_recalibrate(t, 1);
+        ptimer_transaction_commit(t->ptimer);
+        break;
+    case 1: /* TimerValue — read-only; Linux pokes it, ignore. */
+        break;
+    case 2: /* TimerControl */
+        ptimer_transaction_begin(t->ptimer);
+        if (t->control & TIMER_CTRL_ENABLE) {
+            /* Pause while reprogramming, mirroring arm_timer.c. */
+            ptimer_stop(t->ptimer);
+        }
+        t->control = value;
+        freq = t->freq;
+        switch ((value >> 2) & 3) {
+        case 1: freq >>= 4; break;
+        case 2: freq >>= 8; break;
+        }
+        xmsp804_timer_recalibrate(t, t->control & TIMER_CTRL_ENABLE);
+        ptimer_set_freq(t->ptimer, freq);
+        if (t->control & TIMER_CTRL_ENABLE) {
+            ptimer_run(t->ptimer, (t->control & TIMER_CTRL_ONESHOT) != 0);
+        }
+        ptimer_transaction_commit(t->ptimer);
+        break;
+    case 3: /* TimerIntClr */
+        t->int_level = 0;
+        break;
+    case 6: /* TimerBGLoad */
+        t->limit = value;
+        ptimer_transaction_begin(t->ptimer);
+        xmsp804_timer_recalibrate(t, 0);
+        ptimer_transaction_commit(t->ptimer);
+        break;
+    default:
+        qemu_log_mask(LOG_GUEST_ERROR,
+                      "%s: Bad offset %x\n", __func__, (int)offset);
+        break;
+    }
+    xmsp804_timer_update(t);
+}
+
+static uint64_t hisi_xmsp804_read(void *opaque, hwaddr offset, unsigned size)
+{
+    HisiXmsp804State *s = HISI_XMSP804(opaque);
+    int n = offset >> 8;
+
+    if (n >= HISI_XMSP804_NUM_TIMERS) {
+        qemu_log_mask(LOG_GUEST_ERROR, "%s: Bad timer %d\n", __func__, n);
+        return 0;
+    }
+    return xmsp804_timer_read(&s->timer[n], offset & 0xff);
+}
+
+static void hisi_xmsp804_write(void *opaque, hwaddr offset,
+                               uint64_t value, unsigned size)
+{
+    HisiXmsp804State *s = HISI_XMSP804(opaque);
+    int n = offset >> 8;
+
+    if (n >= HISI_XMSP804_NUM_TIMERS) {
+        qemu_log_mask(LOG_GUEST_ERROR, "%s: Bad timer %d\n", __func__, n);
+        return;
+    }
+    xmsp804_timer_write(&s->timer[n], offset & 0xff, (uint32_t)value);
+}
+
+static const MemoryRegionOps hisi_xmsp804_ops = {
+    .read = hisi_xmsp804_read,
+    .write = hisi_xmsp804_write,
+    .endianness = DEVICE_NATIVE_ENDIAN,
+};
+
+static void hisi_xmsp804_tick(void *opaque)
+{
+    HisiXmsp804Timer *t = opaque;
+    t->int_level = 1;
+    xmsp804_timer_update(t);
+}
+
+static void hisi_xmsp804_init(Object *obj)
+{
+    HisiXmsp804State *s = HISI_XMSP804(obj);
+    SysBusDevice *sbd = SYS_BUS_DEVICE(obj);
+    int i;
+
+    for (i = 0; i < HISI_XMSP804_NUM_TIMERS; i++) {
+        sysbus_init_irq(sbd, &s->timer[i].irq);
+    }
+    memory_region_init_io(&s->iomem, obj, &hisi_xmsp804_ops, s,
+                          TYPE_HISI_XMSP804, HISI_XMSP804_MMIO_SIZE);
+    sysbus_init_mmio(sbd, &s->iomem);
+}
+
+static void hisi_xmsp804_realize(DeviceState *dev, Error **errp)
+{
+    HisiXmsp804State *s = HISI_XMSP804(dev);
+    int i;
+
+    for (i = 0; i < HISI_XMSP804_NUM_TIMERS; i++) {
+        HisiXmsp804Timer *t = &s->timer[i];
+
+        t->freq = s->freq;
+        t->control = TIMER_CTRL_IE;
+        /*
+         * CONTINUOUS_TRIGGER matches real SP804 silicon (and the project's
+         * arm_timer.c patch): periodic mode with LOAD=0 keeps reloading
+         * instead of tripping the ptimer "delta zero, disabling" guard.
+         */
+        t->ptimer = ptimer_init(hisi_xmsp804_tick, t,
+                                PTIMER_POLICY_CONTINUOUS_TRIGGER);
+    }
+}
+
+static const VMStateDescription vmstate_hisi_xmsp804_timer = {
+    .name = "hisi-xmsp804-timer",
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (const VMStateField[]) {
+        VMSTATE_UINT32(control, HisiXmsp804Timer),
+        VMSTATE_UINT32(limit, HisiXmsp804Timer),
+        VMSTATE_INT32(int_level, HisiXmsp804Timer),
+        VMSTATE_PTIMER(ptimer, HisiXmsp804Timer),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
+static const VMStateDescription vmstate_hisi_xmsp804 = {
+    .name = "hisi-xmsp804",
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (const VMStateField[]) {
+        VMSTATE_STRUCT_ARRAY(timer, HisiXmsp804State, HISI_XMSP804_NUM_TIMERS,
+                             1, vmstate_hisi_xmsp804_timer, HisiXmsp804Timer),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
+static const Property hisi_xmsp804_properties[] = {
+    DEFINE_PROP_UINT32("freq", HisiXmsp804State, freq, 24000000),
+};
+
+static void hisi_xmsp804_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+
+    dc->realize = hisi_xmsp804_realize;
+    dc->vmsd = &vmstate_hisi_xmsp804;
+    device_class_set_props(dc, hisi_xmsp804_properties);
+}
+
+static const TypeInfo hisi_xmsp804_info = {
+    .name          = TYPE_HISI_XMSP804,
+    .parent        = TYPE_SYS_BUS_DEVICE,
+    .instance_size = sizeof(HisiXmsp804State),
+    .instance_init = hisi_xmsp804_init,
+    .class_init    = hisi_xmsp804_class_init,
+};
+
+static void hisi_xmsp804_register_types(void)
+{
+    type_register_static(&hisi_xmsp804_info);
+}
+
+type_init(hisi_xmsp804_register_types)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -130,6 +130,12 @@ typedef struct HisiSoCConfig {
     hwaddr          timer_bases[HISI_MAX_TIMERS];
     int             timer_irqs[HISI_MAX_TIMERS];
     uint32_t        timer_freq;     /* 0 = device default */
+    /*
+     * Goke V500 "xmsp804": one hisi-xmsp804 device (4 single-timer blocks at
+     * 0x100 stride) at timer_bases[0] instead of the stock dual-timer sp804s.
+     * When set, the sp804 loop above is skipped.  See hisi-xmsp804.c.
+     */
+    bool            xmsp804_timer;
 
     /* SPI (PL022) */
     int             num_spis;

--- a/qemu/setup.sh
+++ b/qemu/setup.sh
@@ -51,6 +51,7 @@ cp qemu/hw/misc/hisi-vi-fp.c        "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-fastboot.c     "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-gzip.c        "$QEMU_DIR/hw/misc/"
 cp qemu/hw/misc/hisi-l2cache.c     "$QEMU_DIR/hw/misc/"
+cp qemu/hw/misc/hisi-xmsp804.c     "$QEMU_DIR/hw/misc/"
 cp qemu/hw/net/hisi-femac.c         "$QEMU_DIR/hw/net/"
 cp qemu/hw/net/hisi-gmac.c          "$QEMU_DIR/hw/net/"
 cp qemu/hw/net/hisi-hieth-sf.c      "$QEMU_DIR/hw/net/"
@@ -154,7 +155,7 @@ fi
 
 # hw/misc/meson.build
 if ! grep -q hisi-sysctl "$QEMU_DIR/hw/misc/meson.build"; then
-    echo "system_ss.add(when: 'CONFIG_HISI_MISC', if_true: files('hisi-sysctl.c', 'hisi-crg.c', 'hisi-fmc.c', 'hisi-sfc350.c', 'hisi-himci.c', 'hisi-regbank.c', 'hisi-vedu.c', 'hisi-mipi-rx.c', 'hisi-rtc.c', 'hisi-ive.c', 'hisi-nnie.c', 'hisi-fastboot.c', 'hisi-gzip.c', 'hisi-hwrng.c', 'hisi-vi-fp.c', 'hisi-l2cache.c'))" \
+    echo "system_ss.add(when: 'CONFIG_HISI_MISC', if_true: files('hisi-sysctl.c', 'hisi-crg.c', 'hisi-fmc.c', 'hisi-sfc350.c', 'hisi-himci.c', 'hisi-regbank.c', 'hisi-vedu.c', 'hisi-mipi-rx.c', 'hisi-rtc.c', 'hisi-ive.c', 'hisi-nnie.c', 'hisi-fastboot.c', 'hisi-gzip.c', 'hisi-hwrng.c', 'hisi-vi-fp.c', 'hisi-l2cache.c', 'hisi-xmsp804.c'))" \
         >> "$QEMU_DIR/hw/misc/meson.build"
     echo "  patched hw/misc/meson.build"
 else
@@ -177,6 +178,11 @@ else
         sed -i "s/'hisi-ive.c'/'hisi-ive.c', 'hisi-nnie.c'/" \
             "$QEMU_DIR/hw/misc/meson.build"
         echo "  hw/misc/meson.build: added hisi-nnie.c"
+    fi
+    if ! grep -q hisi-xmsp804 "$QEMU_DIR/hw/misc/meson.build"; then
+        sed -i "s/'hisi-l2cache.c'/'hisi-l2cache.c', 'hisi-xmsp804.c'/" \
+            "$QEMU_DIR/hw/misc/meson.build"
+        echo "  hw/misc/meson.build: added hisi-xmsp804.c"
     fi
 fi
 


### PR DESCRIPTION
## Problem

`gk7205v500`/`gk7205v510`/`gk7205v530` (and `gk7202v330`) run U-Boot but hang the OpenIPC goke Linux 4.9.37 kernel at `Calibrating delay loop...` — the periodic timer interrupt is never delivered. QEMU logs `sp804_write: Bad offset 108 / 100` at the hang.

Fixes #114.

## Root cause

The goke V500 kernel timer (`drivers/xmedia/timer/xmedia_sp804_timer.c`, `compatible = "xmedia,sp804"`) is **not** a stock ARM SP804. Instead of two timers at offsets `0x00`/`0x20` in one block, it lays out **four independent single-timer blocks at a `0x100` stride** (`xm720xxx.dtsi`), each using the normal SP804 register map:

```
reg = <0x12000000 0x30>,  // timer0: free-running clocksource
      <0x12000100 0x30>,  // timer1: periodic clockevent
      <0x12000200 0x30>,  // timer2
      <0x12000300 0x30>;  // timer3
interrupts = <0 27 4>, <0 6 4>, <0 28 4>;  // blocks 1/2/3
```

On a single-core A7 the kernel runs block0 as the clocksource (works — clocksource/sched_clock register fine) and **block1 @`0x12000100` as the periodic clockevent on GIC SPI 27**. The stock QEMU `sp804` model only decodes `0x00–0x3F`, so the kernel's writes to block1 hit *Bad offset* and the clockevent IRQ never fires — calibration spins forever.

`hi3516ev300` (same V4 family) is unaffected because its kernel uses the standard `hisilicon,hisp804` (0x20 stride, IRQs 5/6).

## Fix

- New `hisi-xmsp804` device modelling four SP804-style single-timer blocks at `0x100` stride, one IRQ each (modelled on the existing `icp_pit` 0x100-stride decode + `arm_timer.c` register semantics, using the `CONTINUOUS_TRIGGER` ptimer policy this tree already relies on).
- New `xmsp804_timer` flag in `HisiSoCConfig`; when set, the timer-init path instantiates `hisi-xmsp804` at `timer_bases[0]` and wires blocks 1/2/3 to GIC SPI 27/6/28. The stock dual-`sp804` path is **untouched** for every other SoC.
- Set the flag on `gk7205v500`/`v510`/`v530`/`gk7202v330`.

Once the timer IRQ is delivered the kernel reaches `console [ttyAMA0] enabled` and flushes its log, so plain `console=ttyAMA0` now works **without** the `earlycon`/`keep_bootcon` workaround the issue described (that symptom was the timer hang, not a separate UART bug).

## Test

New `gk7205v500` full-Linux boot job added to CI as a regression gate for the whole V500 family. Verified locally against `openipc.gk7205v500-nor-lite.tgz`:

```
Calibrating delay loop... 1013.35 BogoMIPS
console [ttyAMA0] enabled
...
openipc-gk7205v500 login:
```

`sp804 Bad offset` count: **0**. Other SoCs (e.g. `hi3516cv500`) still boot — the new path is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)