### PR TITLE
ci: harden U-Boot ping test against flaky first-ping ARP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -716,14 +716,19 @@ jobs:
           echo "setenv gatewayip 10.0.10.1" >&3
           echo "setenv netmask 255.255.255.0" >&3
           sleep 1
-          echo "ping 10.0.10.1" >&3
-
-          # Wait for ping result (up to 30s)
-          for i in $(seq 1 30); do
-            if grep -qE "alive|ARP Retry" /tmp/uboot-ping.txt 2>/dev/null; then
-              break
-            fi
-            sleep 1
+          # U-Boot's first ping right after PHY link-up frequently loses its
+          # ARP (autoneg/host not ready) and its small fixed ARP-retry budget
+          # is exhausted before the host replies.  Re-issue the ping until we
+          # see a result, so a single dropped ARP doesn't fail the whole test.
+          # (up to ~30s, mirroring the old single-send + 30s poll budget)
+          for i in $(seq 1 10); do
+            echo "ping 10.0.10.1" >&3
+            for j in $(seq 1 3); do
+              if grep -q "is alive" /tmp/uboot-ping.txt 2>/dev/null; then
+                break 2
+              fi
+              sleep 1
+            done
           done
 
           exec 3>&-


### PR DESCRIPTION
## Problem

The matrix `Boot ${{ matrix.name }}` job's **U-Boot ping test** step intermittently fails. It sent a single `ping 10.0.10.1` once, immediately after interrupting autoboot, then polled up to 30s for a result.

U-Boot's *first* ping right after the PHY link comes up (`eth0 : phy status change : LINK=UP`) frequently loses its ARP — autoneg/host aren't ready yet — and U-Boot's small fixed ARP-retry budget is exhausted before the host replies. A single dropped first-ping ARP fails the whole test.

Observed on `hi3516cv200` in master push run #118 (27955168299). cv200 passed in #117 and #119, and #118 didn't touch cv200 → confirmed **flaky**, not a regression. The captured `/tmp/uboot-ping.txt` artifact stalls at the link-up line with no `is alive` and no failure line.

## Fix

Re-issue the `ping` inside the result-polling loop (outer `1..10`, inner `1..3` × `sleep 1`, break on `is alive`) instead of sending it exactly once. This mirrors the Linux ping test's `ping -c 3` retry behaviour, keeps the same ~30s budget (well under the step's `timeout-minutes: 2`), and hardens **every** SoC with `matrix.uboot_bin`, not just cv200.

`ARP Retry` was dropped from the break condition so a struggling attempt re-issues rather than bailing straight to failure.

## Out of scope

- The `libfdt.so.1` failure in the dv500/dv519 aarch64 smoke jobs — already removed by cfa5c00 (#119).
- The broader expect/login flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)