### PR TITLE
hisilicon: boot the GSL-signed Hi3519DV500 u-boot from a full NOR image

### DIFF
--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -5289,7 +5289,34 @@ static void hisilicon_common_init(MachineState *machine,
                              "<u-boot-z.bin>", c->name, c->name);
                 exit(1);
             }
-            rom_add_blob_fixed("hisilicon.uboot", udata, ulen,
+            /*
+             * The flash may hold either the raw self-extracting u-boot-z at
+             * offset 0, or a full NOR image whose first partition is the
+             * GSL-signed boot image (boot-<soc>-<binning>-nor.bin) — there the
+             * GSL/DDR header sits at offset 0 and the u-boot-z payload is
+             * embedded deeper (e.g. 0x11200). Both open with an aarch64 reset
+             * branch (b, opcode 0x14......) immediately followed by a run of
+             * 0xdeadbeef self-descriptor markers, so locate that block and load
+             * it at the DDR link address. Loading the GSL header verbatim would
+             * land non-executable bytes at the entry and hang at "Starting".
+             */
+            size_t uoff = 0;
+            {
+                const uint32_t *w = (const uint32_t *)udata;
+                size_t nw = ulen / 4;
+                size_t scan = MIN(nw, (size_t)(0x40000 / 4)); /* first 256 KiB */
+                for (size_t i = 0; i + 5 <= scan; i++) {
+                    if ((le32_to_cpu(w[i]) & 0xFC000000) == 0x14000000 &&
+                        le32_to_cpu(w[i + 1]) == 0xdeadbeef &&
+                        le32_to_cpu(w[i + 2]) == 0xdeadbeef &&
+                        le32_to_cpu(w[i + 3]) == 0xdeadbeef &&
+                        le32_to_cpu(w[i + 4]) == 0xdeadbeef) {
+                        uoff = (size_t)i * 4;
+                        break;
+                    }
+                }
+            }
+            rom_add_blob_fixed("hisilicon.uboot", udata + uoff, ulen - uoff,
                                c->uboot_load_addr);
             g_free(udata);
 


### PR DESCRIPTION
Follow-up to #126. That PR booted the raw self-extracting `u-boot-z` placed at flash offset 0, but the **published** dv500 NOR images (`openipc-hi3519dv500-{dmeb,dmebpro}-nor-ultimate.bin`, from OpenIPC/firmware#2211) put the **GSL-signed** boot image first: a GSL/DDR header at offset 0 with the `u-boot-z` payload embedded deeper (~`0x11200`).

The aarch64 flash-boot path loaded the file from offset 0 to the DDR link address and started CPU0 there, so it executed the non-executable GSL header and hung right after the FMC load (no U-Boot banner).

### Fix
Locate the `u-boot-z` block before loading. Both layouts open the payload with an **aarch64 reset branch** (`b`, opcode `0x14......`) immediately followed by a run of `0xdeadbeef` self-descriptor markers — raw image at offset 0, GSL image at ~`0x11200`. Scan the first 256 KiB for that signature and `rom_add_blob_fixed` from there.

### Verification
Booting the **actual published** GSL-signed images (`-M hi3519dv500,flash-file=openipc-hi3519dv500-<binning>-nor-ultimate.bin`), both binnings, 2/2 runs each:
```
U-Boot 2022.07-g66180744 (Jun 27 2026 ...) hi3519dv500
...
Starting kernel ...
VFS: Mounted root (squashfs filesystem) readonly on device 31:3.
Run /init as init process
Welcome to OpenIPC
openipc-hi3519dv500 login:
```
Zero Oops/panics, deterministic. With this, QEMU boots the released dv500 image verbatim — not just a raw u-boot — closing the loop on OpenIPC/firmware#2208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)