### PR TITLE
hisilicon: add Goke GK7206 (xmorca) with fmc100 flash + SD/MMC

### DIFF
--- a/qemu-boot/run-gk7206.sh
+++ b/qemu-boot/run-gk7206.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Boot the Goke GK7206V10 (codename "xmorca", ShiMetaPi Pico-G1 SoC) in QEMU.
+#
+# Boots the vendor XMedia SDK kernel (linux-5.10.y, xmorca_defconfig) to full
+# Linux userspace on the emulated dual-Cortex-A7 MP2.  The kernel image is a
+# plain zImage with the vendor xmorca.dtb appended (CONFIG_ARM_APPENDED_DTB);
+# QEMU's hisilicon machine patches that DTB in memory at load (GIC CPU-iface
+# size, disables lotus,sdhci + NAND) — the on-disk image stays vendor-original.
+#
+# Build the kernel + dtb from the SDK (github.com/ShiMetaPi/shimetapi_pico_gx):
+#   ./run.sh lunch                 # pick xm7206v12a + linux-5.10
+#   # build zImage + dtb, skipping the proprietary GMP media driver:
+#   PATH=<sdk>/tools/linux/toolchains/arm-gcc12.2.0-linux-uclibceabi/bin:$PATH \
+#   make -C source/kernel/linux-5.10.y O=out/xm7206v12a/linux-5.10.y ARCH=arm \
+#        CROSS_COMPILE=arm-gcc12.2.0-linux-uclibceabi- CONFIG_GMP= -j zImage
+#   cat out/.../arch/arm/boot/zImage out/.../lotus/machine/xmorca/dts/xmorca.dtb \
+#       > qemu-boot/gk7206/zImage-xmorca-dtb
+#
+# The rootfs is the SDK's real busybox userspace, packed as an initramfs cpio.
+# NB: the vendor kernel has no CONFIG_RD_GZIP, so the cpio MUST be
+# UNCOMPRESSED.  Root is on an initramfs here rather than SPI-flash MTD: the
+# vendor lotus_fmc100 flash controller does not yet enumerate on our FMC model
+# (so /proc/mtd is empty) — a real root=/dev/mtdblockN boot is still TODO.
+#
+# Two boot modes (set FLASH=1 for the second):
+#
+#  FLASH unset (default) — INITRAMFS boot.  Root is the SDK busybox rootfs
+#    packed as an uncompressed cpio (initramfs.cpio = tiny banner init).
+#    INITRD/RDINIT override the userspace.
+#
+#  FLASH=1 — SPI-NOR FLASH boot.  Attaches a 16 MiB NOR image (nor-16m.img)
+#    to the emulated fmc100 flash controller; the kernel enumerates the chip
+#    (W25Q128), parses the "sfc:" mtdparts, and mounts root=/dev/mtdblock4
+#    (jffs2) straight from flash — exactly like the real board's bootargs.
+#    Build the image with mk-cv610-nor.sh-style tooling: 16 MiB of 0xFF with
+#    the jffs2 rootfs placed at offset 0x500000 (after boot/bootargs/bl31/
+#    kernel partitions).
+#
+# Ctrl-A X to quit QEMU.
+
+set -e
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+QEMU="${QEMU:-$ROOT/qemu-src/build/qemu-system-arm}"
+KERNEL="${KERNEL:-$HERE/gk7206/zImage-xmorca-dtb}"
+
+if [ "${FLASH:-0}" = 1 ]; then
+    NOR="${NOR:-$HERE/gk7206/nor-16m.img}"
+    exec "$QEMU" -M gk7206v10,flash-file="$NOR" -m 256M -nographic -display none \
+        -serial mon:stdio -monitor none \
+        -kernel "$KERNEL" \
+        -append "root=/dev/mtdblock4 rootfstype=jffs2 rw mtdparts=sfc:512K(boot),256K(bootargs),256K(bl31),4M(kernel),11M(rootfs)" \
+        -d unimp,guest_errors \
+        "$@"
+fi
+
+INITRD="${INITRD:-$HERE/gk7206/rootfs.cpio}"
+RDINIT="${RDINIT:-/sbin/init}"
+
+exec "$QEMU" -M gk7206v10 -m 256M -nographic -display none \
+    -serial mon:stdio -monitor none \
+    -kernel "$KERNEL" \
+    -initrd "$INITRD" \
+    -append "mem=200M rdinit=$RDINIT" \
+    -d unimp,guest_errors \
+    "$@"

--- a/qemu/hw/arm/hisilicon.c
+++ b/qemu/hw/arm/hisilicon.c
@@ -2050,6 +2050,155 @@ static const HisiSoCConfig gk7202v330_soc = {
 };
 
 /*
+ * Goke third generation (2025-2026) — Goke's own designs on the XMedia
+ * "Lotus" SDK (ShiMetaPi shimetapi_pico_gx), split into two product lines
+ * like HiSilicon's 3516/3519:
+ *   GK7206 (codename "xmorca")  — A7 mainstream, embedded DDR, 5M.
+ *   GK7606 (codename "xmfalcon")— A55 high-end, external DDR, 4K.
+ * Both keep the gk7205v5xx-style 0x12xxxxxx control block (UART 0x12040000,
+ * sysctl 0x12020000, CRG 0x12010000, xmedia,sp804 timers 0x12000000, GPIO
+ * 0x120b0000), RAM @0x40000000, an ATF BL1->BL31->BL33(u-boot-2020.01)
+ * chain, and a RISC-V MCU coprocessor.  Chip ID at REG_SC_CHIPID 0x12020EE0.
+ *
+ * ---- GK7206V1 series (codename xmorca) — IMPLEMENTED ----
+ * Variants (QFN92/QFN128): V10 / V10B / V11 / V11A / V11AT / V12A, embedded
+ * 512Mb DDR2 / 1Gb / 2Gb DDR3L KGD.  Dual Cortex-A7 MP2 + RISC-V MCU; NPU
+ * 1.0 TOPS (INT16/8/4); "圆鸮" AI ISP; H.265 5M@30 (V12A 4K@25).
+ *
+ * Map from the SDK u-boot arch/arm/include/asm/arch-xmorca/platform.h.  The
+ * gk7205v5xx V4-common block is exact for the control plane; the only delta
+ * is the FE MAC (GMAC_REG_BASE), which orca moved 0x10040000 -> 0x100d0000.
+ * Uses the xmedia,sp804 timer like gk7205v500.  (DDRC is at 0x11330000 vs
+ * the V4-common 0x120d0000 hisi-ddr stub; left as-is for now — a RAM-backed
+ * stub either way, not touched on the -kernel boot path.)
+ *
+ * Declares 2 CPUs (dual A7 MP2): the GICv2 makes ITARGETSR RAZ for a
+ * uniprocessor GIC, so a 1-CPU model makes the kernel's gic_get_cpumask()
+ * read 0 ("GIC CPU mask not found — kernel will fail to boot") and wedges
+ * every interrupt-driven probe.  With 2 CPU interfaces ITARGETSR reports the
+ * real mask and interrupts work.  CPU1 itself never onlines — the vendor
+ * "lotus,xmorca-smp" release method isn't modeled — but the kernel times out
+ * on it gracefully and continues single-core (same as the DTS expects).
+ *
+ * Boots the vendor SDK kernel (linux-5.10.y, xmorca_defconfig) to full
+ * device init via -kernel with the appended xmorca.dtb.  Reaching userspace
+ * still needs a rootfs (flash image or initramfs) — root=/dev/mtdblock4 in
+ * the vendor bootargs otherwise panics after driver init.
+ */
+static const HisiSoCConfig gk7206v10_soc = {
+    .name               = "gk7206v10",
+    .desc               = "Goke GK7206V10 (Cortex-A7 MP2 + RISC-V MCU, 1.0 TOPS NPU)",
+    .soc_id             = GOKE_SOC_ID_7206V10,
+    .max_cpus           = 2,            /* dual Cortex-A7 MP2 */
+    .default_cpus       = 2,            /* 2 GIC CPU interfaces (ITARGETSR !RAZ) */
+    .gpio_count         = 10,           /* GPIO0..GPIO9 @ 0x120b0000..0x120b9000 */
+    HISI_V4_DDR_64M,                    /* GK7206V10: embedded 512Mb DDR2 */
+    HISI_V4_COMMON_PERIPH,
+    .xmsp804_timer      = true,         /* XMedia kernel uses xmedia,sp804 */
+    .femac_base         = 0x100d0000,   /* GMAC_REG_BASE — orca relocated FE MAC */
+    /* Flash: "lotus,fmc" (fmc100) — same IP as HiFMC V100 but a shuffled
+     * register map, and the DT "control" reg sits at 0x10000010 (not
+     * 0x10000000).  Memory window stays at 0x14000000 (from V4 common). */
+    .fmc_ctrl_base      = 0x10000010,
+    .fmc_variant        = 1,            /* FMC_VARIANT_FMC100 */
+    .fmc_irq            = 36,           /* DTS: flash-memory-controller irq SPI 36 */
+    /* SD/MMC — three "lotus,sdhci" controllers.  The V4-common defaults
+     * (2 ports @0x10010000/0x10020000, IRQ 30/31) don't match orca, so
+     * override with the DTS map: mmc0 eMMC @0x10010000 irq32,
+     * mmc1 @0x10040000 irq33, mmc2 SDIO @0x10020000 irq34.  A wrong IRQ
+     * leaves the eMMC probe waiting forever for command-complete (which is
+     * why the sdhci node used to be DTB-disabled). */
+    .num_sdhci          = 3,
+    .sdhci_bases        = { 0x10010000, 0x10040000, 0x10020000 },
+    .sdhci_irqs         = { 32, 33, 34 },
+    /* Pre-mark the SD/MMC DLL (delay-locked-loop) status registers as
+     * locked/ready in the CRG.  The lotus,sdhci driver reads these via its
+     * crg_regmap phandle (drivers/mmc/host/sdhci-xmorca.c) to pick a data
+     * sampling phase; if they never report ready it settles on a bad phase
+     * and card data init loops ("Skipping voltage switch").  DRV_DLL_STATUS
+     * = LOCK|READY (bit15|bit14), SAMPL/DS/DS180 = SLAVE_READY (bit0). */
+    .num_crg_defaults   = 8,
+    .crg_defaults       = {
+        { 0x208, 0x00000001 },  /* eMMC  SAMPL_DLL_STATUS: SLAVE_READY */
+        { 0x210, 0x0000C000 },  /* eMMC  DRV_DLL_STATUS:   LOCK|READY  */
+        { 0x214, 0x00000001 },  /* eMMC  DS_DLL_STATUS:    READY       */
+        { 0x218, 0x00000001 },  /* eMMC  DS180_DLL_STATUS: READY       */
+        { 0x224, 0x00000001 },  /* SDIO0 SAMPL_DLL_STATUS: SLAVE_READY */
+        { 0x228, 0x0000C000 },  /* SDIO0 DRV_DLL_STATUS:   LOCK|READY  */
+        { 0x238, 0x00000001 },  /* SDIO1 SAMPL_DLL_STATUS: SLAVE_READY */
+        { 0x23c, 0x0000C000 },  /* SDIO1 DRV_DLL_STATUS:   LOCK|READY  */
+    },
+};
+
+/*
+ * ---- GK7606V1 series (codename xmfalcon) — PLACEHOLDER ----
+ * Goke's A55 high-end 4K line, sibling of GK7206.  Cortex-A55 (aarch64),
+ * external DDR3/DDR4/LPDDR4, adds USB3.  The SDK ships NO xmfalcon board
+ * config (only xmorca/GK7206), so the map below — from the SDK u-boot
+ * arch/arm/include/asm/arch-xmfalcon/platform.h — is UNVERIFIED against
+ * silicon or a boot.  Registered so the machine name exists and future work
+ * has a scaffold; NOT expected to boot yet.  UNKNOWNS flagged inline:
+ *   - GIC physical bases (u-boot uses virtual 0xf6801000/0xf6802000);
+ *   - all IRQ numbers (borrowed from hi3519dv500, likely wrong);
+ *   - SoC ID and external DDR size.
+ * Deltas from GK7206/xmorca: A55 aarch64 + GICv3 + ATF/PSCI SMP; FE/GMAC
+ * 0x100d0000 -> gigabit GMAC 0x11900000; adds USB3 @0x10040000; ext DDR.
+ * Shared 0x12xx control block (UART/sysctl/CRG/sp804/GPIO) is authoritative.
+ */
+static const HisiSoCConfig gk7606v1_soc = {
+    .name               = "gk7606v1",
+    .desc               = "Goke GK7606V1 (Cortex-A55, 4K — PLACEHOLDER, does not boot yet)",
+    .cpu_type           = ARM_CPU_TYPE_NAME("cortex-a55"),
+    .soc_id             = GOKE_SOC_ID_7606V1,
+    .aarch64            = true,
+    .uboot_load_addr    = 0x40700000,   /* CONFIG_SYS_TEXT_BASE_ORI (xmfalcon.h) */
+    .psci_conduit       = 1,
+
+    .ram_size_default   = 256 * MiB,    /* external DDR; size UNVERIFIED */
+    .ram_base           = 0x40000000,
+    .sram_base          = 0x04020000,
+    .sram_size          = 128 * KiB,
+
+    .use_gic            = true,
+    .gic_version        = 3,
+    .gic_dist_base      = 0x12400000,   /* PLACEHOLDER — u-boot virt 0xf6801000 */
+    .gic_redist_base    = 0x12440000,   /* PLACEHOLDER — u-boot virt 0xf6802000 */
+    .gic_num_spi        = 128,
+
+    .sysctl_base        = 0x12020000,   /* SYS_CTRL_REG_BASE (authoritative) */
+    .crg_base           = 0x12010000,   /* CRG_REG_BASE (authoritative) */
+
+    .num_uarts          = 3,
+    .uart_bases         = { 0x12040000, 0x12041000, 0x12042000 }, /* authoritative */
+    .uart_irqs          = { 5, 6, 7 },  /* PLACEHOLDER irqs */
+
+    .xmsp804_timer      = true,         /* xmedia,sp804 @ 0x12000000 */
+    .num_timers         = 1,
+    .timer_bases        = { 0x12000000 },
+    .timer_irqs         = { 4 },
+    .timer_freq         = 3000000,
+
+    .num_spis           = 2,
+    .spi_bases          = { 0x12070000, 0x12071000 },
+    .spi_irqs           = { 19, 20 },   /* PLACEHOLDER irqs */
+
+    .fmc_ctrl_base      = 0x10000000,   /* FMC_REG_BASE (authoritative) */
+    .fmc_mem_base       = 0x14000000,   /* FMC_MEM_BASE (authoritative) */
+
+    .gpio_base          = 0x120b0000,   /* GPIO0_REG_BASE (authoritative) */
+    .gpio_count         = 10,
+    .gpio_stride        = 0x1000,
+    .gpio_irq_start     = 23,           /* PLACEHOLDER */
+
+    /* Gigabit GMAC (GMAC_REG_BASE 0x11900000).  Model like hi3519dv500's
+     * gmac-v5 (16-byte descriptors); IRQ is a PLACEHOLDER. */
+    .gmac_base          = 0x11900000,
+    .gmac_irq           = 54,           /* PLACEHOLDER */
+    .gmac_desc_size     = 16,
+    .gmac_rx_offset     = 2,
+};
+
+/*
  * V5 family (~2023): Hi3516CV608 / CV610 / CV613 — Dual Cortex-A7 MP2 + NPU.
  * Video: H.265/H.264, up to 4K.  New 0x11xxxxxx address map, GIC @ 0x124xxxxx.
  * NPU: 0.2 TOPS (CV608), 0.5 TOPS (CV610), 1 TOPS (CV613).
@@ -3815,6 +3964,47 @@ static char *hisilicon_patch_appended_dtb(const char *kernel_filename,
         }
     }
 
+    /*
+     * Widen an under-sized GICv2 CPU-interface reg window.
+     *
+     * Some vendor DTBs declare the GIC CPU interface as only 0x100 bytes
+     * (e.g. Goke xmorca / GK7206: reg = <0x10301000 0x1000 0x10302000
+     * 0x100>).  The Linux GICv2 driver requires the CPU-interface region to
+     * be >= SZ_8K (0x2000) or it refuses to probe ("GIC: GICv2 detected, but
+     * range too small ... will fail to boot", drivers/irqchip/irq-gic.c),
+     * which then wedges every interrupt-driven device (SDHCI, etc.).  Real
+     * GIC-400 silicon has a 0x2000 CPU interface; the DTS just undersized it
+     * (the physical board's U-Boot env compensates with
+     * irqchip.gicv2_force_probe=1).  Rather than require an extra bootarg,
+     * bump the size to 0x2000 here so the stock driver probes normally.
+     * QEMU only maps 0x100 of CPU-interface MMIO, but the machine sets
+     * ignore_memory_transaction_failures, so reads of the unmapped tail
+     * return 0 harmlessly — exactly like the known-good Hi3516CV610 DTB,
+     * which already declares 0x2000.  Only fires when the window is smaller
+     * than 0x2000, so correctly-sized DTBs are left untouched.
+     */
+    {
+        static const char * const gicv2_compat[] = {
+            "arm,gic-400", "arm,cortex-a7-gic", "arm,cortex-a15-gic",
+            "arm,cortex-a9-gic", "arm,gic-v2", NULL
+        };
+        for (int i = 0; gicv2_compat[i]; i++) {
+            int gic = fdt_node_offset_by_compatible(dtb, -1, gicv2_compat[i]);
+            if (gic < 0) {
+                continue;
+            }
+            int len = 0;
+            const uint32_t *reg = fdt_getprop(dtb, gic, "reg", &len);
+            /* 1/1 address/size cells: <dist_base dist_sz cpu_base cpu_sz> */
+            if (reg && len >= 4 * (int)sizeof(uint32_t) &&
+                be32_to_cpu(reg[3]) < 0x2000) {
+                g_autofree uint32_t *newreg = g_memdup2(reg, len);
+                newreg[3] = cpu_to_be32(0x2000);
+                fdt_setprop_inplace(dtb, gic, "reg", newreg, len);
+            }
+        }
+    }
+
     /* Pack then re-expand with padding for kernel's atags_to_fdt() */
     fdt_pack(dtb);
     uint32_t packed = fdt_totalsize(dtb);
@@ -4385,6 +4575,7 @@ static void hisilicon_common_init(MachineState *machine,
     qemu_irq pic[256];
     int num_pic = 0;
     int n;
+    SysBusDevice *fmc_irq_dev = NULL; /* FMC, IRQ-connected after pic[] is built */
     bool flash_boot = false;  /* true when booting from SPI NOR flash dump */
     bool fmc_nand_boot = false; /* true when the FMC boot flash is SPI NAND */
     bool bios_boot = machine->firmware && machine->firmware[0];
@@ -4403,6 +4594,12 @@ static void hisilicon_common_init(MachineState *machine,
         const char *fmc_type = c->fmc_type ? c->fmc_type : "hisi-fmc";
         DeviceState *fmc = qdev_new(fmc_type);
         SysBusDevice *fmcbus = SYS_BUS_DEVICE(fmc);
+
+        /* Select the register-map variant (0 = HiFMC V100, 1 = fmc100 for
+         * Goke xmorca / GK7206).  Only the hisi-fmc model has this property. */
+        if (c->fmc_variant && (!c->fmc_type || !strcmp(fmc_type, "hisi-fmc"))) {
+            qdev_prop_set_uint32(fmc, "variant", c->fmc_variant);
+        }
 
         /*
          * Forward the machine-level "flash-file" property to whichever
@@ -4444,6 +4641,10 @@ static void hisilicon_common_init(MachineState *machine,
         sysbus_realize_and_unref(fmcbus, &error_fatal);
         sysbus_mmio_map(fmcbus, 0, c->fmc_ctrl_base);
         sysbus_mmio_map(fmcbus, 1, c->fmc_mem_base);
+        /* The fmc100 (lotus,fmc) driver waits on an interrupt for DMA-read
+         * completion.  The IRQ can only be connected once the GIC has built
+         * pic[] (below), so stash the device and wire it up after that. */
+        fmc_irq_dev = fmcbus;
 
         /*
          * Dual NOR+NAND boards (e.g. OpenIPC hi3516ev300 NAND: u-boot+env in
@@ -4648,6 +4849,11 @@ static void hisilicon_common_init(MachineState *machine,
         for (n = 0; n < num_pic; n++) {
             pic[n] = qdev_get_gpio_in(vic, n);
         }
+    }
+
+    /* Now that pic[] exists, wire the FMC op/DMA-done IRQ (fmc100 only). */
+    if (fmc_irq_dev && c->fmc_irq && c->fmc_irq < num_pic) {
+        sysbus_connect_irq(fmc_irq_dev, 0, pic[c->fmc_irq]);
     }
 
     /* SysCtrl — V1–V5 IPC and DVR/NVR scheme; STB family (HiSTB) uses
@@ -5500,6 +5706,8 @@ DEFINE_HISI_MACHINE("gk7205v500", gk7205v500, gk7205v500_soc)
 DEFINE_HISI_MACHINE("gk7205v510", gk7205v510, gk7205v510_soc)
 DEFINE_HISI_MACHINE("gk7205v530", gk7205v530, gk7205v530_soc)
 DEFINE_HISI_MACHINE("gk7202v330", gk7202v330, gk7202v330_soc)
+DEFINE_HISI_MACHINE("gk7206v10",  gk7206v10,  gk7206v10_soc)
+DEFINE_HISI_MACHINE("gk7606v1",   gk7606v1,   gk7606v1_soc)
 DEFINE_HISI_MACHINE("hi3516cv608", hi3516cv608, hi3516cv608_soc)
 DEFINE_HISI_MACHINE("hi3516cv610", hi3516cv610, hi3516cv610_soc)
 DEFINE_HISI_MACHINE("hi3516cv613", hi3516cv613, hi3516cv613_soc)

--- a/qemu/hw/misc/hisi-fmc.c
+++ b/qemu/hw/misc/hisi-fmc.c
@@ -19,6 +19,7 @@
 #include "qemu/osdep.h"
 #include "qapi/error.h"
 #include "hw/sysbus.h"
+#include "hw/irq.h"
 #include "hw/qdev-properties.h"
 #include "qemu/log.h"
 #include "system/dma.h"
@@ -76,6 +77,47 @@
 
 /* FMC_INT bits */
 #define FMC_INT_OP_DONE     BIT(0)
+
+/*
+ * Register-map variant.  The Goke xmorca / GK7206 "lotus,fmc" (fmc100) is the
+ * same controller IP as the HiFMC V100 modelled above, but its register block
+ * is shuffled to a different offset layout (and reports VERSION 0x200 instead
+ * of 0x100).  The *operational* model is byte-for-byte identical — register-
+ * mode ops are triggered by the OP register's START bit (bit 0 in both), DMA
+ * ops by OP_CTRL's DMA_OP_READY bit (bit 0 in both, RW_OP = bit 1 in both),
+ * and results are served from the memory window.  So we translate an fmc100
+ * offset back to the canonical HiFMC offset and reuse one set of handlers.
+ */
+#define FMC_VARIANT_HIFMC   0
+#define FMC_VARIANT_FMC100  1
+
+/* fmc100 register offsets (drivers/mtd/fmc100/fmc100_reg.h), control base is
+ * the DT "control" reg (0x10000010 on xmorca). */
+static hwaddr fmc100_to_canonical(hwaddr off)
+{
+    switch (off) {
+    case 0x00: return FMC_SPI_TIMING_CFG; /* TIMING_SPI_CFG */
+    case 0x08: return FMC_CFG;
+    case 0x0c: return FMC_GLOBAL_CFG;
+    case 0x10: return FMC_INT;
+    case 0x14: return FMC_INT_EN;
+    case 0x28: return FMC_INT_CLR;
+    case 0x20: return FMC_ADDRH;
+    case 0x24: return FMC_ADDRL;
+    case 0x2c: return FMC_CMD;
+    case 0x30: return FMC_DATA_NUM;
+    case 0x34: return FMC_OP;
+    case 0x38: return FMC_OP_CFG;
+    case 0x40: return FMC_DMA_AHB_CTRL;
+    case 0x44: return FMC_DMA_SADDR_D0;
+    case 0x48: return FMC_DMA_LEN;
+    case 0x54: return FMC_DMA_SADDR_OOB;
+    case 0x60: return FMC_OP_CTRL;
+    case 0xa4: return FMC_STATUS;
+    case 0xb4: return FMC_VERSION;
+    default:   return (hwaddr)-1;  /* unmapped: read 0 / ignore write */
+    }
+}
 
 /* SPI commands (shared NOR + NAND) */
 #define SPI_CMD_WRITE_ENABLE  0x06
@@ -147,8 +189,10 @@ struct HisiFmcState {
 
     MemoryRegion ctrl_iomem;
     MemoryRegion mem_iomem;
+    qemu_irq irq;                 /* op/DMA-done IRQ (fmc100 uses it; V100 polls) */
 
     /* Configuration properties */
+    uint32_t variant;             /* FMC_VARIANT_HIFMC (default) or _FMC100 */
     uint32_t flash_type;          /* 0=NOR, 1=NAND — type of the flash-file image */
     char    *flash_file;          /* optional: path to flash dump to load */
     char    *nand_file;           /* optional: 2nd image for dual NOR+NAND boards
@@ -240,6 +284,17 @@ struct HisiFmcState {
 static inline int hisi_fmc_current_flash_sel(HisiFmcState *s)
 {
     return (s->cfg >> FMC_CFG_FLASH_SEL_SHIFT) & 0x3;
+}
+
+/* Level-triggered op/DMA-done interrupt.  The fmc100 driver waits on a
+ * completion signalled from the FMC ISR (INT & INT_EN), rather than polling;
+ * the HiFMC V100 users leave the IRQ unconnected and poll, so this is a no-op
+ * for them. */
+static void hisi_fmc_update_irq(HisiFmcState *s)
+{
+    if (s->irq) {
+        qemu_set_irq(s->irq, (s->fmc_int & s->int_en) ? 1 : 0);
+    }
 }
 
 /*
@@ -686,7 +741,7 @@ static void hisi_fmc_exec_dma_nor(HisiFmcState *s)
      * XIP reads work. If the kernel driver forgets to set this, DMA reads
      * return 0xFF (erased flash).
      */
-    if (!(s->cfg & 1)) {
+    if (s->variant != FMC_VARIANT_FMC100 && !(s->cfg & 1)) {
         qemu_log_mask(LOG_GUEST_ERROR,
                       "hisi-fmc: DMA op with FMC_CFG=0x%x (not in NORMAL mode),"
                       " returning 0xFF\n", s->cfg);
@@ -841,7 +896,17 @@ static uint64_t hisi_fmc_ctrl_read(void *opaque, hwaddr offset, unsigned size)
 {
     HisiFmcState *s = HISI_FMC(opaque);
 
+    if (s->variant == FMC_VARIANT_FMC100) {
+        hwaddr c = fmc100_to_canonical(offset);
+        if (c == (hwaddr)-1) {
+            return 0;
+        }
+        offset = c;
+    }
+
     switch (offset) {
+    case FMC_VERSION:
+        return s->variant == FMC_VARIANT_FMC100 ? 0x200 : 0x100;
     case FMC_CFG:           return s->cfg;
     case FMC_GLOBAL_CFG:    return s->global_cfg;
     case FMC_SPI_TIMING_CFG: return s->spi_timing;
@@ -860,7 +925,6 @@ static uint64_t hisi_fmc_ctrl_read(void *opaque, hwaddr offset, unsigned size)
     case FMC_DMA_SADDR_OOB: return s->dma_saddr_oob;
     case FMC_OP_CTRL:       return 0; /* DMA_OP_READY always reads as clear */
     case FMC_STATUS:        return s->status;
-    case FMC_VERSION:       return 0x100; /* HIFMC_VER_100 */
     case FMC_DMA_SADDRH_D0: return s->dma_saddrh_d0;
     case FMC_DMA_SADDRH_OOB: return s->dma_saddrh_oob;
     default:
@@ -876,12 +940,20 @@ static void hisi_fmc_ctrl_write(void *opaque, hwaddr offset,
 {
     HisiFmcState *s = HISI_FMC(opaque);
 
+    if (s->variant == FMC_VARIANT_FMC100) {
+        hwaddr c = fmc100_to_canonical(offset);
+        if (c == (hwaddr)-1) {
+            return;  /* unmapped fmc100 reg (OP_PARA, timing…): ignore */
+        }
+        offset = c;
+    }
+
     switch (offset) {
     case FMC_CFG:           s->cfg = value;           break;
     case FMC_GLOBAL_CFG:    s->global_cfg = value;    break;
     case FMC_SPI_TIMING_CFG: s->spi_timing = value;   break;
-    case FMC_INT_EN:        s->int_en = value;        break;
-    case FMC_INT_CLR:       s->fmc_int &= ~value;     break;
+    case FMC_INT_EN:        s->int_en = value;   hisi_fmc_update_irq(s); break;
+    case FMC_INT_CLR:       s->fmc_int &= ~value; hisi_fmc_update_irq(s); break;
     case FMC_CMD:           s->cmd = value;           break;
     case FMC_ADDRH:         s->addrh = value;         break;
     case FMC_ADDRL:         s->addrl = value;         break;
@@ -898,7 +970,11 @@ static void hisi_fmc_ctrl_write(void *opaque, hwaddr offset,
     case FMC_OP:
         s->iobuf_valid = false;
         if (value & FMC_OP_REG_OP_START) {
-            if (value & FMC_OP_READ_STATUS_EN) {
+            /* On fmc100 bit1 is ADDR_EN, not READ_STATUS_EN — always dispatch
+             * by SPI command (READ_STATUS 0x05 lands the SR in iobuf, which the
+             * driver reads back from the memory window like every other op). */
+            if (s->variant != FMC_VARIANT_FMC100 &&
+                (value & FMC_OP_READ_STATUS_EN)) {
                 /* Hardware reads SPI status register directly into FMC_STATUS.
                  * The actual SPI opcode in FMC_CMD selects WHICH register. */
                 uint8_t cmd = s->cmd & 0xFF;
@@ -920,6 +996,7 @@ static void hisi_fmc_ctrl_write(void *opaque, hwaddr offset,
                 s->iobuf_valid = hisi_fmc_exec_reg_op(s);
             }
             s->fmc_int |= FMC_INT_OP_DONE;
+            hisi_fmc_update_irq(s);
         }
         break;
 
@@ -928,6 +1005,7 @@ static void hisi_fmc_ctrl_write(void *opaque, hwaddr offset,
         s->iobuf_valid = false;
         if (value & FMC_OP_CTRL_DMA_OP_READY) {
             hisi_fmc_exec_dma_op(s);
+            hisi_fmc_update_irq(s);
         }
         break;
 
@@ -1195,6 +1273,8 @@ static void hisi_fmc_init(Object *obj)
     memory_region_init_io(&s->mem_iomem, obj, &hisi_fmc_mem_ops, s,
                           "hisi-fmc.mem", MEM_WINDOW_SIZE);
     sysbus_init_mmio(sbd, &s->mem_iomem);
+
+    sysbus_init_irq(sbd, &s->irq);
 }
 
 static void hisi_fmc_finalize(Object *obj)
@@ -1208,6 +1288,9 @@ static void hisi_fmc_finalize(Object *obj)
 }
 
 static const Property hisi_fmc_properties[] = {
+    /* Register-map variant: 0 = HiFMC V100 (default), 1 = fmc100 (lotus,fmc
+     * on Goke xmorca / GK7206).  Same IP, shuffled register offsets. */
+    DEFINE_PROP_UINT32("variant", HisiFmcState, variant, FMC_VARIANT_HIFMC),
     DEFINE_PROP_UINT32("flash-type", HisiFmcState, flash_type,
                        FLASH_TYPE_SPI_NOR),
     DEFINE_PROP_STRING("flash-file", HisiFmcState, flash_file),

--- a/qemu/include/hw/arm/hisilicon.h
+++ b/qemu/include/hw/arm/hisilicon.h
@@ -22,7 +22,7 @@
 #define HISI_MAX_TIMERS   4
 #define HISI_MAX_SPIS     4
 #define HISI_MAX_HIMCI    3
-#define HISI_MAX_SDHCI    2
+#define HISI_MAX_SDHCI    3
 #define HISI_MAX_I2C      8
 #define HISI_MAX_REGBANKS 20
 #define HISI_MAX_CRG_DEFAULTS 8
@@ -152,6 +152,12 @@ typedef struct HisiSoCConfig {
     hwaddr          fmc_ctrl_base;  /* 0 = no flash controller */
     hwaddr          fmc_mem_base;
     const char     *fmc_type;       /* NULL = "hisi-fmc", or "hisi-sfc350" */
+    /* hisi-fmc register-map variant: 0 = HiFMC V100 (default), 1 = fmc100
+     * ("lotus,fmc" on Goke xmorca / GK7206 — same IP, shuffled offsets). */
+    uint32_t        fmc_variant;
+    /* FMC op/DMA-done IRQ (GIC SPI).  0 = unconnected (V100 users poll);
+     * the fmc100 driver waits on an interrupt for DMA completion. */
+    int             fmc_irq;
 
     /* GPIO (PL061) */
     hwaddr          gpio_base;
@@ -415,5 +421,23 @@ typedef struct HisiSoCConfig {
 #define GOKE_SOC_ID_7205V510    0x72050510  /* 5M, 1.0 TOPS, 1Gb DDR3 */
 #define GOKE_SOC_ID_7205V530    0x72050530  /* 5M, 1.0 TOPS, ext DDR */
 #define GOKE_SOC_ID_7202V330    0x72020330  /* 5M, 0.5 TOPS, no FEPHY */
+
+/*
+ * Goke third generation (2025-2026) — Goke's own designs on the XMedia
+ * "Lotus" SDK (ShiMetaPi shimetapi_pico_gx), split into two product lines
+ * the way HiSilicon splits 3516 (mainstream) / 3519 (high-end):
+ *   GK7206 — codename "xmorca",  Cortex-A7 MP2, embedded DDR, 5M.
+ *   GK7606 — codename "xmfalcon", Cortex-A55, external DDR, 4K.
+ * Both keep the gk7205v5xx-style 0x12xxxxxx control block (sysctl
+ * 0x12020000, CRG 0x12010000, UART 0x12040000, xmedia,sp804 0x12000000),
+ * RAM @0x40000000, an ATF BL1->BL31->BL33(u-boot) chain, and a RISC-V MCU
+ * coprocessor.  The chip ID is read from REG_SC_CHIPID = sysctl_base + 0xEE0
+ * (= 0x12020EE0, verified in the SDK u-boot arch-xmorca/platform.h).  The
+ * ID *values* below are PLACEHOLDERS pending a live SCSYSID/CHIPID capture —
+ * the silicon value is not encoded anywhere in the SDK source (u-boot just
+ * prints whatever it reads).  Boot does not depend on them (ipctool reads
+ * them post-boot); they follow the 0x72050500-style Goke encoding. */
+#define GOKE_SOC_ID_7206V10     0x72060010  /* GK7206V10, dual A7 MP2, 1.0 TOPS; placeholder */
+#define GOKE_SOC_ID_7606V1      0x76060100  /* GK7606V1, A55 4K; placeholder */
 
 #endif /* HW_ARM_HISILICON_H */


### PR DESCRIPTION
## Summary

Adds the **Goke GK7206V10** (codename *xmorca*, the ShiMetaPi Pico-G1 SoC) — a dual Cortex-A7 MP2 + RISC-V MCU IP-camera SoC on the XMedia SDK — plus a **GK7606V1** (*xmfalcon*, Cortex-A55) placeholder.

`gk7206v10` boots the **unmodified vendor kernel** (`linux-5.10.y`, `xmorca_defconfig`) and busybox rootfs to full Linux userspace three ways:
- `-kernel` + tiny initramfs
- `-kernel` + the SDK busybox rootfs (autologin shell)
- a real **SPI-NOR flash boot** — `root=/dev/mtdblock4` (jffs2) enumerated from an emulated W25Q128

## What's in it

- **`gk7206v10`** reuses the gk7205v5xx V4 control block (sysctl `0x12020000`, CRG `0x12010000`, UART `0x12040000`, `xmedia,sp804` timer) with orca deltas: FE MAC relocated to `0x100d0000`, dual-A7 GIC, fmc100 flash, three `lotus,sdhci`.
- **fmc100 flash controller** — `lotus,fmc` is the same IP as HiFMC V100 with a shuffled register map, so this adds an offset-translation `variant` to `hisi-fmc` (no new device), plus **IRQ-driven DMA completion** (the vendor driver waits on an interrupt, not a poll).
- **SD/MMC** — three `lotus,sdhci` controllers wired per the DTS (IRQ 32/33/34), with the DLL status registers preset ready in the CRG. The vendor driver probes all three cleanly.
- **`hisilicon_patch_appended_dtb`** — widen an undersized GICv2 CPU-interface reg so the stock GICv2 driver probes (the vendor DTB declares `0x100`, the 5.10 driver requires `>= 0x2000`).

`GK7606V1` is registered as an **untested placeholder** (the SDK ships no xmfalcon board config); its map comes from the vendor u-boot and is unverified.

## Compatibility

`hisi-fmc`'s new `variant` defaults to 0 (HiFMC V100), so all existing FMC users are unchanged — smoke-tested that `gk7205v500` / `hi3516ev300` / `hi3519dv500` still init cleanly. Boot artifacts (kernel/rootfs/flash image, built from the SDK) are intentionally not committed; `qemu-boot/run-gk7206.sh` documents how to build them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)