### PR TITLE
hisilicon: map dv500 IOCFG2/IOCFG3 + PMC AON pad-mux (fixes #122)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2412,12 +2412,20 @@ static const HisiSoCConfig hi3519dv500_soc = {
     .gpio_stride        = 0x1000,
     .gpio_irq_start     = 23,
 
-    .num_regbanks       = 4,
+    .num_regbanks       = 7,
     .regbanks           = {
         { "hisi-misc",       0x11024000, 0x5000  },
         { "hisi-ddr",        0x11140000, 0x20000 },
+        /* Pinmux (IOCFG) controllers — vendor sys_config: iocfg=0x10260000,
+         * iocfg2=0x179F0000, iocfg3=0x0EFF0000; plus the AON pad-mux in the
+         * PMC at 0x11120000.  RAM-backed regbanks so the kernel's pin_mux.c
+         * writes persist and /dev/mem pinmux tools (ipctool reginfo) read the
+         * configured mux selections instead of all-zero. */
         { "hisi-iocfg0",     0x10260000, 0x10000 },
-        { "hisi-iocfg1",     0x11130000, 0x10000 },
+        { "hisi-iocfg1",     0x11130000, 0x10000 },   /* CORE_IOCFG window, kept as a stub */
+        { "hisi-iocfg2",     0x179F0000, 0x10000 },
+        { "hisi-iocfg3",     0x0EFF0000, 0x10000 },
+        { "hisi-pmc",        0x11120000, 0x10000 },   /* AON pad-mux (GPIO9) + PMC regs */
     },
 };
 
@@ -2479,12 +2487,20 @@ static const HisiSoCConfig hi3516dv500_soc = {
     .gpio_stride        = 0x1000,
     .gpio_irq_start     = 23,
 
-    .num_regbanks       = 4,
+    .num_regbanks       = 7,
     .regbanks           = {
         { "hisi-misc",       0x11024000, 0x5000  },
         { "hisi-ddr",        0x11140000, 0x20000 },
+        /* Pinmux (IOCFG) controllers — vendor sys_config: iocfg=0x10260000,
+         * iocfg2=0x179F0000, iocfg3=0x0EFF0000; plus the AON pad-mux in the
+         * PMC at 0x11120000.  RAM-backed regbanks so the kernel's pin_mux.c
+         * writes persist and /dev/mem pinmux tools (ipctool reginfo) read the
+         * configured mux selections instead of all-zero. */
         { "hisi-iocfg0",     0x10260000, 0x10000 },
-        { "hisi-iocfg1",     0x11130000, 0x10000 },
+        { "hisi-iocfg1",     0x11130000, 0x10000 },   /* CORE_IOCFG window, kept as a stub */
+        { "hisi-iocfg2",     0x179F0000, 0x10000 },
+        { "hisi-iocfg3",     0x0EFF0000, 0x10000 },
+        { "hisi-pmc",        0x11120000, 0x10000 },   /* AON pad-mux (GPIO9) + PMC regs */
     },
 };
 


### PR DESCRIPTION
## What

`hi3519dv500`/`hi3516dv500` only mapped IOCFG0 (`0x10260000`) plus a cv6xx-leftover regbank at `0x11130000`. The SoC's other pinmux controllers — IOCFG2 (`0x179F0000`), IOCFG3 (`0x0EFF0000`) and the AON pad-mux in the PMC (`0x11120000`) — were unmapped, so `/dev/mem` pinmux tools (`ipctool reginfo`) read `0` outside IOCFG0, and the vendor kernel's `pin_mux.c` writes to iocfg2/iocfg3 landed on unmapped MMIO (dropped).

## Change

Add RAM-backed regbanks for the three regions (`num_regbanks` 4 → 7) on both dv500 configs.

## Verification

Booted OpenIPC Linux on the machine and round-tripped known mux values through `/dev/mem`, decoded with `ipctool reginfo` (OpenIPC/ipctool#177):

| addr | written | reginfo decode |
| --- | --- | --- |
| `0x10260000` (IOCFG0) | `0x5` | `[I2C1_SDA]` |
| `0x179F0034` (IOCFG2) | `0x6` | `[VI_CLK]` |
| `0x179F0044` (IOCFG2) | `0x1` | `[SENSOR0_CLK]` |
| `0x0EFF0024` (IOCFG3) | `0x2` | `[I2C5_SCL]` |
| `0x11120204` (PMC AON) | `0x1` | `[GPIO9_0]` |

All decode to the correct function (before the fix the writes vanished and read `0`). The kernel's own USB-init write to IOCFG2 `0x179F0010` (`USB_VBUS`) also reads back now.

Fixes #122.