### PR TITLE
hisi-fmc: SPI-NAND flash boot (UBI/UBIFS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -852,3 +852,92 @@ jobs:
             boot-output.txt
             qemu-boot/qemu.log
           retention-days: 7
+
+  boot-hi3516ev300-nand:
+    name: Boot hi3516ev300 (SPI-NAND / UBI)
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libfdt1 libglib2.0-0 libpixman-1-0 libslirp0 \
+            mtd-utils squashfs-tools python3-pip
+          pip3 install --break-system-packages ubi_reader
+
+      - name: Download QEMU binary
+        uses: actions/download-artifact@v4
+        with:
+          name: qemu-arm
+          path: qemu-src/build/
+
+      - name: Make QEMU executable
+        run: chmod +x qemu-src/build/qemu-system-arm
+
+      - name: Assemble SPI-NAND image from OpenIPC ev300 NAND release
+        run: bash qemu-boot/mk-ev300-nand.sh
+
+      - name: "OpenIPC NAND/UBI flash-boot"
+        timeout-minutes: 4
+        run: |
+          # Boots ENTIRELY from the emulated SPI-NAND (no -kernel): boot ROM ->
+          # U-Boot (attaches UBI, reads kernel volume) -> kernel -> ubiblock
+          # squashfs root.  nand-jedec/nand-oob-size present the W25N01GV the
+          # OpenIPC ev300 U-Boot SPI-NAND id table knows.
+          #
+          # The gate is the NAND/UBI storage chain itself — U-Boot + kernel
+          # attach UBI from the emulated NAND and mount the squashfs rootfs via
+          # ubiblock — which is exactly what this PR delivers and is fully
+          # deterministic.  It deliberately does NOT wait for a login prompt:
+          # the OpenIPC "ultimate" rootfs (the only NAND build OpenIPC ships
+          # for ev300) runs load_hisilicon, which insmods the vendor MPP/mmz
+          # blob that hangs on QEMU regardless of storage backend.
+          QEMU=./qemu-src/build/qemu-system-arm
+          timeout 180 $QEMU -M hi3516ev300,sensor=none,flash-file=qemu-boot/ev300-nand.img \
+            -global hisi-fmc.nand-jedec=0xEFAA21 \
+            -global hisi-fmc.nand-oob-size=64 \
+            -nographic -serial mon:stdio -nic user,restrict=on \
+            -d unimp,guest_errors -D qemu-boot/qemu.log 2>&1 | tee boot-output.txt &
+          QEMU_PID=$!
+
+          for i in $(seq 1 180); do
+            if grep -q "Mounted root (squashfs filesystem)" boot-output.txt 2>/dev/null; then
+              echo ""
+              echo "=== NAND -> UBI -> squashfs root mounted ==="
+              kill $QEMU_PID 2>/dev/null || true
+              # The whole chain must have run, and cleanly.
+              grep -q "block ubiblock0_1: created from ubi0:1(rootfs)" boot-output.txt \
+                || { echo "FAIL: ubiblock not created from NAND UBI"; exit 1; }
+              if grep -qE "Kernel panic|Unable to mount root|spi_flash_probe\(\) failed" boot-output.txt; then
+                echo "=== FAIL: panic / NAND-boot regression ==="
+                grep -nE "Kernel panic|Unable to mount root|spi_flash_probe\(\) failed" boot-output.txt | head
+                exit 1
+              fi
+              echo "=== Boot clean (boot ROM -> U-Boot UBI -> kernel UBI -> ubiblock -> squashfs root) ==="
+              exit 0
+            fi
+            if ! kill -0 $QEMU_PID 2>/dev/null; then
+              echo "=== FAIL: QEMU exited before mounting root ==="
+              tail -40 boot-output.txt
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "=== TIMEOUT: root not mounted from NAND/UBI ==="
+          tail -40 boot-output.txt
+          kill $QEMU_PID 2>/dev/null || true
+          exit 1
+
+      - name: Upload boot log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: boot-log-hi3516ev300-nand
+          path: |
+            boot-output.txt
+            qemu-boot/qemu.log
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ qemu-boot/
 ├── run-3519v101.sh
 ├── run-ev300.sh
 ├── run-ev300-flash.sh           # Boot from SPI NOR flash dump (no -kernel needed)
+├── mk-ev300-nand.sh             # Assemble OpenIPC ev300 SPI-NAND/UBI image
+├── run-ev300-nand.sh            # Boot from SPI NAND image (UBI rootfs)
+├── run-gk7205v510-nand.sh       # Boot a GD5F1GM7 SPI-NAND camera dump
 ├── run-cv610.sh
 ├── test-ive-init.c              # IVE basic test (hw_id, dma, sad, ccl)
 ├── test-ive-ops.c               # IVE operations test for QEMU (register-level)
@@ -236,6 +239,31 @@ will succeed
 A test passes only if the firmware actually issues the unlock
 sequence — without the knob, the same firmware silently "works"
 against an emulator that never had the lock to begin with.
+
+#### SPI-NAND flash boot (UBI/UBIFS)
+
+`hisi-fmc` also models a SPI-NAND chip (GigaDevice GD5F1GM7 by default:
+2 KiB page, 128 KiB block, 128 MiB), so NAND/UBI firmware boots straight
+from a flash image — boot ROM → U-Boot → UBI → kernel → UBIFS/ubiblock
+root, the same path as silicon. A `flash-file` larger than 16 MiB is
+auto-detected as SPI-NAND, and the SoC's SYSSTAT boot-strap reports the
+NAND boot device so U-Boot takes the NAND path instead of probing NOR.
+
+```bash
+# Goke GK7205V510 — boot a real 128 MiB GD5F1GM7 camera dump:
+bash qemu-boot/run-gk7205v510-nand.sh nand-dump.bin
+
+# OpenIPC hi3516ev300 NAND build — assemble image, then flash-boot it:
+bash qemu-boot/mk-ev300-nand.sh        # u-boot + ubinize(kernel+rootfs+rootfs_data)
+bash qemu-boot/run-ev300-nand.sh
+```
+
+`nand-jedec` overrides the READ-ID and `nand-oob-size` the spare-area size
+(128 for GD5F1GM7, 64 for W25N01GV) for firmware whose ID table differs —
+e.g. the OpenIPC ev300 U-Boot wants W25N01GV
+(`-global hisi-fmc.nand-jedec=0xEFAA21 -global hisi-fmc.nand-oob-size=64`).
+Dual NOR+NAND boards (NOR boot/env, NAND rootfs) attach the second chip
+with `-global hisi-fmc.nand-file=…`.
 
 ### Method 2: Boot with separate kernel and rootfs
 

--- a/qemu-boot/mk-ev300-nand.sh
+++ b/qemu-boot/mk-ev300-nand.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Assemble a bootable SPI-NAND image for the emulated Hi3516EV300 from the
+# OpenIPC hi3516ev300 NAND release, then boot it with run-ev300-nand.sh.
+#
+# OpenIPC ships the NAND build as three pieces:
+#   u-boot-hi3516ev300-nand.bin          (U-Boot, gzip-loader format)
+#   openipc.hi3516ev300-nand-ultimate.tgz -> uImage + rootfs.ubi
+# The rootfs.ubi only contains the rootfs (+rootfs_data) volumes; OpenIPC adds
+# the "kernel" volume at flash time and (on the ubiblock layout) the rootfs is
+# a squashfs.  This script reproduces that: it builds a UBI image with the
+# kernel volume + a squashfs rootfs + an autoresize rootfs_data, and lays it
+# out per the default env (mtdparts=hinand:768k(boot),256k(env),-(ubi)):
+#   0x000000  boot  (u-boot)
+#   0x0C0000  env   (blank -> U-Boot default env, root=/dev/ubiblock0_1)
+#   0x100000  ubi   (kernel + rootfs + rootfs_data)
+#
+# Requires: ubinize, mksquashfs, ubireader_extract_files (ubi_reader).
+#
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORK="${WORK:-/tmp/ev300-nand-mk}"
+DL="https://github.com/OpenIPC/firmware/releases/download/latest"
+PAGE=2048; PEB=128KiB
+
+mkdir -p "$WORK"; cd "$WORK"
+[ -f u-boot-hi3516ev300-nand.bin ] || curl -sL -o u-boot-hi3516ev300-nand.bin "$DL/u-boot-hi3516ev300-nand.bin"
+[ -f nand.tgz ]                    || curl -sL -o nand.tgz "$DL/openipc.hi3516ev300-nand-ultimate.tgz"
+tar xzf nand.tgz
+
+# Extract the OpenIPC rootfs (UBIFS) to a tree, restore exec bits that the
+# extractor drops, and repack as squashfs to match the ubiblock root= env.
+rm -rf rfs; ubireader_extract_files -k -o rfs rootfs.ubi.hi3516ev300 >/dev/null 2>&1 || true
+RFS="$(find rfs -maxdepth 2 -type d -name rootfs | head -1)"
+for d in overlay media utils proc sys tmp run dev mnt; do mkdir -p "$RFS/$d"; done
+chmod +x "$RFS/init"
+for d in bin sbin usr/bin usr/sbin usr/libexec etc/init.d; do
+    [ -d "$RFS/$d" ] && chmod -R +x "$RFS/$d"
+done
+find "$RFS/lib" "$RFS/usr/lib" -name '*.so*' -exec chmod +x {} + 2>/dev/null || true
+mksquashfs "$RFS" rootfs.squashfs -comp xz -b 131072 -noappend -all-root >/dev/null
+
+cat > ubinize.cfg <<EOF
+[kernel]
+mode=ubi
+image=uImage.hi3516ev300
+vol_id=0
+vol_type=static
+vol_name=kernel
+
+[rootfs]
+mode=ubi
+image=rootfs.squashfs
+vol_id=1
+vol_type=static
+vol_name=rootfs
+
+[rootfs_data]
+mode=ubi
+vol_id=2
+vol_type=dynamic
+vol_name=rootfs_data
+vol_size=128KiB
+vol_flags=autoresize
+EOF
+ubinize -o ev300.ubi -p "$PEB" -m "$PAGE" -s "$PAGE" ubinize.cfg
+
+python3 - <<PY
+img = bytearray(b'\xff' * 0x2000000)          # 32 MiB image (model pads to 128 MiB)
+ub  = open('u-boot-hi3516ev300-nand.bin', 'rb').read(); img[0:len(ub)] = ub
+ubi = open('ev300.ubi', 'rb').read();          img[0x100000:0x100000+len(ubi)] = ubi
+open('$SCRIPT_DIR/ev300-nand.img', 'wb').write(img)
+print('wrote ev300-nand.img (%d bytes, ubi %d)' % (len(img), len(ubi)))
+PY
+echo "Done: $SCRIPT_DIR/ev300-nand.img — boot with: bash qemu-boot/run-ev300-nand.sh"

--- a/qemu-boot/run-ev300-nand.sh
+++ b/qemu-boot/run-ev300-nand.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Boot OpenIPC on emulated Hi3516EV300 ENTIRELY FROM a SPI-NAND image
+# (no -kernel / -initrd / -dtb).  The synthetic boot ROM runs U-Boot from
+# NAND; U-Boot reports the boot device as SPI-NAND (SYSSTAT strap), attaches
+# UBI, reads the kernel volume and bootm's it; the kernel attaches UBI and
+# mounts the squashfs rootfs via ubiblock — all from the emulated GD5F1GM7.
+#
+# Build the image first:
+#   bash qemu-boot/mk-ev300-nand.sh        # assembles ev300-nand.img
+#
+# The image is >16 MiB so the FMC auto-selects SPI-NAND mode.  nand-jedec
+# presents the universally-supported Winbond W25N01GV (the OpenIPC ev300
+# U-Boot SPI-NAND ID table predates GD5F1GM7); nand-oob-size matches it.
+#
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+QEMU="$REPO_ROOT/qemu-src/build/qemu-system-arm"
+
+FLASH="${FLASH:-$SCRIPT_DIR/ev300-nand.img}"
+if [ ! -f "$FLASH" ]; then
+    echo "Error: NAND image not found: $FLASH" >&2
+    echo "Build it first:  bash qemu-boot/mk-ev300-nand.sh" >&2
+    exit 1
+fi
+
+# Boot from a throwaway copy: U-Boot's saveenv / UBI writes back to NAND.
+IMG="$(mktemp /tmp/ev300-nand.XXXXXX.img)"
+cp -f "$FLASH" "$IMG"
+
+# sensor=none skips the SoC-default IMX335 attach so OpenIPC's load_hisilicon
+# doesn't insmod the vendor MPP blob (which hangs on QEMU before login).
+"$QEMU" -M hi3516ev300,sensor=none,flash-file="$IMG" \
+    -global hisi-fmc.nand-jedec=0xEFAA21 \
+    -global hisi-fmc.nand-oob-size=64 \
+    -nographic -serial mon:stdio -nic user,restrict=on \
+    -d unimp,guest_errors -D "$SCRIPT_DIR/qemu-ev300-nand.log" \
+    "$@"
+rc=$?
+rm -f "$IMG"
+exit $rc

--- a/qemu-boot/run-gk7205v510-nand.sh
+++ b/qemu-boot/run-gk7205v510-nand.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Boot OpenIPC on emulated Goke GK7205V510 ENTIRELY FROM a 128 MiB SPI-NAND
+# dump (no -kernel / -initrd / -dtb).  The synthetic boot ROM parses the
+# xm720/Goke-V500 "deadbeef" loader descriptor, copies U-Boot from NAND to
+# DDR and jumps to it; U-Boot reads its env + kernel from NAND, attaches UBI
+# and boots root=ubi0:ubifs / ubiblock — all from the emulated GD5F1GM7.
+#
+# The FMC controller auto-selects SPI-NAND mode because the image is > 16 MiB.
+#
+# Usage:
+#   bash qemu-boot/run-gk7205v510-nand.sh <nand-dump.bin> [extra qemu args...]
+#   FLASH=/path/to/nand.bin bash qemu-boot/run-gk7205v510-nand.sh
+#
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+QEMU="$REPO_ROOT/qemu-src/build/qemu-system-arm"
+
+# NAND dump: first positional arg, or $FLASH.
+FLASH="${1:-${FLASH:-}}"
+[ -n "$1" ] && shift
+
+if [ -z "$FLASH" ] || [ ! -f "$FLASH" ]; then
+    echo "Error: NAND dump not found: '${FLASH:-<unset>}'" >&2
+    echo "Usage: $0 <nand-dump.bin> [extra qemu args...]" >&2
+    exit 1
+fi
+
+# Boot from a throwaway copy: U-Boot's saveenv writes back to the env region,
+# so keep the source dump pristine and let each run start clean.
+IMG="$(mktemp /tmp/gk7205v510-nand.XXXXXX.img)"
+cp -f "$FLASH" "$IMG"
+
+# restrict=on makes busybox ntpd's NTP-pool DNS fail fast so init doesn't
+# stall (see openhisilicon#104); drop it if you need guest outbound traffic.
+"$QEMU" -M gk7205v510,flash-file="$IMG" \
+    -nographic -serial mon:stdio -nic user,restrict=on \
+    -d unimp,guest_errors -D "$SCRIPT_DIR/qemu-gk7205v510-nand.log" \
+    "$@"
+rc=$?
+rm -f "$IMG"
+exit $rc

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -48,6 +48,7 @@
 #include <libfdt.h>
 #include "hw/loader.h"
 #include <zlib.h>  /* crc32() for uImage header fixup */
+#include <glib/gstdio.h>  /* g_stat() for flash-image size sniffing */
 
 
 /* ── SoC configuration tables ──────────────────────────────────────── */
@@ -4160,6 +4161,7 @@ static void hisilicon_common_init(MachineState *machine,
     int num_pic = 0;
     int n;
     bool flash_boot = false;  /* true when booting from SPI NOR flash dump */
+    bool fmc_nand_boot = false; /* true when the FMC boot flash is SPI NAND */
     bool bios_boot = machine->firmware && machine->firmware[0];
                                 /* true when -bios loads a mask-ROM ELF */
 
@@ -4193,11 +4195,46 @@ static void hisilicon_common_init(MachineState *machine,
         HisiMachineState *hms = (HisiMachineState *)machine;
         if (hms->flash_file && hms->flash_file[0]) {
             qdev_prop_set_string(fmc, "flash-file", hms->flash_file);
+
+            /*
+             * Auto-select SPI-NAND mode by image size.  The hisi-fmc model
+             * backs SPI NOR up to 16 MiB; anything larger is a SPI-NAND dump
+             * (e.g. the 128 MiB GD5F1GM7 on Goke-V500 NAND boards).  Setting
+             * flash-type=1 before realize makes the FMC allocate the NAND
+             * array + OOB and report the GigaDevice ID, so U-Boot/Linux can
+             * attach UBI and flash-boot straight from the dump.  Only the
+             * hisi-fmc controller has a flash-type property (hisi-sfc350 is
+             * NOR-only), so gate on the device type.  See widgetii#115.
+             */
+            if (!c->fmc_type || !strcmp(fmc_type, "hisi-fmc")) {
+                GStatBuf st;
+                if (g_stat(hms->flash_file, &st) == 0 &&
+                    st.st_size > 16 * 1024 * 1024) {
+                    qdev_prop_set_uint32(fmc, "flash-type", 1 /* SPI NAND */);
+                    fmc_nand_boot = true;
+                }
+            }
         }
 
         sysbus_realize_and_unref(fmcbus, &error_fatal);
         sysbus_mmio_map(fmcbus, 0, c->fmc_ctrl_base);
         sysbus_mmio_map(fmcbus, 1, c->fmc_mem_base);
+
+        /*
+         * Dual NOR+NAND boards (e.g. OpenIPC hi3516ev300 NAND: u-boot+env in
+         * SPI-NOR, rootfs in SPI-NAND) pass `-global hisi-fmc.nand-file=...`
+         * (applied during realize, so this is queried afterwards).  Their boot
+         * flash device type is SPI-NAND, so report that in SYSSTAT too — after
+         * the NOR scan U-Boot's dev_type_switch(DEFAULT) returns the FMC to
+         * NAND mode, letting hifmc100_host_init succeed.
+         */
+        if (!c->fmc_type || !strcmp(fmc_type, "hisi-fmc")) {
+            char *nf = object_property_get_str(OBJECT(fmc), "nand-file", NULL);
+            if (nf && nf[0]) {
+                fmc_nand_boot = true;
+            }
+            g_free(nf);
+        }
 
         /* Check if flash-file was set (via either the machine-level
          * property or a device-level -global). */
@@ -4361,9 +4398,28 @@ static void hisilicon_common_init(MachineState *machine,
          * load attempt and soft-resets in a loop.  Must run AFTER
          * sysctl mmio map so the store lands in the device's regbank.
          */
+        /*
+         * SYSSTAT (0x8c) boot-strap bits, OR-ed together:
+         *   bit5 (0x20) — BOOT_MODE fastboot pin, for -bios mask-ROM runs.
+         *   SPI device type = SPI NAND.  U-Boot's get_boot_media() reads
+         *     GET_SPI_DEVICE_TYPE(SYSSTAT); if it isn't NAND, spi_flash_probe()
+         *     drives the SPI-NOR path (env-in-NOR, NOR scan) instead of NAND,
+         *     so NAND-boot OpenIPC images loop on the missing NOR env and never
+         *     attach UBI.  The strap BIT IS SOC-SPECIFIC: bit10 (0x400) on
+         *     ev200/ev300/dv200/3518ev300, bit6 (0x40) on cv500/dv300.  Set
+         *     both so whichever bit the running SoC samples reads NAND; the
+         *     unused one is harmless.  See widgetii#115.
+         */
+        uint32_t sysstat = 0;
         if (bios_boot) {
+            sysstat |= 0x20;
+        }
+        if (fmc_nand_boot) {
+            sysstat |= 0x40 | 0x400;
+        }
+        if (sysstat) {
             address_space_stl(&address_space_memory,
-                              c->sysctl_base + 0x8c, 0x20,
+                              c->sysctl_base + 0x8c, sysstat,
                               MEMTXATTRS_UNSPECIFIED, NULL);
         }
     }

--- a/qemu/hw/misc/hisi-fmc.c
+++ b/qemu/hw/misc/hisi-fmc.c
@@ -1,14 +1,14 @@
 /*
  * HiSilicon HiFMC V100 Flash Memory Controller emulation.
  *
- * Emulates the FMC found on Hi3516CV300 / Hi3516EV300 SoCs, with a
- * RAM-backed SPI NOR flash (Winbond W25Q64, 8 MiB) or SPI NAND flash
- * (Winbond W25N01GV, 128 MiB).  Supports both register-mode (small
- * reads via memory window) and DMA-mode transfers.
+ * Emulates the FMC found on Hi3516CV300 / Hi3516EV300 / Goke-V500 SoCs,
+ * with a RAM-backed SPI NOR flash (Winbond W25Q64, 8 MiB) or SPI NAND
+ * flash (GigaDevice GD5F1GM7, 128 MiB).  Supports both register-mode
+ * (small reads via memory window) and DMA-mode transfers.
  *
  * The flash-type property selects which flash is physically present:
  *   0 = SPI NOR  (default, W25Q64 8 MiB)
- *   1 = SPI NAND (W25N01GV 128 MiB, 2K+64 pages)
+ *   1 = SPI NAND (GD5F1GM7 128 MiB, 2K page + 128B OOB)
  *
  * Copyright (c) 2026 OpenIPC.
  * Written by Dmitry Ilyin
@@ -63,6 +63,10 @@
 #define FMC_OP_ADDR_EN          BIT(6)
 #define FMC_OP_CMD1_EN          BIT(7)
 
+/* FMC_OP_CFG bits */
+#define FMC_OP_CFG_FM_CS_SHIFT  11
+#define FMC_OP_CFG_FM_CS_MASK   (0x3 << FMC_OP_CFG_FM_CS_SHIFT)
+
 /* FMC_OP_CTRL bits */
 #define FMC_OP_CTRL_DMA_OP_READY BIT(0)
 #define FMC_OP_CTRL_RW_OP        BIT(1)
@@ -114,13 +118,16 @@
 #define NOR_SECTOR_SIZE     (64 * 1024)
 #define NOR_PAGE_SIZE       256
 
-/* NAND flash identity: Winbond W25N01GV (128 MiB) */
-#define NAND_JEDEC_0        0xEF    /* Winbond */
-#define NAND_JEDEC_1        0xAA
-#define NAND_JEDEC_2        0x21
+/* NAND flash identity: GigaDevice GD5F1GM7UEYIG (128 MiB, on-die 24b/1K ECC)
+ * READ_ID (0x9F) returns mfr 0xC8 (GigaDevice) + device 0x91; the hifmc100
+ * driver compares id_len = 2 bytes.  Override with the `flash-jedec`
+ * property (e.g. 0xC8AA21 to emulate a Winbond W25N01GV instead). */
+#define NAND_JEDEC_0        0xC8    /* GigaDevice */
+#define NAND_JEDEC_1        0x91    /* GD5F1GM7 device ID */
+#define NAND_JEDEC_2        0x00
 #define NAND_FLASH_SIZE     (128 * 1024 * 1024)
 #define NAND_PAGE_SIZE      2048
-#define NAND_OOB_SIZE       64
+#define NAND_OOB_SIZE       128     /* GD5F1GM7 spare area */
 #define NAND_PAGES_PER_BLOCK 64
 #define NAND_BLOCK_SIZE     (NAND_PAGE_SIZE * NAND_PAGES_PER_BLOCK)
 #define NAND_BLOCK_COUNT    1024
@@ -142,9 +149,25 @@ struct HisiFmcState {
     MemoryRegion mem_iomem;
 
     /* Configuration properties */
-    uint32_t flash_type;          /* 0=NOR, 1=NAND */
+    uint32_t flash_type;          /* 0=NOR, 1=NAND — type of the flash-file image */
     char    *flash_file;          /* optional: path to flash dump to load */
-    uint32_t flash_jedec;         /* optional: JEDEC ID override (e.g. 0xEF4018) */
+    char    *nand_file;           /* optional: 2nd image for dual NOR+NAND boards
+                                   * (flash-file is NOR u-boot+env, nand-file is
+                                   * the SPI-NAND rootfs).  See widgetii#115. */
+    uint32_t flash_jedec;         /* optional: NOR JEDEC ID override */
+    uint32_t nand_jedec;          /* optional: NAND READ_ID override (e.g. 0xEFAA21
+                                   * to present W25N01GV instead of GD5F1GM7) */
+    uint32_t nand_oob_size;       /* spare bytes/page (128 GD5F1GM7, 64 W25N01GV) */
+
+    /* Which chips are physically present (dual-flash capable) + their
+     * chip-selects.  The guest selects a CS via FMC_OP_CFG bits[12:11]
+     * (OP_CFG_FM_CS); a chip must only answer on its own CS, otherwise the
+     * NOR scan phantom-detects the NOR on every CS and claims them all
+     * (shared hifmc_cs_user[]), starving the NAND of a free CS. */
+    bool     has_nor;
+    bool     has_nand;
+    uint32_t nor_cs;              /* NOR chip-select (boot flash = 0) */
+    uint32_t nand_cs;             /* NAND chip-select (0 alone, 1 if NOR present) */
 
     /* Control registers */
     uint32_t cfg;
@@ -171,11 +194,13 @@ struct HisiFmcState {
     uint8_t  sr;
     uint8_t  sr2;                 /* Status Register-2 (QE bit at bit 1) */
     uint8_t  sr3;                 /* Status Register-3 */
-    uint8_t *flash;
+    uint8_t *flash;               /* SPI NOR data (XIP-able boot/env) */
     uint32_t flash_size;
 
     /* NAND-specific state */
-    uint8_t *nand_oob;            /* OOB area: NAND_OOB_SIZE per page */
+    uint8_t *nand_data;           /* SPI NAND page data */
+    uint32_t nand_size;           /* NAND data area size */
+    uint8_t *nand_oob;            /* OOB area: nand_oob_size per page */
     uint8_t  nand_feature_protect; /* feature reg 0xA0 */
     uint8_t  nand_feature_config;  /* feature reg 0xB0 */
 
@@ -218,30 +243,46 @@ static inline int hisi_fmc_current_flash_sel(HisiFmcState *s)
 }
 
 /*
- * Write-back modified flash data to the backing file.
- * Called after every erase / page-program / DMA-write so that the
- * on-disk image stays in sync with the in-memory flash array — matching
- * real NOR flash persistence behavior.
+ * Write-back modified flash data to a backing file so the on-disk image
+ * stays in sync with the in-memory array (matches real flash persistence).
  */
-static void hisi_fmc_flush_to_file(HisiFmcState *s, uint32_t offset,
-                                    uint32_t len)
+static void hisi_fmc_flush(const char *file, const uint8_t *data,
+                           uint32_t total, uint32_t offset, uint32_t len)
 {
-    if (!s->flash_file || !s->flash_file[0]) {
+    if (!file || !file[0]) {
         return;
     }
-    if (offset + len > s->flash_size) {
-        len = s->flash_size - offset;
+    if (offset >= total) {
+        return;
     }
-    FILE *f = fopen(s->flash_file, "r+b");
+    if (offset + len > total) {
+        len = total - offset;
+    }
+    FILE *f = fopen(file, "r+b");
     if (!f) {
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "hisi-fmc: cannot open '%s' for write-back\n",
-                      s->flash_file);
+                      "hisi-fmc: cannot open '%s' for write-back\n", file);
         return;
     }
     fseek(f, offset, SEEK_SET);
-    fwrite(&s->flash[offset], 1, len, f);
+    fwrite(&data[offset], 1, len, f);
     fclose(f);
+}
+
+/* NOR write-back: NOR always lives in flash-file. */
+static void hisi_fmc_flush_to_file(HisiFmcState *s, uint32_t offset,
+                                    uint32_t len)
+{
+    hisi_fmc_flush(s->flash_file, s->flash, s->flash_size, offset, len);
+}
+
+/* NAND write-back: backing file is flash-file when the NAND is the only
+ * chip (flash_type=NAND), or the separate nand-file on dual NOR+NAND boards. */
+static void hisi_fmc_flush_nand(HisiFmcState *s, uint32_t offset, uint32_t len)
+{
+    const char *file = (s->flash_type == FLASH_TYPE_SPI_NAND)
+                       ? s->flash_file : s->nand_file;
+    hisi_fmc_flush(file, s->nand_data, s->nand_size, offset, len);
 }
 
 /*
@@ -510,9 +551,17 @@ static void hisi_fmc_exec_nand_reg_op(HisiFmcState *s)
 
     switch (spi_cmd) {
     case SPI_CMD_READ_ID:
-        s->iobuf[0] = NAND_JEDEC_0;
-        s->iobuf[1] = NAND_JEDEC_1;
-        s->iobuf[2] = NAND_JEDEC_2;
+        if (s->nand_jedec) {
+            /* User-specified NAND ID, e.g. 0xEFAA21 for Winbond W25N01GV */
+            s->iobuf[0] = (s->nand_jedec >> 16) & 0xFF;
+            s->iobuf[1] = (s->nand_jedec >> 8) & 0xFF;
+            s->iobuf[2] = s->nand_jedec & 0xFF;
+        } else {
+            /* Default: GigaDevice GD5F1GM7 (0xC8 0x91) */
+            s->iobuf[0] = NAND_JEDEC_0;
+            s->iobuf[1] = NAND_JEDEC_1;
+            s->iobuf[2] = NAND_JEDEC_2;
+        }
         if (len > 3) {
             memset(&s->iobuf[3], 0, len - 3);
         }
@@ -566,13 +615,16 @@ static void hisi_fmc_exec_nand_reg_op(HisiFmcState *s)
     case SPI_CMD_SECTOR_ERASE: { /* 0xD8 = Block Erase for NAND */
         if (s->sr & SPI_SR_WEL) {
             uint32_t block, page, column;
+            uint32_t nblocks = s->nand_size / NAND_BLOCK_SIZE;
             hisi_fmc_nand_decode_addr(s, &block, &page, &column);
-            if (block < NAND_BLOCK_COUNT) {
+            if (block < nblocks) {
                 uint32_t flash_off = block * NAND_BLOCK_SIZE;
-                uint32_t oob_off = block * NAND_PAGES_PER_BLOCK * NAND_OOB_SIZE;
-                memset(&s->flash[flash_off], 0xFF, NAND_BLOCK_SIZE);
+                uint32_t oob_off = block * NAND_PAGES_PER_BLOCK *
+                                   s->nand_oob_size;
+                memset(&s->nand_data[flash_off], 0xFF, NAND_BLOCK_SIZE);
                 memset(&s->nand_oob[oob_off], 0xFF,
-                       NAND_PAGES_PER_BLOCK * NAND_OOB_SIZE);
+                       NAND_PAGES_PER_BLOCK * s->nand_oob_size);
+                hisi_fmc_flush_nand(s, flash_off, NAND_BLOCK_SIZE);
             }
             s->sr &= ~SPI_SR_WEL;
         }
@@ -588,23 +640,32 @@ static void hisi_fmc_exec_nand_reg_op(HisiFmcState *s)
 
 /* ── Register-mode dispatch ──────────────────────────────────────────── */
 
-/* Returns true if the command wrote results to iobuf */
+/* Returns true if the command wrote results to iobuf.
+ *
+ * Routing is by the FMC's current flash-select (FMC_CFG) AND which chips are
+ * physically present.  On dual NOR+NAND boards both are present and the guest
+ * driver flips FMC_CFG before NOR vs NAND ops (hifmc_dev_type_switch); when a
+ * chip is absent the bus floats, so we return 0x00 so its probe fails cleanly. */
 static bool hisi_fmc_exec_reg_op(HisiFmcState *s)
 {
     bool wrote_iobuf = true;
-    if (s->flash_type == FLASH_TYPE_SPI_NAND &&
-        hisi_fmc_current_flash_sel(s) == FLASH_TYPE_SPI_NAND) {
+    int sel = hisi_fmc_current_flash_sel(s);
+    uint32_t cs = (s->op_cfg & FMC_OP_CFG_FM_CS_MASK) >> FMC_OP_CFG_FM_CS_SHIFT;
+
+    if (sel == FLASH_TYPE_SPI_NAND && s->has_nand && cs == s->nand_cs) {
         hisi_fmc_exec_nand_reg_op(s);
-    } else if (s->flash_type == FLASH_TYPE_SPI_NOR &&
-               hisi_fmc_current_flash_sel(s) == FLASH_TYPE_SPI_NOR) {
+    } else if (sel == FLASH_TYPE_SPI_NOR && s->has_nor && cs == s->nor_cs) {
         wrote_iobuf = hisi_fmc_exec_nor_reg_op(s);
     } else {
-        /* Wrong flash selected — no chip responds, return 0x00 ID */
+        /* Selected chip not present — the SPI bus floats high, so a real
+         * controller reads 0xFF (not 0x00).  U-Boot's NOR probe treats an
+         * all-0x00 ID as a present-but-unknown chip and retries forever; 0xFF
+         * is "no device" and it gives up cleanly. */
         uint32_t len = s->data_num & 0x3FFF;
         if (len > IOBUF_SIZE) {
             len = IOBUF_SIZE;
         }
-        memset(s->iobuf, 0x00, len);
+        memset(s->iobuf, 0xFF, len);
     }
     s->fmc_int |= FMC_INT_OP_DONE;
     return wrote_iobuf;
@@ -699,7 +760,8 @@ static void hisi_fmc_exec_dma_nand(HisiFmcState *s)
 
     hisi_fmc_nand_decode_addr(s, &block, &page, &column);
 
-    if (block >= NAND_BLOCK_COUNT || page >= NAND_PAGES_PER_BLOCK) {
+    uint32_t nblocks = s->nand_size / NAND_BLOCK_SIZE;
+    if (block >= nblocks || page >= NAND_PAGES_PER_BLOCK) {
         qemu_log_mask(LOG_GUEST_ERROR,
                       "hisi-fmc: NAND DMA out of range block=%u page=%u\n",
                       block, page);
@@ -708,49 +770,52 @@ static void hisi_fmc_exec_dma_nand(HisiFmcState *s)
 
     uint32_t page_idx = block * NAND_PAGES_PER_BLOCK + page;
     uint32_t flash_off = page_idx * NAND_PAGE_SIZE;
-    uint32_t oob_off = page_idx * NAND_OOB_SIZE;
-    uint32_t dma_len = s->dma_len;
+    uint32_t oob_off = page_idx * s->nand_oob_size;
 
-    if (dma_len > NAND_PAGE_SIZE) {
-        dma_len = NAND_PAGE_SIZE;
-    }
-
+    /*
+     * The hifmc100 driver only programs FMC_DMA_LEN for OOB-only / ecc0
+     * transfers (drivers/mtd/nand/hifmc100/hifmc100.c).  A normal page DMA
+     * always moves a full page + spare, selected by FMC_OP_CTRL's RD_OP_SEL
+     * field (READ_ALL_PAGE), NOT by FMC_DMA_LEN — which keeps a stale value
+     * (e.g. the last OOB size) from a prior op.  Sizing the data copy by
+     * s->dma_len therefore truncated every page read (corrupting the U-Boot
+     * env CRC and all UBI reads).  Always transfer a whole page + OOB.
+     */
     if (!is_write) {
-        /* DMA read: flash → guest memory (page data) */
-        if (dma_len > 0) {
-            dma_memory_write(&address_space_memory, dma_addr,
-                             &s->flash[flash_off], dma_len,
-                             MEMTXATTRS_UNSPECIFIED);
-        }
-        /* OOB → guest memory */
+        /* DMA read: flash → guest memory (full page data + spare) */
+        dma_memory_write(&address_space_memory, dma_addr,
+                         &s->nand_data[flash_off], NAND_PAGE_SIZE,
+                         MEMTXATTRS_UNSPECIFIED);
         if (s->dma_saddr_oob) {
             dma_memory_write(&address_space_memory, dma_oob_addr,
-                             &s->nand_oob[oob_off], NAND_OOB_SIZE,
+                             &s->nand_oob[oob_off], s->nand_oob_size,
                              MEMTXATTRS_UNSPECIFIED);
         }
     } else {
-        /* DMA write: guest memory → flash (page program) */
+        /* DMA write: guest memory → flash (full page program) */
         if (s->sr & SPI_SR_WEL) {
-            if (dma_len > 0) {
-                uint8_t *buf = g_malloc(dma_len);
-                dma_memory_read(&address_space_memory, dma_addr,
-                                buf, dma_len, MEMTXATTRS_UNSPECIFIED);
-                /* NAND program: can only clear bits */
-                for (uint32_t i = 0; i < dma_len; i++) {
-                    s->flash[flash_off + i] &= buf[i];
-                }
-                g_free(buf);
+            uint8_t *buf = g_malloc(NAND_PAGE_SIZE);
+            dma_memory_read(&address_space_memory, dma_addr,
+                            buf, NAND_PAGE_SIZE, MEMTXATTRS_UNSPECIFIED);
+            /* NAND program: can only clear bits */
+            for (uint32_t i = 0; i < NAND_PAGE_SIZE; i++) {
+                s->nand_data[flash_off + i] &= buf[i];
             }
+            g_free(buf);
             /* OOB write */
             if (s->dma_saddr_oob) {
-                uint8_t oob_buf[NAND_OOB_SIZE];
+                uint8_t *oob_buf = g_malloc(s->nand_oob_size);
                 dma_memory_read(&address_space_memory, dma_oob_addr,
-                                oob_buf, NAND_OOB_SIZE,
+                                oob_buf, s->nand_oob_size,
                                 MEMTXATTRS_UNSPECIFIED);
-                for (int i = 0; i < NAND_OOB_SIZE; i++) {
+                for (uint32_t i = 0; i < s->nand_oob_size; i++) {
                     s->nand_oob[oob_off + i] &= oob_buf[i];
                 }
+                g_free(oob_buf);
             }
+            /* Persist the page so saveenv / UBI writes survive (matches the
+             * NOR write-back behaviour; OOB lives only in RAM). */
+            hisi_fmc_flush_nand(s, flash_off, NAND_PAGE_SIZE);
             s->sr &= ~SPI_SR_WEL;
         }
     }
@@ -758,14 +823,14 @@ static void hisi_fmc_exec_dma_nand(HisiFmcState *s)
 
 static void hisi_fmc_exec_dma_op(HisiFmcState *s)
 {
-    if (s->flash_type == FLASH_TYPE_SPI_NAND &&
-        hisi_fmc_current_flash_sel(s) == FLASH_TYPE_SPI_NAND) {
+    int sel = hisi_fmc_current_flash_sel(s);
+
+    if (sel == FLASH_TYPE_SPI_NAND && s->has_nand) {
         hisi_fmc_exec_dma_nand(s);
-    } else if (s->flash_type == FLASH_TYPE_SPI_NOR &&
-               hisi_fmc_current_flash_sel(s) == FLASH_TYPE_SPI_NOR) {
+    } else if (sel == FLASH_TYPE_SPI_NOR && s->has_nor) {
         hisi_fmc_exec_dma_nor(s);
     }
-    /* else: wrong flash type selected, no-op */
+    /* else: selected chip not present, no-op */
 
     s->fmc_int |= FMC_INT_OP_DONE;
 }
@@ -898,16 +963,20 @@ static uint64_t hisi_fmc_mem_read(void *opaque, hwaddr offset, unsigned size)
         return s->iobuf[offset];
     }
 
-    /* Direct flash read — memory-mapped XIP access used by boot ROM and
-     * U-Boot to read flash contents from the FMC memory window. */
-    if (s->flash && offset < s->flash_size) {
+    /* Direct flash read — memory-mapped XIP access used by the boot ROM and
+     * U-Boot to read flash from the FMC memory window.  The boot/XIP chip is
+     * NOR when present (dual NOR+NAND or NOR-only boards); on NAND-only boards
+     * the boot ROM XIPs the NAND data area linearly (data-only dump). */
+    const uint8_t *xip = s->has_nor ? s->flash : s->nand_data;
+    uint32_t xip_size = s->has_nor ? s->flash_size : s->nand_size;
+    if (xip && offset < xip_size) {
         if (size == 4 && (offset & 3) == 0) {
-            return ldl_le_p(&s->flash[offset]);
+            return ldl_le_p(&xip[offset]);
         }
         if (size == 2 && (offset & 1) == 0) {
-            return lduw_le_p(&s->flash[offset]);
+            return lduw_le_p(&xip[offset]);
         }
-        return s->flash[offset];
+        return xip[offset];
     }
 
     return 0;
@@ -937,80 +1006,102 @@ static const MemoryRegionOps hisi_fmc_mem_ops = {
 
 /* ── Device lifecycle ────────────────────────────────────────────────── */
 
+/* Load a backing file into a buffer of at least min_size, growing to fit a
+ * larger image.  Returns the allocated buffer (0xFF-filled past the file) and
+ * its size via *out_size, or sets errp and returns NULL. */
+static uint8_t *hisi_fmc_load_image(const char *file, uint32_t min_size,
+                                    uint32_t *out_size, Error **errp)
+{
+    struct stat st;
+    uint32_t size = min_size;
+    if (file && file[0]) {
+        if (stat(file, &st) != 0) {
+            error_setg(errp, "hisi-fmc: cannot stat flash file '%s'", file);
+            return NULL;
+        }
+        if ((uint32_t)st.st_size > size) {
+            size = (uint32_t)st.st_size;
+        }
+    }
+    uint8_t *buf = g_malloc(size);
+    memset(buf, 0xFF, size);
+    if (file && file[0]) {
+        FILE *f = fopen(file, "rb");
+        if (!f) {
+            error_setg(errp, "hisi-fmc: cannot open flash file '%s'", file);
+            g_free(buf);
+            return NULL;
+        }
+        size_t nread = fread(buf, 1, st.st_size, f);
+        fclose(f);
+        if (nread != (size_t)st.st_size) {
+            error_setg(errp, "hisi-fmc: short read from '%s'", file);
+            g_free(buf);
+            return NULL;
+        }
+        qemu_log("hisi-fmc: loaded %u bytes from '%s'\n",
+                 (uint32_t)st.st_size, file);
+    }
+    *out_size = size;
+    return buf;
+}
+
 static void hisi_fmc_realize(DeviceState *dev, Error **errp)
 {
     HisiFmcState *s = HISI_FMC(dev);
 
-    if (s->flash_type == FLASH_TYPE_SPI_NAND) {
-        s->flash_size = NAND_FLASH_SIZE;
-        s->flash = g_malloc(NAND_FLASH_SIZE);
-        memset(s->flash, 0xFF, NAND_FLASH_SIZE);
-        s->nand_oob = g_malloc(NAND_TOTAL_PAGES * NAND_OOB_SIZE);
-        memset(s->nand_oob, 0xFF, NAND_TOTAL_PAGES * NAND_OOB_SIZE);
-        /* Set initial FMC_CFG to SPI_NAND */
-        s->cfg = (s->cfg & ~FMC_CFG_FLASH_SEL_MASK) |
-                 (FLASH_TYPE_SPI_NAND << FMC_CFG_FLASH_SEL_SHIFT);
-    } else {
-        s->flash_size = NOR_FLASH_SIZE;
-        s->flash = g_malloc(NOR_FLASH_SIZE);
-        memset(s->flash, 0xFF, NOR_FLASH_SIZE);
-        /* FMC_CFG defaults to 0 (SPI_NOR) */
-        /* Many NOR flash chips ship with QE (Quad Enable) bit set in SR2.
-         * XM firmware expects to read SR2 and find QE=1, then disables it.
-         * Default 0x02 matches common factory programming. */
-        s->sr2 = 0x02;
+    /*
+     * Chip topology:
+     *   flash_type == NAND  → flash-file is the SPI-NAND image (NAND-only).
+     *   flash_type == NOR   → flash-file is the SPI-NOR image (NOR present).
+     *   nand-file given     → an additional SPI-NAND chip (dual NOR+NAND
+     *                         board: NOR holds u-boot+env, NAND holds rootfs).
+     */
+    const char *nor_file  = (s->flash_type == FLASH_TYPE_SPI_NOR)
+                            ? s->flash_file : NULL;
+    const char *nand_file = (s->flash_type == FLASH_TYPE_SPI_NAND)
+                            ? s->flash_file : s->nand_file;
 
-        /* WPS block lock array — all blocks start unlocked.
-         * On real hardware, blocks default to locked when WPS is first
-         * enabled, but the flash image we load represents a previously-
-         * configured device where firmware has already set the lock state.
-         * Starting unlocked lets the firmware's Global Lock (0x7E) + selective
-         * Unlock (0x39) sequence establish the correct protection map. */
-        s->num_blocks = NOR_FLASH_SIZE / NOR_SECTOR_SIZE;
+    /* ── SPI NOR ── */
+    if (s->flash_type == FLASH_TYPE_SPI_NOR) {
+        s->has_nor = true;
+        /* Many NOR chips ship with QE set in SR2; XM firmware expects QE=1. */
+        s->sr2 = 0x02;
+        s->flash = hisi_fmc_load_image(nor_file, NOR_FLASH_SIZE,
+                                       &s->flash_size, errp);
+        if (!s->flash) {
+            return;
+        }
+        /* WPS block-lock arrays — all blocks start unlocked. */
+        s->num_blocks = s->flash_size / NOR_SECTOR_SIZE;
         s->block_locked = g_malloc0(s->num_blocks);
         s->block_ever_unlocked = g_malloc0(s->num_blocks);
     }
 
-    /* Load flash contents from file if specified */
-    if (s->flash_file && s->flash_file[0]) {
-        struct stat st;
-        if (stat(s->flash_file, &st) != 0) {
-            error_setg(errp, "hisi-fmc: cannot stat flash file '%s'",
-                       s->flash_file);
+    /* ── SPI NAND ── */
+    if (nand_file || s->flash_type == FLASH_TYPE_SPI_NAND) {
+        s->has_nand = true;
+        /* NAND sits on its own chip-select.  Alone it is CS0; alongside a NOR
+         * boot flash (CS0) it is CS1, matching dual NOR+NAND board wiring. */
+        s->nand_cs = s->has_nor ? 1 : 0;
+        s->nand_data = hisi_fmc_load_image(nand_file, NAND_FLASH_SIZE,
+                                           &s->nand_size, errp);
+        if (!s->nand_data) {
             return;
         }
-        uint32_t file_size = (uint32_t)st.st_size;
-        if (file_size > s->flash_size) {
-            /* Re-allocate to fit the larger dump */
-            g_free(s->flash);
-            s->flash_size = file_size;
-            s->flash = g_malloc(file_size);
-            memset(s->flash, 0xFF, file_size);
+        uint32_t npages = s->nand_size / NAND_PAGE_SIZE;
+        s->nand_oob = g_malloc(npages * s->nand_oob_size);
+        memset(s->nand_oob, 0xFF, npages * s->nand_oob_size);
+        /* On NAND-only boards the boot ROM XIPs NAND and the guest starts in
+         * NAND mode; on dual boards FMC_CFG stays NOR for the NOR-resident
+         * u-boot+env and the driver flips it before NAND ops. */
+        if (!s->has_nor) {
+            s->cfg = (s->cfg & ~FMC_CFG_FLASH_SEL_MASK) |
+                     (FLASH_TYPE_SPI_NAND << FMC_CFG_FLASH_SEL_SHIFT);
+        }
+    }
 
-            /* Resize block lock arrays to match */
-            g_free(s->block_locked);
-            g_free(s->block_ever_unlocked);
-            s->num_blocks = file_size / NOR_SECTOR_SIZE;
-            s->block_locked = g_malloc0(s->num_blocks);
-            s->block_ever_unlocked = g_malloc0(s->num_blocks);
-        }
-        FILE *f = fopen(s->flash_file, "rb");
-        if (!f) {
-            error_setg(errp, "hisi-fmc: cannot open flash file '%s'",
-                       s->flash_file);
-            return;
-        }
-        size_t nread = fread(s->flash, 1, file_size, f);
-        fclose(f);
-        if (nread != file_size) {
-            error_setg(errp, "hisi-fmc: short read from '%s' "
-                       "(got %zu, expected %u)", s->flash_file,
-                       nread, file_size);
-            return;
-        }
-        qemu_log("hisi-fmc: loaded %u bytes from '%s'\n",
-                 file_size, s->flash_file);
-
+    if (s->has_nor) {
         /* Scan for SquashFS partitions and pre-mark non-SquashFS blocks as
          * ever_unlocked.  This protects SquashFS data from errant erases
          * while allowing the firmware to freely erase/write other blocks
@@ -1102,6 +1193,7 @@ static void hisi_fmc_finalize(Object *obj)
 {
     HisiFmcState *s = HISI_FMC(obj);
     g_free(s->flash);
+    g_free(s->nand_data);
     g_free(s->nand_oob);
     g_free(s->block_locked);
     g_free(s->block_ever_unlocked);
@@ -1111,7 +1203,16 @@ static const Property hisi_fmc_properties[] = {
     DEFINE_PROP_UINT32("flash-type", HisiFmcState, flash_type,
                        FLASH_TYPE_SPI_NOR),
     DEFINE_PROP_STRING("flash-file", HisiFmcState, flash_file),
+    /* Second image for dual NOR+NAND boards: flash-file is the SPI-NOR
+     * (u-boot + env), nand-file is the SPI-NAND (rootfs UBI). */
+    DEFINE_PROP_STRING("nand-file", HisiFmcState, nand_file),
     DEFINE_PROP_UINT32("flash-jedec", HisiFmcState, flash_jedec, 0),
+    /* NAND READ_ID override (default GigaDevice GD5F1GM7 0xC8 0x91); set
+     * 0xEFAA21 to present Winbond W25N01GV for firmware whose SPI-NAND ID
+     * table lacks GD5F1GM7. */
+    DEFINE_PROP_UINT32("nand-jedec", HisiFmcState, nand_jedec, 0),
+    /* NAND spare bytes per page: 128 (GD5F1GM7), 64 (W25N01GV). */
+    DEFINE_PROP_UINT32("nand-oob-size", HisiFmcState, nand_oob_size, 128),
     /* Start the chip in the as-shipped factory-locked state for SPI NOR.
      * When on: SR3.WPS = 1, every block individually locked, no block
      * ever-unlocked.  Lets CI exercise the recovery-unlock path


### PR DESCRIPTION
## Summary

Closes #115 — the HiSilicon/Goke machines modelled **SPI NOR only**, so the NAND/UBI firmware OpenIPC ships for several SoCs (e.g. gk7205v5xx, hi3516ev300 NAND) could not be attached or booted. This adds a working **SPI-NAND** path to the HiFMC controller and boots such firmware end-to-end from a flash image — boot ROM → U-Boot → UBI → kernel → UBIFS/ubiblock rootfs, the same sequence as silicon.

## What changed

**`qemu/hw/misc/hisi-fmc.c`**
- Model a SPI-NAND chip (GigaDevice **GD5F1GM7**: 2 KiB page, 128 KiB block, 128 MiB) **alongside** NOR.
- **Page-read fix:** the data DMA was sized by `FMC_DMA_LEN`, but the hifmc100 driver only programs that for OOB transfers — a full page is selected by `FMC_OP_CTRL` `RD_OP_SEL`. Every page read was truncated, corrupting the U-Boot env CRC and all UBI reads. Now always transfers a whole page + OOB; adds NAND write-back for page-program and block-erase.
- **Dual NOR+NAND**: back both chips simultaneously (NOR boot/env + NAND rootfs), routed by `FMC_CFG` flash-select and chip presence.
- **Chip-select aware** (`FMC_OP_CFG` `FM_CS`): a chip answers only on its own CS, otherwise the NOR scan phantom-detects NOR on every CS and claims them all (shared `hifmc_cs_user[]`), starving NAND.
- New props: `nand-file`, `nand-jedec`, `nand-oob-size`.

**`qemu/hw/arm/hisilicon.c`**
- Auto-select SPI-NAND when the flash image is >16 MiB.
- Report the NAND boot device in **SYSSTAT** so U-Boot's `get_boot_media()` takes the NAND path. The strap bit is **SoC-specific** (bit 10 on ev200/ev300/dv200/3518ev300, bit 6 on cv500/dv300) — set both.

**`qemu-boot/`** — `mk-ev300-nand.sh` assembles a bootable image from the OpenIPC hi3516ev300 NAND release; `run-ev300-nand.sh` and `run-gk7205v510-nand.sh` boot it / a real GD5F1GM7 camera dump.

**CI** — `boot-hi3516ev300-nand` job assembles the OpenIPC NAND image and gates on the full storage chain (boot ROM → U-Boot UBI → kernel UBI → ubiblock → squashfs root mounted).

## Verification

- **hi3516ev300 OpenIPC NAND**: boots from emulated SPI-NAND, U-Boot and kernel attach UBI, `ubiblock0_1` created, squashfs root mounted — gated in CI.
- **gk7205v510**: boots a real 128 MiB GD5F1GM7 camera dump to userspace.
- **NOR regressions unaffected**: cv610 NOR flash-boot still mounts its squashfs root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)