### PR TITLE
hisilicon: boot the published GSL-signed cv6xx NOR images (cv610 + cv608)

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2096,7 +2096,13 @@ static const HisiSoCConfig hi3516cv608_soc = {
     .uart_bases         = { 0x11040000, 0x11041000, 0x11042000 },
     .uart_irqs          = { 10, 11, 12 },
 
-    .num_timers         = 0,
+    /* Same SP804-style udelay timer as cv610 (cv608 is the same A7 MP2 die):
+     * without it U-Boot's udelay() spins forever and hangs in the SPI-NOR
+     * probe on a flash boot (-machine hi3516cv608,flash-file=...). */
+    .num_timers         = 1,
+    .timer_bases        = { 0x11000000 },
+    .timer_irqs         = { 4 },
+    .timer_freq         = 3000000,
 
     .num_spis           = 2,
     .spi_bases          = { 0x11070000, 0x11071000 },
@@ -3995,7 +4001,11 @@ static void hisilicon_write_bootrom(MemoryRegion *sysmem,
              * 0x40 bytes — 16 words of vector table + markers — before that
              * address word, however the run is split:
              *   xm720/V500  : 8 vectors + 8 markers, block @0x7000 -> 0x40707000
-             *   V5 / cv6xx  : 12 vectors + 4 markers, block @0x0000 -> 0x41700000
+             *   cv6xx raw   : 8 vectors + 8 markers, block @0x0000 -> 0x41700000
+             *   cv6xx signed: same descriptor, but the u-boot block sits behind
+             *                 the GSL/DDR header so the block opens @0x9400; the
+             *                 header also contains a spurious 0xdeadbeef run, so
+             *                 the scan must keep going until a run passes sanity.
              * The run length (>= 4) distinguishes these from older V4 images,
              * which use a 2-marker descriptor in a different layout and boot
              * correctly from ram_base via a position-independent reset branch —
@@ -4017,7 +4027,8 @@ static void hisilicon_write_bootrom(MemoryRegion *sysmem,
                 }
                 size_t la_idx = i + run;  /* load-address word follows the run */
                 if (la_idx < 16 || la_idx >= scan) {
-                    break;
+                    i += run;             /* run too near the edges — keep scanning */
+                    continue;
                 }
                 uint32_t load_addr = le32_to_cpu(w[la_idx]);
                 size_t blk_off = (la_idx - 16) * 4; /* block opens 0x40 earlier */
@@ -4029,8 +4040,17 @@ static void hisilicon_write_bootrom(MemoryRegion *sysmem,
                     (blk_vec & 0xFF000000) == 0xEA000000) {
                     flash_src += blk_off;
                     ram_dst = load_addr;
+                    break;                /* real loader descriptor found */
                 }
-                break;
+                /*
+                 * A 0xdeadbeef run that fails the sanity check is not the
+                 * loader descriptor — e.g. the GSL-signed cv6xx boot image
+                 * carries a spurious 6-word run inside its DDR-init blob (~0xc00)
+                 * ahead of the real u-boot descriptor at 0x9420.  Skip it and
+                 * keep scanning instead of giving up (which left the stub copying
+                 * the GSL header at offset 0 to DRAM and hanging).
+                 */
+                i += run;
             }
             g_free(data);
         }


### PR DESCRIPTION
Makes `-machine hi3516cv610/cv608,flash-file=<published openipc-…-nor.bin>` boot the **actual published** OpenIPC full NOR images end to end, not just the raw u-boot-z.

## Two fixes

**1. `hisilicon_write_bootrom()` descriptor scan.** It located u-boot via the `0xdeadbeef` self-descriptor run but `break`ed at the *first* run even when it failed the sanity check (load addr in DRAM + reset-branch at block start). The GSL-signed boot image carries a spurious 6-word `0xdeadbeef` run inside its DDR-init blob (~`0xc00`) **ahead** of the real u-boot descriptor at `0x9420`, so the machine gave up, fell back to copying the GSL header at offset 0 to DRAM, and hung — only the raw (unsigned) u-boot-z booted. Now it keeps scanning past sanity-failing runs and stops only on a valid descriptor, so u-boot (flash `0x9400`) is copied to `0x41700000` and entered, as the boot ROM does on silicon.

**2. `hi3516cv608` SP804 timer.** cv608 lacked the `0x11000000` udelay timer that cv610 already has (same A7 MP2 die). Without it U-Boot's `udelay()` spins forever and hangs in the SPI-NOR probe on a flash boot. Added it.

aarch64 (Hi3519DV500/Hi3516DV500) is untouched — `hisilicon_write_bootrom()` early-returns for aarch64 (those use the `uboot_load_addr` path), so no regression.

## Verification (published images from OpenIPC/firmware `image` release)

| image | machine | result |
| --- | --- | --- |
| `openipc-hi3516cv610-ddr2-64m-nor-ultimate.bin` | hi3516cv610 | u-boot → kernel → squashfs root → init ✅ |
| `openipc-hi3516cv610-ddr3-128m-nor-ultimate.bin` | hi3516cv610 | full boot to userspace (network, dropbear) ✅ |
| `openipc-hi3516cv610-ddr3-512m-nor-ultimate.bin` | hi3516cv610 | full boot ✅ |
| `openipc-hi3516cv608-nor-ultimate.bin` | hi3516cv608 | full boot (needs fix #2) ✅ |

cv613 (same A7 MP2 die) has the identical latent timer gap; the same one-line addition applies if it ever ships an image.