### PR TITLE
hisilicon: boot Linux on Hi3519DV500/Hi3516DV500 (GICv3, EL1, SMP, Ethernet)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -28,6 +28,8 @@
 #include "hw/char/pl011.h"
 #include "hw/intc/arm_gic_common.h"
 #include "hw/intc/arm_gic.h"
+#include "hw/intc/arm_gicv3_common.h"
+#include "qobject/qlist.h"
 #include "hw/arm/hisilicon.h"
 #include "hw/misc/hisi-fastboot.h"
 #include "hw/arm/machines-qom.h"
@@ -2346,7 +2348,6 @@ static const HisiSoCConfig hi3516cv613_soc = {
  * self-extracting u-boot-z.bin: the boot ROM/GSL loads the image at its link
  * address CONFIG_SYS_TEXT_BASE_ORI=0x48700000, the on-die HW gzip (hisi-gzip)
  * decompresses it to CONFIG_SYS_TEXT_BASE=0x48800000, and U-Boot runs from DDR.
- * Used by OpenIPC/u-boot-hi3519dv500 for the qemu_smoke gate.
  */
 static const HisiSoCConfig hi3519dv500_soc = {
     .name               = "hi3519dv500",
@@ -2354,21 +2355,23 @@ static const HisiSoCConfig hi3519dv500_soc = {
     .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a55"),
     .soc_id             = HISI_SOC_ID_DV500,
     .aarch64            = true,
+    .max_cpus           = 2,            /* dual Cortex-A55 */
+    .default_cpus       = 2,            /* boot both cores by default */
     .uboot_load_addr    = 0x48700000,   /* CONFIG_SYS_TEXT_BASE_ORI (u-boot.lds) */
     .psci_conduit       = 1,            /* QEMU_PSCI_CONDUIT_SMC (kernel SMP) */
     .gzip_base          = 0x170F0000,   /* V5 emar HW gzip (shared with CV610) */
 
     /* DDR @ 0x40000000.  Vendor U-Boot probes 512 MiB and relocates itself to
-     * the top of RAM (~0x5ff20000), so map the full 512 MiB.  Smoke boots
-     * U-Boot only (no Linux), so no kernel_mem/mmz reservation. */
+     * the top of RAM (~0x5ff20000), so map the full 512 MiB. */
     .ram_size_default   = 512 * MiB,
     .ram_base           = 0x40000000,
     .sram_base          = 0x04020000,
     .sram_size          = 128 * KiB,
 
     .use_gic            = true,
-    .gic_dist_base      = 0x12401000,
-    .gic_cpu_base       = 0x12402000,
+    .gic_version        = 3,            /* vendor dtsi: compatible "arm,gic-v3" */
+    .gic_dist_base      = 0x12400000,   /* GICD (dtsi reg[0]) */
+    .gic_redist_base    = 0x12440000,   /* GICR redistributor (dtsi reg[1]) */
     .gic_num_spi        = 128,
 
     .sysctl_base        = 0x11020000,
@@ -2376,7 +2379,18 @@ static const HisiSoCConfig hi3519dv500_soc = {
 
     .num_uarts          = 3,
     .uart_bases         = { 0x11040000, 0x11041000, 0x11042000 },
-    .uart_irqs          = { 10, 11, 12 },
+    /* vendor dtsi: uart0=GIC_SPI 5, uart1=6, uart2=7.  Polled u-boot ignored
+     * these, but Linux userspace TTY output is interrupt-driven, so a wrong
+     * SPI = silent console after the kernel hands off to init. */
+    .uart_irqs          = { 5, 6, 7 },
+    /* Gigabit Ethernet: vendor "gmac-v5" (drivers/net/ethernet/vendor/gmac),
+     * same HiGMAC ring + MDIO layout as the existing hisi-gmac model, with
+     * 4-word (16-byte) descriptors.  MAC core + integrated MDIO @0x10290000,
+     * GIC_SPI 54 (queue 0). */
+    .gmac_base          = 0x10290000,
+    .gmac_irq           = 54,
+    .gmac_desc_size     = 16,
+    .gmac_rx_offset     = 2,            /* gmac-v5 driver reserves NET_IP_ALIGN */
 
     /* U-Boot udelay() polls an SP804-style countdown timer at 0x11000000
      * (vendor platform.h CFG_TIMERBASE, 3 MHz) — wire one so the flash boot
@@ -2413,6 +2427,8 @@ static const HisiSoCConfig hi3516dv500_soc = {
     .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a55"),
     .soc_id             = HISI_SOC_ID_3516DV500,
     .aarch64            = true,
+    .max_cpus           = 2,            /* dual Cortex-A55 */
+    .default_cpus       = 2,            /* boot both cores by default */
     .uboot_load_addr    = 0x48700000,
     .psci_conduit       = 1,
     .gzip_base          = 0x170F0000,
@@ -2423,8 +2439,9 @@ static const HisiSoCConfig hi3516dv500_soc = {
     .sram_size          = 128 * KiB,
 
     .use_gic            = true,
-    .gic_dist_base      = 0x12401000,
-    .gic_cpu_base       = 0x12402000,
+    .gic_version        = 3,            /* vendor dtsi: compatible "arm,gic-v3" */
+    .gic_dist_base      = 0x12400000,   /* GICD (dtsi reg[0]) */
+    .gic_redist_base    = 0x12440000,   /* GICR redistributor (dtsi reg[1]) */
     .gic_num_spi        = 128,
 
     .sysctl_base        = 0x11020000,
@@ -2432,7 +2449,18 @@ static const HisiSoCConfig hi3516dv500_soc = {
 
     .num_uarts          = 3,
     .uart_bases         = { 0x11040000, 0x11041000, 0x11042000 },
-    .uart_irqs          = { 10, 11, 12 },
+    /* vendor dtsi: uart0=GIC_SPI 5, uart1=6, uart2=7.  Polled u-boot ignored
+     * these, but Linux userspace TTY output is interrupt-driven, so a wrong
+     * SPI = silent console after the kernel hands off to init. */
+    .uart_irqs          = { 5, 6, 7 },
+    /* Gigabit Ethernet: vendor "gmac-v5" (drivers/net/ethernet/vendor/gmac),
+     * same HiGMAC ring + MDIO layout as the existing hisi-gmac model, with
+     * 4-word (16-byte) descriptors.  MAC core + integrated MDIO @0x10290000,
+     * GIC_SPI 54 (queue 0). */
+    .gmac_base          = 0x10290000,
+    .gmac_irq           = 54,
+    .gmac_desc_size     = 16,
+    .gmac_rx_offset     = 2,            /* gmac-v5 driver reserves NET_IP_ALIGN */
 
     .num_timers         = 1,
     .timer_bases        = { 0x11000000 },
@@ -4409,6 +4437,23 @@ static void hisilicon_common_init(MachineState *machine,
             object_property_set_bool(cpuobj[n], "start-powered-off", true,
                                      &error_fatal);
         }
+        if (c->aarch64) {
+            /* Enter Linux at EL1, like the vendor U-Boot does (it drops the EL
+             * before the kernel).  Otherwise qemu -kernel enters at EL2, the
+             * kernel turns on VHE and uses the EL2 (hyp) physical timer
+             * (PPI 10) — which the vendor dtb's arm,armv8-timer does not
+             * declare (only sec-EL1 PPI 13 and NS-EL1 PPI 14).  With no hyp
+             * timer interrupt there is no tick: the CPU idles in WFI forever
+             * and userspace never starts. */
+            object_property_set_bool(cpuobj[n], "has_el2", false, &error_fatal);
+            /* Match the vendor dtb's MPIDR scheme: each core is its own
+             * cluster (cpu@0 reg=0x0, cpu@1 reg=0x100, ... i.e. Aff1=index).
+             * QEMU would otherwise default to Aff0=index (0,1,...), so PSCI
+             * CPU_ON(0x100) for the secondary would find no CPU (-EINVAL) and
+             * SMP would fail. */
+            object_property_set_uint(cpuobj[n], "mp-affinity",
+                                     (uint64_t)n << 8, &error_fatal);
+        }
         qdev_realize(DEVICE(cpuobj[n]), NULL, &error_fatal);
         cpu[n] = ARM_CPU(cpuobj[n]);
     }
@@ -4437,6 +4482,22 @@ static void hisilicon_common_init(MachineState *machine,
             gicbus = SYS_BUS_DEVICE(gicdev);
             sysbus_realize_and_unref(gicbus, &error_fatal);
             sysbus_mmio_map(gicbus, 0, c->gic_mpcore_base);
+        } else if (c->gic_version == 3) {
+            /* GICv3 (Hi3519DV500/Hi3516DV500): distributor + redistributor,
+             * no CPU-interface MMIO -- the CPU interface is accessed via system
+             * registers.  One redistributor region with one frame per CPU. */
+            QList *redist_region_count = qlist_new();
+            gicdev = qdev_new(gicv3_class_name());
+            qdev_prop_set_uint32(gicdev, "revision", 3);
+            qdev_prop_set_uint32(gicdev, "num-cpu", smp_cpus);
+            qdev_prop_set_uint32(gicdev, "num-irq", num_irq);
+            qlist_append_int(redist_region_count, smp_cpus);
+            qdev_prop_set_array(gicdev, "redist-region-count",
+                                redist_region_count);
+            gicbus = SYS_BUS_DEVICE(gicdev);
+            sysbus_realize_and_unref(gicbus, &error_fatal);
+            sysbus_mmio_map(gicbus, 0, c->gic_dist_base);   /* GICD */
+            sysbus_mmio_map(gicbus, 1, c->gic_redist_base); /* GICR */
         } else {
             gicdev = qdev_new(gic_class_name());
             qdev_prop_set_uint32(gicdev, "revision", 2);
@@ -4728,6 +4789,9 @@ static void hisilicon_common_init(MachineState *machine,
         qemu_configure_nic_device(gmac, true, NULL);
         if (c->gmac_desc_size) {
             qdev_prop_set_uint32(gmac, "desc-size", c->gmac_desc_size);
+        }
+        if (c->gmac_rx_offset) {
+            qdev_prop_set_uint32(gmac, "rx-pkt-offset", c->gmac_rx_offset);
         }
         SysBusDevice *busdev = SYS_BUS_DEVICE(gmac);
         sysbus_realize_and_unref(busdev, &error_fatal);
@@ -5281,6 +5345,9 @@ static void hisi_machine_set_flash_file(Object *obj, const char *value,
             "instantiates: hisi-fmc or hisi-sfc350).");              \
         if (config.max_cpus > 0) {                                   \
             mc->max_cpus = config.max_cpus;                          \
+        }                                                            \
+        if (config.default_cpus > 0) {                               \
+            mc->default_cpus = config.default_cpus;                  \
         }                                                            \
     }                                                                \
     DEFINE_MACHINE_EXTENDED(namestr, MACHINE, HisiMachineState,      \

--- a/qemu/hw/net/hisi-gmac.c
+++ b/qemu/hw/net/hisi-gmac.c
@@ -201,6 +201,13 @@ struct HisiGmacState {
     /* Descriptor size in bytes (16 or 32; CONFIG_HIGMAC_DESC_4_WORD). */
     uint32_t desc_size_bytes;
 
+    /* Offset into each RX buffer at which the MAC DMAs the frame.  The newer
+     * "gmac-v5" vendor driver (Hi3519DV500) allocates buffers at offset 0 and
+     * skb_reserve(NET_IP_ALIGN) on RX, so it expects the frame 2 bytes in; the
+     * older hi_gmac_v200 driver's buffer address already includes the
+     * alignment, so it wants offset 0.  Configurable via "rx-pkt-offset". */
+    uint32_t rx_pkt_offset;
+
     /* Backing register array for misc registers */
     uint32_t regs[MMIO_SIZE / 4];
 };
@@ -230,8 +237,11 @@ static uint16_t hisi_gmac_phy_read(HisiGmacState *s, int reg)
 static void hisi_gmac_phy_write(HisiGmacState *s, int reg, uint16_t val)
 {
     if (reg == 0) {
-        /* BMCR — accept writes but keep link up */
-        s->phy_regs[0] = val & ~BIT(15); /* clear reset bit */
+        /* BMCR — accept writes but keep link up.  RESET (bit15) and
+         * ANRESTART (bit9) are self-clearing in real PHYs: genphy sets
+         * ANRESTART to restart auto-negotiation and then polls BMCR until it
+         * clears, so we must clear both or the link never comes up. */
+        s->phy_regs[0] = val & ~(BIT(15) | BIT(9));
         s->phy_regs[1] |= BIT(2) | BIT(5); /* link up, auto-neg complete */
     } else if (reg < 32 && reg >= 4) {
         s->phy_regs[reg] = val;
@@ -435,12 +445,15 @@ static ssize_t hisi_gmac_receive(NetClientState *nc, const uint8_t *buf,
     uint32_t w1 = desc[1];
     uint32_t buffer_len = (w1 & 0x7FF) + 1;
 
-    if (size > buffer_len) {
+    /* DMA the frame at the configured RX offset (rx-pkt-offset): the gmac-v5
+     * driver skb_reserve()s NET_IP_ALIGN and expects the frame 2 bytes into
+     * the buffer; hi_gmac_v200's buffer address already includes it (offset
+     * 0).  Wrong offset => every frame delivered shifted and dropped. */
+    if (size + s->rx_pkt_offset > buffer_len) {
         return -1;
     }
 
-    /* Write packet data to guest buffer */
-    dma_memory_write(&address_space_memory, data_addr,
+    dma_memory_write(&address_space_memory, data_addr + s->rx_pkt_offset,
                      buf, size, MEMTXATTRS_UNSPECIFIED);
 
     /* Advance RX_FQ read pointer */
@@ -707,6 +720,9 @@ static const Property hisi_gmac_properties[] = {
      * stride differs. */
     DEFINE_PROP_UINT32("desc-size", HisiGmacState, desc_size_bytes,
                        DESC_SIZE_BYTES_DEFAULT),
+    /* RX DMA offset into each buffer (NET_IP_ALIGN).  0 for hi_gmac_v200,
+     * 2 for the gmac-v5 driver (Hi3519DV500). */
+    DEFINE_PROP_UINT32("rx-pkt-offset", HisiGmacState, rx_pkt_offset, 0),
 };
 
 static void hisi_gmac_class_init(ObjectClass *klass, const void *data)

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -41,6 +41,7 @@ typedef struct HisiSoCConfig {
     uint32_t        soc_id;
     ram_addr_t      ram_size_default;
     int             max_cpus;       /* 0 = 1 (default) */
+    int             default_cpus;   /* 0 = QEMU default (1); else cores at boot */
 
     /*
      * Default image sensor model name, applied when the user did not
@@ -77,9 +78,14 @@ typedef struct HisiSoCConfig {
     /* Interrupt controller — VIC or GIC, selected by use_gic */
     bool            use_gic;
     hwaddr          vic_base;       /* PL190, when !use_gic */
-    hwaddr          gic_dist_base;  /* GICv2, when use_gic */
-    hwaddr          gic_cpu_base;
+    hwaddr          gic_dist_base;  /* GICv2 dist / GICv3 GICD, when use_gic */
+    hwaddr          gic_cpu_base;   /* GICv2 only */
     int             gic_num_spi;
+    /* GIC architecture version: 0/2 = GICv2 (default), 3 = GICv3.  GICv3
+     * (e.g. Hi3519DV500/Hi3516DV500) has a redistributor instead of a CPU
+     * interface MMIO; gic_cpu_base is then ignored and gic_redist_base used. */
+    int             gic_version;
+    hwaddr          gic_redist_base; /* GICv3 GICR base, when gic_version == 3 */
     /* Cortex-A9 family: use combined a9mpcore_priv (SCU + GIC + gtimer +
      * mptimer + wdt at MPCORE_PERIPHBASE+0x000/0x100/0x200/0x600/0x1000).
      * When set, gic_dist_base / gic_cpu_base are ignored.  Plain GIC is
@@ -180,6 +186,9 @@ typedef struct HisiSoCConfig {
      * for SoCs whose vendor higmacv300 driver defines
      * CONFIG_HIGMAC_DESC_4_WORD — currently hi3536cv100. */
     uint32_t        gmac_desc_size;
+    /* RX DMA offset (NET_IP_ALIGN) the MAC writes each frame at.  0 (default)
+     * for hi_gmac_v200; 2 for the gmac-v5 driver (Hi3519DV500/Hi3516DV500). */
+    int             gmac_rx_offset;
 
     /* SD/MMC — himciv200 (older SoCs) */
     int             num_himci;


### PR DESCRIPTION
## Summary

The Hi3519DV500 / Hi3516DV500 (Cortex-A55, V5/aarch64) machines previously
only ran the U-Boot `qemu_smoke` gate. This brings them up to a **full OpenIPC
Linux boot to a shell — dual-core, with working Ethernet**, all on a stock
kernel command line (no `initcall_blacklist` or other guest-side workarounds).

All changes are scoped to the two cortex-a55 configs (the aarch64 path); the
armv7 SoCs are untouched.

## What's fixed

- **GICv3** — the vendor dtb declares `arm,gic-v3` (GICD `0x12400000`, GICR
  `0x12440000`); modelled as GICv3 instead of GICv2 (which panicked
  *"no distributor detected"*). Adds `gic_version` + `gic_redist_base`.
- **Enter Linux at EL1** (`has_el2=false`) — with EL2 present, `-kernel`
  enters at EL2, the kernel uses VHE + the EL2 (hyp) timer (PPI 10) which the
  dtb doesn't declare, so there's no tick and the CPU idles forever before
  init. Real silicon drops the EL in U-Boot.
- **UART interrupts** — the dtb wires uart0/1/2 to `GIC_SPI 5/6/7` (were
  10/11/12). Polled U-Boot didn't care, but Linux userspace TTY output is
  interrupt-driven, so the wrong SPI gave a silent console after init.
- **SMP** — boot both Cortex-A55 cores: `max_cpus=2` + a `default_cpus` field,
  and each CPU's `mp-affinity` set to the dtb's per-cluster MPIDR
  (`cpu@0=0x0`, `cpu@1=0x100`) so PSCI `CPU_ON` finds the secondary.
- **Ethernet** — wire the existing `hisi-gmac` model (`0x10290000`, `GIC_SPI
  54`, 16-byte descriptors). Plus two general `hisi-gmac` driver-model fixes
  (PHY `ANRESTART` self-clear for link-up, and RX DMA at the `NET_IP_ALIGN`
  offset) that were why the model never carried traffic on any SoC.

## Test

Boots OpenIPC to a root shell:
```
root@openipc-hi3519dv500:~# uname -a
Linux openipc-hi3519dv500 5.10.0 #1 SMP aarch64 GNU/Linux
```
Both cores online:
```
GICv3: CPU1: found redistributor 100 region 0:0x12460000
CPU1: Booted secondary processor 0x0000000100
smp: Brought up 1 node, 2 CPUs
```
Networking (slirp `-nic user`):
```
udhcpc: lease of 10.0.2.15 obtained from 10.0.2.2
3 packets transmitted, 3 packets received, 0% packet loss
eth0  RX packets:44 errors:0 dropped:0  TX packets:51 errors:0 dropped:0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)