### PR TITLE
hisilicon: add the SP804 udelay timer to hi3516cv613

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2290,7 +2290,13 @@ static const HisiSoCConfig hi3516cv613_soc = {
     .uart_bases         = { 0x11040000, 0x11041000, 0x11042000 },
     .uart_irqs          = { 10, 11, 12 },
 
-    .num_timers         = 0,
+    /* Same SP804-style udelay timer as cv610/cv608 (cv613 is the same A7 MP2
+     * die): without it U-Boot's udelay() spins forever and hangs in the
+     * SPI-NOR probe on a flash boot (-machine hi3516cv613,flash-file=...). */
+    .num_timers         = 1,
+    .timer_bases        = { 0x11000000 },
+    .timer_irqs         = { 4 },
+    .timer_freq         = 3000000,
 
     .num_spis           = 2,
     .spi_bases          = { 0x11070000, 0x11071000 },


### PR DESCRIPTION
Follow-up to #124. cv613 is the same Cortex-A7 MP2 die as cv610/cv608 but its machine config still had `.num_timers = 0`, so U-Boot's `udelay()` spins forever and hangs in the SPI-NOR probe on a flash boot. Add the SP804 timer at `0x11000000` (3 MHz, IRQ 4), identical to cv610/cv608.

Verified by flash-booting `openipc-hi3516cv610-ddr3-128m-nor-ultimate.bin` on `-machine hi3516cv613` (same die, 128 MiB): u-boot → FIT → kernel 5.10 → squashfs root → `Run /init`. (No dedicated cv613 OpenIPC image exists, so a cv610 image is used on the cv613 machine.)